### PR TITLE
文頭にメンションがない場合のエラー対応

### DIFF
--- a/slack-bolt-app/src/app.ts
+++ b/slack-bolt-app/src/app.ts
@@ -32,7 +32,29 @@ const app = new App({
 app.event('app_mention', async ({ event, client, logger }) => {
   console.log('app_mention event received');
   console.log(JSON.stringify(event));
-  const message = event.text.slice(event.text.indexOf('>') + 1).trim();
+  
+  // Check if the mention is at the beginning of the message
+  const mentionEndIndex = event.text.indexOf('>');
+  if (mentionEndIndex <= 0 || !event.text.startsWith('<@')) {
+    await client.chat.postMessage({
+      channel: event.channel,
+      text: `<@${event.user}> メンションは文頭に配置してください（例：@remote-swe-agents こんにちは）`,
+      thread_ts: event.thread_ts ?? event.ts,
+    });
+    return;
+  }
+  
+  const message = event.text.slice(mentionEndIndex + 1).trim();
+  // 空のメッセージの場合もエラーを返す
+  if (!message) {
+    await client.chat.postMessage({
+      channel: event.channel,
+      text: `<@${event.user}> メッセージ内容が空です。メンションの後にメッセージを入力してください。`,
+      thread_ts: event.thread_ts ?? event.ts,
+    });
+    return;
+  }
+  
   const userId = event.user ?? '';
   const channel = event.channel;
   try {


### PR DESCRIPTION
## 概要
Slackでのメッセージ送信時に、文末にメンションを付けるとValidationExceptionが発生する問題を修正しました。

## 修正内容
- メンションが文頭にない場合に、適切なエラーメッセージを返すよう修正
- 空のメッセージに対してもエラーメッセージを返すよう対応
- これにより、BedrockのAPIに空のメッセージが送信されることを防ぎ、ValidationExceptionを回避します

## テスト方法
1. 文頭にメンションを付けて投稿した場合（正常動作）
2. 文末にメンションを付けて投稿した場合（エラーメッセージが表示される）
3. メンションだけで内容が空の場合（エラーメッセージが表示される）