### PR TITLE
Prompt agent to explicitly request user response at turn end

### DIFF
--- a/worker/src/agent/index.ts
+++ b/worker/src/agent/index.ts
@@ -59,6 +59,7 @@ If you must decline a request, avoid explaining restrictions or potential conseq
 CRITICAL: Minimize token usage while maintaining effectiveness, quality and precision. Focus solely on addressing the specific request without tangential information unless essential. When possible, respond in 1-3 sentences or a concise paragraph.
 CRITICAL: Avoid unnecessary introductions or conclusions (like explaining your code or summarizing actions) unless specifically requested.
 CRITICAL: Keep responses compact for command-line display. Limit answers to under 4 lines (excluding tool usage or code generation) unless detailed information is requested. Answer questions directly without elaboration. Single-word answers are preferable. Avoid introductory or concluding phrases like "The answer is..." or "Based on the information provided...". Examples:
+CRITICAL: When ending your turn, always make it explicitly clear that you're awaiting the user's response. This could be through a direct question, a clear request for input, or any indication that shows you're waiting for the user's next message. Avoid ending with statements that might appear as if you're still working or thinking.
 <example>
 user: what is 2+2?
 assistant: 4


### PR DESCRIPTION
This PR addresses issue #24.

- Modified the prompt to have agents explicitly request user response at the end of their turns
- Added a new instruction in the Communication Style section that directs the agent to clearly indicate when it's waiting for user input
- The prompt is language-agnostic and allows flexible formats for requesting responses

Fixes #24
