### PR TITLE
Save images locally and provide path info in messages

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -24,6 +24,7 @@ This project consists of the following main components:
 - Use Promise-based patterns for asynchronous operations
 - Use Prettier for code formatting
 - Prefer function-based implementations over classes
+- DO NOT write code comment unless the implementation is so complicated or difficult to understand without comments.
 
 ## Commonly Used Commands
 

--- a/slack-bolt-app/src/app.ts
+++ b/slack-bolt-app/src/app.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import { Message } from '@aws-sdk/client-bedrock-runtime';
 import { s3, BucketName } from './common/s3';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { IdempotencyAlreadyInProgressError } from '@aws-lambda-powertools/idempotency';
 
 const SigningSecret = process.env.SIGNING_SECRET!;
 const BotToken = process.env.BOT_TOKEN!;
@@ -291,6 +292,7 @@ app.event('app_mention', async ({ event, client, logger }) => {
   } catch (e: any) {
     console.log(e);
     if (e.message.includes('already_reacted')) return;
+    if (e instanceof IdempotencyAlreadyInProgressError) return;
 
     await client.chat.postMessage({
       channel,

--- a/worker/src/agent/common/messages.ts
+++ b/worker/src/agent/common/messages.ts
@@ -217,20 +217,20 @@ const ensureImagesDirectory = () => {
 // Save image to local filesystem and return the path
 const saveImageToLocalFs = async (imageBuffer: Buffer): Promise<string> => {
   const imagesDir = ensureImagesDirectory();
-  
+
   // Since we're converting to webp above, we know the extension
   const extension = 'webp';
-  
+
   // Create path with sequence number
   const fileName = `image${imageSeqNo}.${extension}`;
   const filePath = path.join(imagesDir, fileName);
-  
+
   // Write image to file
   writeFileSync(filePath, imageBuffer);
-  
+
   // Increment sequence number for next image
   imageSeqNo++;
-  
+
   // Return the path in the format specified in the issue
   return `.remote_swe_workspace/images/${fileName}`;
 };
@@ -244,11 +244,11 @@ const postProcessMessageContent = async (content: string) => {
       resultArray.push(c);
       continue;
     }
-    
+
     // Process image
     const s3Key = c.image.source.s3Key;
     let imageBuffer: Buffer;
-    
+
     if (s3Key in imageCache) {
       imageBuffer = imageCache[s3Key];
     } else {
@@ -257,7 +257,7 @@ const postProcessMessageContent = async (content: string) => {
       imageBuffer = await sharp(file).webp({ lossless: false, quality: 80 }).toBuffer();
       imageCache[s3Key] = imageBuffer;
     }
-    
+
     // Add image to result
     resultArray.push({
       image: {
@@ -267,10 +267,10 @@ const postProcessMessageContent = async (content: string) => {
         },
       },
     });
-    
+
     // Save image to local filesystem
     const localPath = await saveImageToLocalFs(imageBuffer);
-    
+
     // Add a text block after the image with the path information
     resultArray.push({
       text: `the image is stored locally on ${localPath}`,

--- a/worker/src/agent/common/messages.ts
+++ b/worker/src/agent/common/messages.ts
@@ -5,7 +5,6 @@ import sharp from 'sharp';
 import { ddb, TableName } from './ddb';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
-import { fileTypeFromBuffer } from 'file-type';
 
 // Maximum input token count before applying middle-out strategy
 export const MAX_INPUT_TOKEN = 80_000;
@@ -201,7 +200,7 @@ const preProcessMessageContent = async (content: Message['content']) => {
   return JSON.stringify(content);
 };
 
-const imageCache: Record<string, Buffer> = {};
+const imageCache: Record<string, { data: Buffer; localPath: string }> = {};
 // Image sequence number, reset when the process is killed
 let imageSeqNo = 0;
 


### PR DESCRIPTION
# Image Local Path Feature

This PR implements the feature requested in issue #12 to allow agents programmatic access to images by:

1. Saving incoming images to the local filesystem at `~/.remote_swe_workspace/images/image[seqNo].[extension]`
2. Appending a text block after each image block with path information
3. Maintaining a sequence counter that increments for each image and resets when the process is killed

## Implementation Details:
- Added utility functions to save images locally
- Modified `postProcessMessageContent` to append text blocks with path info
- Images are saved as webp format (matching the existing conversion)

Fixes #12