### PR TITLE
use reportProgress tool in a more robust way

### DIFF
--- a/slack-bolt-app/src/app.ts
+++ b/slack-bolt-app/src/app.ts
@@ -203,7 +203,7 @@ app.event('app_mention', async ({ event, client, logger }) => {
       const cloudwatchUrl = `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups/log-group/${encodeURIComponent(logGroupName)}/log-events/${encodeURIComponent(logStreamName)}`;
 
       await Promise.all([
-        saveConversationHistory(workerId, message, imageKeys),
+        saveConversationHistory(workerId, message, userId, imageKeys),
         sendEvent(workerId, 'onMessageReceived'),
         lambda.send(
           new InvokeCommand({

--- a/slack-bolt-app/src/util/history.ts
+++ b/slack-bolt-app/src/util/history.ts
@@ -9,9 +9,15 @@ type MessageItem = {
   role: string;
   tokenCount: number;
   messageType: string;
+  slackUserId: string;
 };
 
-export const saveConversationHistory = async (workerId: string, message: string, imageS3Keys: string[] = []) => {
+export const saveConversationHistory = async (
+  workerId: string,
+  message: string,
+  slackUserId: string,
+  imageS3Keys: string[] = []
+) => {
   const content = [];
   if (message) {
     content.push({ text: message });
@@ -36,6 +42,7 @@ export const saveConversationHistory = async (workerId: string, message: string,
         role: 'user',
         tokenCount: 0,
         messageType: 'userMessage',
+        slackUserId,
       } satisfies MessageItem,
     })
   );

--- a/worker/src/agent/common/messages.ts
+++ b/worker/src/agent/common/messages.ts
@@ -17,6 +17,7 @@ type MessageItem = {
   role: string;
   tokenCount: number;
   messageType: string;
+  slackUserId?: string;
 };
 
 export const saveConversationHistoryAtomic = async (
@@ -113,7 +114,15 @@ export const getConversationHistory = async (workerId: string) => {
     items.push(...(page.Items as any));
   }
 
-  return { items };
+  return { items, slackUserId: searchForLastSlackUserId(items) };
+};
+
+const searchForLastSlackUserId = (items: MessageItem[]) => {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (items[i].slackUserId) {
+      return items[i].slackUserId;
+    }
+  }
 };
 
 export const middleOutFiltering = async (items: MessageItem[]) => {

--- a/worker/src/agent/tools/report-progress/index.ts
+++ b/worker/src/agent/tools/report-progress/index.ts
@@ -6,22 +6,19 @@ const inputSchema = z.object({
   message: z.string().describe('The message you want to send to the user.'),
 });
 
-const name = 'reportProgressToUser';
+const name = 'sendMessageToUser';
 
 export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,
   handler: async (input: z.infer<typeof inputSchema>) => {
+    if (!input.message) return 'No message was sent.';
     await sendMessage(input.message, true);
-    return 'successfully sent a message.';
+    return 'Successfully sent a message.';
   },
   schema: inputSchema,
   toolSpec: async () => ({
     name,
-    description: `Send any message to the user. This is especially valuable if the message contains any information the user want to know, such as how you are solving the problem now. Without this tool, a user cannot know your progress because message is only sent when you finished using tools and end your turn. 
-
-!IMPORTANT
-Any tool result contains the elapsed time since the last time you sent a message. If it is more than 3 minutes, you should report some progress message using this tool.
-      `,
+    description: `Send any message to the user. This is especially valuable if the message contains any information the user want to know, such as how you are solving the problem now. Without this tool, a user cannot know your progress because message is only sent when you finished using tools and end your turn.`,
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),
     },

--- a/worker/src/agent/tools/report-progress/index.ts
+++ b/worker/src/agent/tools/report-progress/index.ts
@@ -3,10 +3,13 @@ import { z } from 'zod';
 import { sendMessage } from '../../../common/slack';
 
 const inputSchema = z.object({
-  message: z.string().describe('The message you want to send to the user.'),
+  thought: z.string().describe('Your thoughts on the message.'),
+  message: z
+    .string()
+    .describe('The message you want to send to the user. Set empty string to avoid sending unnecessary message.'),
 });
 
-const name = 'sendMessageToUser';
+const name = 'sendMessageToUserIfNecessary';
 
 export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,
@@ -18,7 +21,11 @@ export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   schema: inputSchema,
   toolSpec: async () => ({
     name,
-    description: `Send any message to the user. This is especially valuable if the message contains any information the user want to know, such as how you are solving the problem now. Without this tool, a user cannot know your progress because message is only sent when you finished using tools and end your turn.`,
+    description: `
+Send any message to the user. This is especially valuable if the message contains any information the user want to know, such as how you are solving the problem now. Without this tool, a user cannot know your progress because message is only sent when you finished using tools and end your turn.
+
+Please output your thoughts on how to compose your message to the user before actually writing the message. Remember, if you do not have anything to send or just too immature to report progress, you can just pass an empty string to the \`message\` property to skip sending a message.
+    `,
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),
     },

--- a/worker/src/agent/tools/think/index.ts
+++ b/worker/src/agent/tools/think/index.ts
@@ -1,0 +1,25 @@
+import { ToolDefinition, zodToJsonSchemaBody } from '../../common/lib';
+import { z } from 'zod';
+
+const inputSchema = z.object({
+  thought: z.string().describe('Your thoughts.'),
+});
+
+const name = 'think';
+
+// https://www.anthropic.com/engineering/claude-think-tool
+export const thinkTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>) => {
+    return 'Nice thought.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed. For example, if you explore the repo and discover the source of a bug, call this tool to brainstorm several unique ways of fixing the bug, and assess which change(s) are likely to be simplest and most effective. Alternatively, if you receive some test results, call this tool to brainstorm ways to fix the failing tests.
+`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR tries to resolve the problem that an agent does not send any message for a while after user's message, making users confused if the agent is stuck or not.

To improve the situation, we use [toolConfig](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolConfiguration.html#bedrock-Type-runtime_ToolConfiguration-tools) to force the agent to use reportProgress tool. To let the agent decide not to use the tool, we also added a think tool (kind of no-op tool in this case, but it will also improve the agents' thought capability), and toolConfig any option.

Because toolConfig option cannot be enabled with reasoning option, we need special handling for the props.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
