### PR TITLE
Save images in JPEG format locally for better CLI compatibility

### DIFF
--- a/worker/src/agent/common/messages.ts
+++ b/worker/src/agent/common/messages.ts
@@ -215,15 +215,16 @@ const ensureImagesDirectory = () => {
 const saveImageToLocalFs = async (imageBuffer: Buffer): Promise<string> => {
   const imagesDir = ensureImagesDirectory();
 
-  // Since we're converting to webp above, we know the extension
-  const extension = 'webp';
+  // Convert webp to jpeg for better compatibility with CLI tools
+  const jpegBuffer = await sharp(imageBuffer).jpeg({ quality: 85 }).toBuffer();
+  const extension = 'jpeg';
 
   // Create path with sequence number
   const fileName = `image${imageSeqNo}.${extension}`;
   const filePath = path.join(imagesDir, fileName);
 
   // Write image to file
-  writeFileSync(filePath, imageBuffer);
+  writeFileSync(filePath, jpegBuffer);
 
   // Increment sequence number for next image
   imageSeqNo++;


### PR DESCRIPTION
## Description
This PR fixes issue #16 by changing the image format from webp to JPEG when saving images locally.

### Changes
- Modified the `saveImageToLocalFs` function to convert webp images to JPEG format before saving
- WebP format is still used in the `postProcessMessageContent` function for efficiency
- Changed file extension from 'webp' to 'jpeg'

This change improves compatibility with various CLI tools that may not handle webp files as easily as JPEG.

closes #16 