### PR TITLE
Add createPullRequest tool

### DIFF
--- a/worker/src/agent/common/metadata.ts
+++ b/worker/src/agent/common/metadata.ts
@@ -39,3 +39,34 @@ export const readMetadata = async (tag: string, workerId: string = process.env.W
 
   return result.Item;
 };
+
+/**
+ * Update existing metadata in DynamoDB by merging with new data.
+ * @param tag The tag to use as the SK in DynamoDB
+ * @param data The new object data to merge with existing data
+ * @param workerId The worker ID to use as part of the PK
+ * @returns The updated metadata object
+ */
+export const updateMetadata = async (tag: string, data: object, workerId: string = process.env.WORKER_ID!) => {
+  // First read the existing metadata
+  const existingData = (await readMetadata(tag, workerId)) || {};
+
+  // Merge existing data with new data (new data overwrites existing fields with the same name)
+  const mergedData = {
+    ...existingData,
+    ...data,
+    // Preserve PK and SK which should not be overwritten
+    PK: `metadata-${workerId}`,
+    SK: tag,
+  };
+
+  // Write merged data back to DynamoDB
+  await ddb.send(
+    new PutCommand({
+      TableName,
+      Item: mergedData,
+    })
+  );
+
+  return mergedData;
+};

--- a/worker/src/agent/index.ts
+++ b/worker/src/agent/index.ts
@@ -24,6 +24,7 @@ import { bedrockConverse } from './common/bedrock';
 import { cloneRepositoryTool } from './tools/repo';
 import { getMcpToolSpecs, tryExecuteMcpTool } from './mcp';
 import { sendImageTool } from './tools/send-image';
+import { createPullRequestTool } from './tools/pr-create';
 import { readMetadata } from './common/metadata';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
@@ -138,6 +139,7 @@ Users will primarily request software engineering assistance including bug fixes
     fileEditTool,
     webBrowserTool,
     sendImageTool,
+    createPullRequestTool,
   ];
   const toolConfig: ConverseCommandInput['toolConfig'] = {
     tools: [

--- a/worker/src/agent/tools/pr-create/index.ts
+++ b/worker/src/agent/tools/pr-create/index.ts
@@ -1,0 +1,104 @@
+import { executeCommand } from '../command-execution';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../common/lib';
+import { z } from 'zod';
+import { readMetadata, updateMetadata } from '../../common/metadata';
+
+const inputSchema = z.object({
+  title: z.string().describe('PR title'),
+  description: z.string().describe('PR description'),
+  issueNo: z.string().describe('Issue number to be closed by this PR'),
+  directory: z.string().describe('Local directory containing the git repository'),
+});
+
+const execute = async (command: string, plain = false): Promise<any> => {
+  const res = await executeCommand(command);
+
+  if (res.error != null) {
+    throw new Error(JSON.stringify(res));
+  }
+  if (plain) {
+    return res.stdout;
+  }
+  try {
+    const parsed = JSON.parse(res.stdout);
+    return parsed;
+  } catch (e) {
+    return res.stdout;
+  }
+};
+
+const createPullRequest = async (input: { title: string; description: string; issueNo: string; directory: string }) => {
+  const { title, description, issueNo, directory } = input;
+  const workerId = process.env.WORKER_ID!;
+
+  // Check if PR has already been created in this session
+  const prMetadata = await readMetadata('pull-request', workerId);
+  if (prMetadata && prMetadata.prId) {
+    return `Error: A pull request (${prMetadata.prId}) has already been created in this session. Please use the existing PR.`;
+  }
+
+  // Get repository metadata to verify directory matches
+  const repoMetadata = await readMetadata('repo', workerId);
+  if (!repoMetadata || !repoMetadata.repoDirectory) {
+    return 'Error: No repository has been cloned in this session. Please clone a repository first using cloneGitHubRepository.';
+  }
+
+  // Ensure directory matches with the cloned repository
+  if (repoMetadata.repoDirectory !== directory) {
+    return `Error: The specified directory (${directory}) does not match the cloned repository directory (${repoMetadata.repoDirectory}).`;
+  }
+
+  try {
+    // Ensure description includes "close #issueNo"
+    let finalDescription = description;
+    const closePattern = new RegExp(
+      `close #${issueNo}|closes #${issueNo}|closed #${issueNo}|fix #${issueNo}|fixes #${issueNo}|fixed #${issueNo}|resolve #${issueNo}|resolves #${issueNo}|resolved #${issueNo}`,
+      'i'
+    );
+
+    if (!closePattern.test(description)) {
+      finalDescription = `${description}\n\nCloses #${issueNo}`;
+    }
+
+    // Create PR using heredoc for proper markdown formatting
+    const result = await execute(
+      `cd ${directory} && gh pr create --title "${title}" --body "$(cat <<EOF
+${finalDescription}
+EOF
+)"`,
+      true
+    );
+
+    // Extract PR number from GitHub CLI output
+    const prUrlMatch = result.match(/https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/(\d+)/);
+    if (!prUrlMatch || !prUrlMatch[1]) {
+      throw new Error('Failed to extract PR number from GitHub response');
+    }
+
+    const prId = prUrlMatch[1];
+
+    // Store PR ID in DynamoDB
+    await updateMetadata('pull-request', { prId }, workerId);
+
+    return `Successfully created PR #${prId}: ${result}`;
+  } catch (e) {
+    return `Error creating PR: ${(e as Error).message}`;
+  }
+};
+
+const name = 'createPullRequest';
+
+export const createPullRequestTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: createPullRequest,
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Create a GitHub pull request from the current branch and store its ID for later use.
+The PR description will always include "Closes #issueNo" to ensure the referenced issue is closed when the PR is merged.
+Only one PR can be created per session.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};


### PR DESCRIPTION
## Issue

This PR resolves issue #3 by implementing a new  tool to improve Pull Request management.

## Changes

- Added new  tool that:
  - Creates PR with proper markdown formatting using heredoc
  - Ensures 'close #issueNo' is consistently included
  - Prevents multiple PRs in a single session
  - Stores PR ID in DynamoDB for later reference
- Added new  function that merges new metadata with existing values
- Registered the new tool in the agent's tool collection

## Features

- PR description format is preserved using heredoc syntax
- Only one PR can be created per session (subsequent attempts return error)
- PR ID is stored for later reference via DynamoDB
- Automatically ensures issue closing syntax is present in description

Closes #3