### PR TITLE
send quick response after the user message

### DIFF
--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -717,7 +717,7 @@ exports[`Snapshot test 1`] = `
       ],
       "Properties": {
         "Architectures": [
-          "arm64",
+          "x86_64",
         ],
         "Code": {
           "ImageUri": {
@@ -931,7 +931,7 @@ exports[`Snapshot test 1`] = `
       ],
       "Properties": {
         "Architectures": [
-          "arm64",
+          "x86_64",
         ],
         "Code": {
           "ImageUri": {

--- a/packages/agent-core/src/lib/index.ts
+++ b/packages/agent-core/src/lib/index.ts
@@ -3,3 +3,4 @@ export * from './prompt';
 export * from './slack';
 export * from './messages';
 export * from './metadata';
+export * from './prompt';

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.ts"],

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -1,5 +1,6 @@
 import { PutCommand, QueryCommand, paginateQuery } from '@aws-sdk/lib-dynamodb';
 import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
+import { renderUserMessage } from '@remote-swe-agents/agent-core/lib';
 import { Message } from '@aws-sdk/client-bedrock-runtime';
 
 type MessageItem = {
@@ -20,7 +21,7 @@ export const saveConversationHistory = async (
 ) => {
   const content = [];
   if (message) {
-    content.push({ text: message });
+    content.push({ text: renderUserMessage({ message }) });
   }
   imageS3Keys.forEach((key) => {
     content.push({

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -209,8 +209,6 @@ Users will primarily request software engineering assistance including bug fixes
     });
     firstCachePoint = secondCachePoint;
 
-    const forceReport = Date.now() - lastReportedTime > 300 * 1000;
-
     const res = await pRetry(
       async () => {
         try {
@@ -330,7 +328,7 @@ Users will primarily request software engineering assistance including bug fixes
             toolUseId,
             content: toolResultObject ?? [
               {
-                text: renderToolResult({ toolResult, forceReport }),
+                text: renderToolResult({ toolResult, forceReport: Date.now() - lastReportedTime > 300 * 1000 }),
               },
             ],
           },

--- a/packages/worker/src/local.ts
+++ b/packages/worker/src/local.ts
@@ -11,7 +11,7 @@ const rl = createInterface({
 const workerId = WorkerId;
 
 import { WorkerId } from './common/constants';
-import { saveConversationHistory } from '@remote-swe-agents/agent-core/lib';
+import { renderUserMessage, saveConversationHistory } from '@remote-swe-agents/agent-core/lib';
 
 async function processInput(input: string) {
   try {
@@ -20,7 +20,7 @@ async function processInput(input: string) {
         workerId,
         {
           role: 'user',
-          content: [{ text: input }],
+          content: [{ text: renderUserMessage({ message: input }) }],
         },
         0,
         'userMessage'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR makes boltApp send the below prompt right after a user message, making an initial response faster and UX better.

https://github.com/aws-samples/remote-swe-agents/blob/cfccb7754740cc8a1cfad9d86aa0211ef817e83a/packages/agent-core/src/lib/prompt.ts#L14-L22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
