### PR TITLE
Cache source.tar.gz using S3 ETag

### DIFF
--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -185,59 +185,19 @@ sudo -u ubuntu bash -c "gh config set prompt disabled"
 # Create setup script
 mkdir -p /opt/scripts
 cat << 'EOF' > /opt/scripts/start-app.sh
-#!/bin/bash -l
+#!/bin/bash
 
 # Set S3 bucket name
 S3_BUCKET_NAME="${sourceBucket.bucketName}"
 ETAG_FILE="/opt/myapp/.source_etag"
-SOURCE_EXTRACTED_DIR="/opt/myapp/extracted_source"
 SOURCE_TAR_NAME="source.tar.gz"
 
 # Enable strict mode for safety
 set -e
 
-# Get current ETag from S3
-CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
-
-# Check if we can use cached source code
-if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
-  CACHED_ETAG=$(cat $ETAG_FILE)
-  
-  if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
-    echo "ETag matches. Using cached source files."
-    # Clean up existing files first
-    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
-    # Copy cached source files to current directory
-    cp -r $SOURCE_EXTRACTED_DIR/* ./
-    # Copy hidden files separately to avoid errors with . and ..
-    find $SOURCE_EXTRACTED_DIR -name ".*" -type f -exec cp {} ./ \;
-  else
-    echo "ETag different. Downloading fresh source files."
-    # Perform full download and extraction
-    # Clean up existing files
-    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
-    
-    # Download source code from S3
-    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
-    
-    # Extract and clean up
-    tar -xvzf $SOURCE_TAR_NAME
-    rm -f $SOURCE_TAR_NAME
-    
-    # Cache the extracted files
-    rm -rf "$SOURCE_EXTRACTED_DIR"
-    mkdir -p "$SOURCE_EXTRACTED_DIR"
-    
-    # Copy files to cache directory
-    cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
-    # Copy hidden files separately to avoid errors
-    find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ \;
-    
-    # Save the ETag only after successful operations
-    echo "$CURRENT_ETAG" > "$ETAG_FILE"
-  fi
-else
-  echo "No cached source files. Downloading fresh source files."
+# Function to download and extract fresh source files
+download_fresh_files() {
+  echo "Downloading fresh source files."
   # Clean up existing files
   rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
   
@@ -248,27 +208,38 @@ else
   tar -xvzf $SOURCE_TAR_NAME
   rm -f $SOURCE_TAR_NAME
   
-  # Create cache directory and copy extracted files
-  mkdir -p "$SOURCE_EXTRACTED_DIR"
-  
-  # Copy files to cache directory
-  cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
-  # Copy hidden files separately to avoid errors
-  find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ \;
-  
-  # Save the ETag only after successful operations
+  # Install dependencies and build
+  npm ci
+  npm run build -w packages/agent-core
+
+  # Save the ETag
   echo "$CURRENT_ETAG" > "$ETAG_FILE"
+}
+
+# Get current ETag from S3
+CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+
+# Check if we can use cached source code
+if [ -f "$ETAG_FILE" ]; then
+  CACHED_ETAG=$(cat $ETAG_FILE)
+  
+  if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
+    echo "ETag matches. Using existing source files."
+    # Files are already in place, no need to do anything
+  else
+    # ETag doesn't match, need to download fresh files
+    download_fresh_files
+  fi
+else
+  # No ETAG file, need to download fresh files
+  download_fresh_files
 fi
 
-# Install dependencies and build
-npm ci
-npm run build -w packages/agent-core
-
 # Set up dynamic environment variables
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
-export WORKER_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
-export SLACK_CHANNEL_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
-export SLACK_THREAD_TS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
+export WORKER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+export SLACK_CHANNEL_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
+export SLACK_THREAD_TS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
 export SLACK_BOT_TOKEN=$(aws ssm get-parameter --name ${props.slackBotTokenParameter.parameterName} --query "Parameter.Value" --output text)
 export GITHUB_PERSONAL_ACCESS_TOKEN=${props.githubPersonalAccessTokenParameter ? `$(aws ssm get-parameter --name ${props.githubPersonalAccessTokenParameter.parameterName} --query \"Parameter.Value\" --output text)` : '""'}
 
@@ -350,8 +321,8 @@ EOF
 cat << 'EOF' > /opt/scripts/start-fluent-bit.sh
 #!/bin/bash
 
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
-export WORKER_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
+export WORKER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
 exec /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
 EOF

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -193,6 +193,9 @@ ETAG_FILE="/opt/myapp/.source_etag"
 SOURCE_EXTRACTED_DIR="/opt/myapp/extracted_source"
 SOURCE_TAR_NAME="source.tar.gz"
 
+# Enable strict mode for safety
+set -e
+
 # Get current ETag from S3
 CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
 
@@ -202,13 +205,17 @@ if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
   
   if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
     echo "ETag matches. Using cached source files."
+    # Clean up existing files first
+    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
     # Copy cached source files to current directory
-    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+    cp -r $SOURCE_EXTRACTED_DIR/* ./
+    # Copy hidden files separately to avoid errors with . and ..
+    find $SOURCE_EXTRACTED_DIR -name ".*" -type f -exec cp {} ./ \;
   else
     echo "ETag different. Downloading fresh source files."
     # Perform full download and extraction
     # Clean up existing files
-    rm -rf ./{*,.*} 2>/dev/null || true
+    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
     
     # Download source code from S3
     aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
@@ -218,17 +225,21 @@ if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
     rm -f $SOURCE_TAR_NAME
     
     # Cache the extracted files
-    rm -rf "$SOURCE_EXTRACTED_DIR" 2>/dev/null || true
+    rm -rf "$SOURCE_EXTRACTED_DIR"
     mkdir -p "$SOURCE_EXTRACTED_DIR"
-    cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
     
-    # Save the ETag
+    # Copy files to cache directory
+    cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
+    # Copy hidden files separately to avoid errors
+    find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ \;
+    
+    # Save the ETag only after successful operations
     echo "$CURRENT_ETAG" > "$ETAG_FILE"
   fi
 else
   echo "No cached source files. Downloading fresh source files."
   # Clean up existing files
-  rm -rf ./{*,.*} 2>/dev/null || true
+  rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
   
   # Download source code from S3
   aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
@@ -239,9 +250,13 @@ else
   
   # Create cache directory and copy extracted files
   mkdir -p "$SOURCE_EXTRACTED_DIR"
-  cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
   
-  # Save the ETag
+  # Copy files to cache directory
+  cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
+  # Copy hidden files separately to avoid errors
+  find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ \;
+  
+  # Save the ETag only after successful operations
   echo "$CURRENT_ETAG" > "$ETAG_FILE"
 fi
 

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -250,6 +250,11 @@ else
   download_fresh_files
 fi
 
+if [ "$NO_START" == "true" ]; then
+  echo "NO_START=true is passed. Existing..."
+  exit 0
+fi
+
 # Set up dynamic environment variables
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
 export WORKER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
@@ -266,6 +271,9 @@ EOF
 # Make script executable and set ownership
 chmod +x /opt/scripts/start-app.sh
 chown ubuntu:ubuntu /opt/scripts/start-app.sh
+
+# cache worker files
+sudo -u ubuntu bash -i -c "NO_START=true /opt/scripts/start-app.sh"
 
 cat << EOF > /etc/systemd/system/myapp.service
 [Unit]

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2114,6 +2114,11 @@ phases:
               SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
+              # Enable strict mode for safety
+
+              set -e
+
+
               # Get current ETag from S3
 
               CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
@@ -2131,9 +2136,17 @@ phases:
 
               \\    echo \\"ETag matches. Using cached source files.\\"
 
+              \\    # Clean up existing files first
+
+              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
+
               \\    # Copy cached source files to current directory
 
-              \\    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+              \\    cp -r $SOURCE_EXTRACTED_DIR/* ./
+
+              \\    # Copy hidden files separately to avoid errors with . and ..
+
+              \\    find $SOURCE_EXTRACTED_DIR -name \\".*\\" -type f -exec cp {} ./ ;
 
               \\  else
 
@@ -2143,7 +2156,7 @@ phases:
 
               \\    # Clean up existing files
 
-              \\    rm -rf ./{*,.*} 2>/dev/null || true
+              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
 
               \\   \\ 
 
@@ -2163,15 +2176,23 @@ phases:
 
               \\    # Cache the extracted files
 
-              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\" 2>/dev/null || true
+              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\"
 
               \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
 
-              \\    cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+              \\   \\ 
+
+              \\    # Copy files to cache directory
+
+              \\    cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
+
+              \\    # Copy hidden files separately to avoid errors
+
+              \\    find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
 
               \\   \\ 
 
-              \\    # Save the ETag
+              \\    # Save the ETag only after successful operations
 
               \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
 
@@ -2183,7 +2204,7 @@ phases:
 
               \\  # Clean up existing files
 
-              \\  rm -rf ./{*,.*} 2>/dev/null || true
+              \\  rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
 
               \\ \\ 
 
@@ -2205,11 +2226,19 @@ phases:
 
               \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
 
-              \\  cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+              \\ \\ 
+
+              \\  # Copy files to cache directory
+
+              \\  cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
+
+              \\  # Copy hidden files separately to avoid errors
+
+              \\  find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
 
               \\ \\ 
 
-              \\  # Save the ETag
+              \\  # Save the ETag only after successful operations
 
               \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
 
@@ -2759,6 +2788,11 @@ phases:
               SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
+              # Enable strict mode for safety
+
+              set -e
+
+
               # Get current ETag from S3
 
               CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
@@ -2776,9 +2810,17 @@ phases:
 
               \\    echo \\"ETag matches. Using cached source files.\\"
 
+              \\    # Clean up existing files first
+
+              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
+
               \\    # Copy cached source files to current directory
 
-              \\    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+              \\    cp -r $SOURCE_EXTRACTED_DIR/* ./
+
+              \\    # Copy hidden files separately to avoid errors with . and ..
+
+              \\    find $SOURCE_EXTRACTED_DIR -name \\".*\\" -type f -exec cp {} ./ ;
 
               \\  else
 
@@ -2788,7 +2830,7 @@ phases:
 
               \\    # Clean up existing files
 
-              \\    rm -rf ./{*,.*} 2>/dev/null || true
+              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
 
               \\   \\ 
 
@@ -2808,15 +2850,23 @@ phases:
 
               \\    # Cache the extracted files
 
-              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\" 2>/dev/null || true
+              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\"
 
               \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
 
-              \\    cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+              \\   \\ 
+
+              \\    # Copy files to cache directory
+
+              \\    cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
+
+              \\    # Copy hidden files separately to avoid errors
+
+              \\    find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
 
               \\   \\ 
 
-              \\    # Save the ETag
+              \\    # Save the ETag only after successful operations
 
               \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
 
@@ -2828,7 +2878,7 @@ phases:
 
               \\  # Clean up existing files
 
-              \\  rm -rf ./{*,.*} 2>/dev/null || true
+              \\  rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
 
               \\ \\ 
 
@@ -2850,11 +2900,19 @@ phases:
 
               \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
 
-              \\  cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+              \\ \\ 
+
+              \\  # Copy files to cache directory
+
+              \\  cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
+
+              \\  # Copy hidden files separately to avoid errors
+
+              \\  find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
 
               \\ \\ 
 
-              \\  # Save the ETag
+              \\  # Save the ETag only after successful operations
 
               \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
 
@@ -3251,6 +3309,9 @@ ETAG_FILE="/opt/myapp/.source_etag"
 SOURCE_EXTRACTED_DIR="/opt/myapp/extracted_source"
 SOURCE_TAR_NAME="source.tar.gz"
 
+# Enable strict mode for safety
+set -e
+
 # Get current ETag from S3
 CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
 
@@ -3260,13 +3321,17 @@ if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
   
   if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
     echo "ETag matches. Using cached source files."
+    # Clean up existing files first
+    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
     # Copy cached source files to current directory
-    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+    cp -r $SOURCE_EXTRACTED_DIR/* ./
+    # Copy hidden files separately to avoid errors with . and ..
+    find $SOURCE_EXTRACTED_DIR -name ".*" -type f -exec cp {} ./ ;
   else
     echo "ETag different. Downloading fresh source files."
     # Perform full download and extraction
     # Clean up existing files
-    rm -rf ./{*,.*} 2>/dev/null || true
+    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
     
     # Download source code from S3
     aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
@@ -3276,17 +3341,21 @@ if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
     rm -f $SOURCE_TAR_NAME
     
     # Cache the extracted files
-    rm -rf "$SOURCE_EXTRACTED_DIR" 2>/dev/null || true
+    rm -rf "$SOURCE_EXTRACTED_DIR"
     mkdir -p "$SOURCE_EXTRACTED_DIR"
-    cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
     
-    # Save the ETag
+    # Copy files to cache directory
+    cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
+    # Copy hidden files separately to avoid errors
+    find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ ;
+    
+    # Save the ETag only after successful operations
     echo "$CURRENT_ETAG" > "$ETAG_FILE"
   fi
 else
   echo "No cached source files. Downloading fresh source files."
   # Clean up existing files
-  rm -rf ./{*,.*} 2>/dev/null || true
+  rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
   
   # Download source code from S3
   aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
@@ -3297,9 +3366,13 @@ else
   
   # Create cache directory and copy extracted files
   mkdir -p "$SOURCE_EXTRACTED_DIR"
-  cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
   
-  # Save the ETag
+  # Copy files to cache directory
+  cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
+  # Copy hidden files separately to avoid errors
+  find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ ;
+  
+  # Save the ETag only after successful operations
   echo "$CURRENT_ETAG" > "$ETAG_FILE"
 fi
 

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2099,25 +2099,121 @@ phases:
               #!/bin/bash -l
 
 
-              # Clean up existing files
+              # Set S3 bucket name
 
-              rm -rf ./{*,.*}
-
-
-              # Download source code from S3
-
-              aws s3 cp s3://",
+              S3_BUCKET_NAME=\\"",
               {
                 "Ref": "WorkerSourceBucket539ACD15",
               },
-              "/source/source.tar.gz ./source.tar.gz
+              "\\"
+
+              ETAG_FILE=\\"/opt/myapp/.source_etag\\"
+
+              SOURCE_EXTRACTED_DIR=\\"/opt/myapp/extracted_source\\"
+
+              SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
-              # Extract and clean up
+              # Get current ETag from S3
 
-              tar -xvzf source.tar.gz
+              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
 
-              rm -f source.tar.gz
+
+              # Check if we can use cached source code
+
+              if [ -f \\"$ETAG_FILE\\" ] && [ -d \\"$SOURCE_EXTRACTED_DIR\\" ]; then
+
+              \\  CACHED_ETAG=$(cat $ETAG_FILE)
+
+              \\ \\ 
+
+              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
+
+              \\    echo \\"ETag matches. Using cached source files.\\"
+
+              \\    # Copy cached source files to current directory
+
+              \\    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+
+              \\  else
+
+              \\    echo \\"ETag different. Downloading fresh source files.\\"
+
+              \\    # Perform full download and extraction
+
+              \\    # Clean up existing files
+
+              \\    rm -rf ./{*,.*} 2>/dev/null || true
+
+              \\   \\ 
+
+              \\    # Download source code from S3
+
+              \\    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+
+              \\   \\ 
+
+              \\    # Extract and clean up
+
+              \\    tar -xvzf $SOURCE_TAR_NAME
+
+              \\    rm -f $SOURCE_TAR_NAME
+
+              \\   \\ 
+
+              \\    # Cache the extracted files
+
+              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\" 2>/dev/null || true
+
+              \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+
+              \\    cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+
+              \\   \\ 
+
+              \\    # Save the ETag
+
+              \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              \\  fi
+
+              else
+
+              \\  echo \\"No cached source files. Downloading fresh source files.\\"
+
+              \\  # Clean up existing files
+
+              \\  rm -rf ./{*,.*} 2>/dev/null || true
+
+              \\ \\ 
+
+              \\  # Download source code from S3
+
+              \\  aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+
+              \\ \\ 
+
+              \\  # Extract and clean up
+
+              \\  tar -xvzf $SOURCE_TAR_NAME
+
+              \\  rm -f $SOURCE_TAR_NAME
+
+              \\ \\ 
+
+              \\  # Create cache directory and copy extracted files
+
+              \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+
+              \\  cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+
+              \\ \\ 
+
+              \\  # Save the ETag
+
+              \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              fi
 
 
               # Install dependencies and build
@@ -2648,25 +2744,121 @@ phases:
               #!/bin/bash -l
 
 
-              # Clean up existing files
+              # Set S3 bucket name
 
-              rm -rf ./{*,.*}
-
-
-              # Download source code from S3
-
-              aws s3 cp s3://",
+              S3_BUCKET_NAME=\\"",
               {
                 "Ref": "WorkerSourceBucket539ACD15",
               },
-              "/source/source.tar.gz ./source.tar.gz
+              "\\"
+
+              ETAG_FILE=\\"/opt/myapp/.source_etag\\"
+
+              SOURCE_EXTRACTED_DIR=\\"/opt/myapp/extracted_source\\"
+
+              SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
-              # Extract and clean up
+              # Get current ETag from S3
 
-              tar -xvzf source.tar.gz
+              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
 
-              rm -f source.tar.gz
+
+              # Check if we can use cached source code
+
+              if [ -f \\"$ETAG_FILE\\" ] && [ -d \\"$SOURCE_EXTRACTED_DIR\\" ]; then
+
+              \\  CACHED_ETAG=$(cat $ETAG_FILE)
+
+              \\ \\ 
+
+              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
+
+              \\    echo \\"ETag matches. Using cached source files.\\"
+
+              \\    # Copy cached source files to current directory
+
+              \\    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+
+              \\  else
+
+              \\    echo \\"ETag different. Downloading fresh source files.\\"
+
+              \\    # Perform full download and extraction
+
+              \\    # Clean up existing files
+
+              \\    rm -rf ./{*,.*} 2>/dev/null || true
+
+              \\   \\ 
+
+              \\    # Download source code from S3
+
+              \\    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+
+              \\   \\ 
+
+              \\    # Extract and clean up
+
+              \\    tar -xvzf $SOURCE_TAR_NAME
+
+              \\    rm -f $SOURCE_TAR_NAME
+
+              \\   \\ 
+
+              \\    # Cache the extracted files
+
+              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\" 2>/dev/null || true
+
+              \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+
+              \\    cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+
+              \\   \\ 
+
+              \\    # Save the ETag
+
+              \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              \\  fi
+
+              else
+
+              \\  echo \\"No cached source files. Downloading fresh source files.\\"
+
+              \\  # Clean up existing files
+
+              \\  rm -rf ./{*,.*} 2>/dev/null || true
+
+              \\ \\ 
+
+              \\  # Download source code from S3
+
+              \\  aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+
+              \\ \\ 
+
+              \\  # Extract and clean up
+
+              \\  tar -xvzf $SOURCE_TAR_NAME
+
+              \\  rm -f $SOURCE_TAR_NAME
+
+              \\ \\ 
+
+              \\  # Create cache directory and copy extracted files
+
+              \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+
+              \\  cp -r ./{*,.*} \\"$SOURCE_EXTRACTED_DIR\\"/ 2>/dev/null || true
+
+              \\ \\ 
+
+              \\  # Save the ETag
+
+              \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              fi
 
 
               # Install dependencies and build
@@ -3049,19 +3241,67 @@ mkdir -p /opt/scripts
 cat << 'EOF' > /opt/scripts/start-app.sh
 #!/bin/bash -l
 
-# Clean up existing files
-rm -rf ./{*,.*}
-
-# Download source code from S3
-aws s3 cp s3://",
+# Set S3 bucket name
+S3_BUCKET_NAME="",
                   {
                     "Ref": "WorkerSourceBucket539ACD15",
                   },
-                  "/source/source.tar.gz ./source.tar.gz
+                  ""
+ETAG_FILE="/opt/myapp/.source_etag"
+SOURCE_EXTRACTED_DIR="/opt/myapp/extracted_source"
+SOURCE_TAR_NAME="source.tar.gz"
 
-# Extract and clean up
-tar -xvzf source.tar.gz
-rm -f source.tar.gz
+# Get current ETag from S3
+CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+
+# Check if we can use cached source code
+if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
+  CACHED_ETAG=$(cat $ETAG_FILE)
+  
+  if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
+    echo "ETag matches. Using cached source files."
+    # Copy cached source files to current directory
+    cp -r $SOURCE_EXTRACTED_DIR/{*,.*} ./ 2>/dev/null || true
+  else
+    echo "ETag different. Downloading fresh source files."
+    # Perform full download and extraction
+    # Clean up existing files
+    rm -rf ./{*,.*} 2>/dev/null || true
+    
+    # Download source code from S3
+    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+    
+    # Extract and clean up
+    tar -xvzf $SOURCE_TAR_NAME
+    rm -f $SOURCE_TAR_NAME
+    
+    # Cache the extracted files
+    rm -rf "$SOURCE_EXTRACTED_DIR" 2>/dev/null || true
+    mkdir -p "$SOURCE_EXTRACTED_DIR"
+    cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
+    
+    # Save the ETag
+    echo "$CURRENT_ETAG" > "$ETAG_FILE"
+  fi
+else
+  echo "No cached source files. Downloading fresh source files."
+  # Clean up existing files
+  rm -rf ./{*,.*} 2>/dev/null || true
+  
+  # Download source code from S3
+  aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
+  
+  # Extract and clean up
+  tar -xvzf $SOURCE_TAR_NAME
+  rm -f $SOURCE_TAR_NAME
+  
+  # Create cache directory and copy extracted files
+  mkdir -p "$SOURCE_EXTRACTED_DIR"
+  cp -r ./{*,.*} "$SOURCE_EXTRACTED_DIR"/ 2>/dev/null || true
+  
+  # Save the ETag
+  echo "$CURRENT_ETAG" > "$ETAG_FILE"
+fi
 
 # Install dependencies and build
 npm ci

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2121,7 +2121,7 @@ phases:
 
               cat << 'EOF' > /opt/scripts/start-app.sh
 
-              #!/bin/bash -l
+              #!/bin/bash
 
 
               # Set S3 bucket name
@@ -2134,8 +2134,6 @@ phases:
 
               ETAG_FILE=\\"/opt/myapp/.source_etag\\"
 
-              SOURCE_EXTRACTED_DIR=\\"/opt/myapp/extracted_source\\"
-
               SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
@@ -2144,88 +2142,11 @@ phases:
               set -e
 
 
-              # Get current ETag from S3
+              # Function to download and extract fresh source files
 
-              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+              download_fresh_files() {
 
-
-              # Check if we can use cached source code
-
-              if [ -f \\"$ETAG_FILE\\" ] && [ -d \\"$SOURCE_EXTRACTED_DIR\\" ]; then
-
-              \\  CACHED_ETAG=$(cat $ETAG_FILE)
-
-              \\ \\ 
-
-              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
-
-              \\    echo \\"ETag matches. Using cached source files.\\"
-
-              \\    # Clean up existing files first
-
-              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
-
-              \\    # Copy cached source files to current directory
-
-              \\    cp -r $SOURCE_EXTRACTED_DIR/* ./
-
-              \\    # Copy hidden files separately to avoid errors with . and ..
-
-              \\    find $SOURCE_EXTRACTED_DIR -name \\".*\\" -type f -exec cp {} ./ ;
-
-              \\  else
-
-              \\    echo \\"ETag different. Downloading fresh source files.\\"
-
-              \\    # Perform full download and extraction
-
-              \\    # Clean up existing files
-
-              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
-
-              \\   \\ 
-
-              \\    # Download source code from S3
-
-              \\    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
-
-              \\   \\ 
-
-              \\    # Extract and clean up
-
-              \\    tar -xvzf $SOURCE_TAR_NAME
-
-              \\    rm -f $SOURCE_TAR_NAME
-
-              \\   \\ 
-
-              \\    # Cache the extracted files
-
-              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\"
-
-              \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
-
-              \\   \\ 
-
-              \\    # Copy files to cache directory
-
-              \\    cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
-
-              \\    # Copy hidden files separately to avoid errors
-
-              \\    find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
-
-              \\   \\ 
-
-              \\    # Save the ETag only after successful operations
-
-              \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
-
-              \\  fi
-
-              else
-
-              \\  echo \\"No cached source files. Downloading fresh source files.\\"
+              \\  echo \\"Downloading fresh source files.\\"
 
               \\  # Clean up existing files
 
@@ -2247,45 +2168,74 @@ phases:
 
               \\ \\ 
 
-              \\  # Create cache directory and copy extracted files
+              \\  # Install dependencies and build
 
-              \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+              \\  npm ci
 
-              \\ \\ 
+              \\  npm run build -w packages/agent-core
 
-              \\  # Copy files to cache directory
 
-              \\  cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
-
-              \\  # Copy hidden files separately to avoid errors
-
-              \\  find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
-
-              \\ \\ 
-
-              \\  # Save the ETag only after successful operations
+              \\  # Save the ETag
 
               \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              }
+
+
+              # Get current ETag from S3
+
+              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+
+
+              # Check if we can use cached source code
+
+              if [ -f \\"$ETAG_FILE\\" ]; then
+
+              \\  CACHED_ETAG=$(cat $ETAG_FILE)
+
+              \\ \\ 
+
+              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
+
+              \\    echo \\"ETag matches. Using existing source files.\\"
+
+              \\    # Files are already in place, no need to do anything
+
+              \\  else
+
+              \\    # ETag doesn't match, need to download fresh files
+
+              \\    download_fresh_files
+
+              \\  fi
+
+              else
+
+              \\  # No ETAG file, need to download fresh files
+
+              \\  download_fresh_files
 
               fi
 
 
-              # Install dependencies and build
+              if [ \\"$NO_START\\" == \\"true\\" ]; then
 
-              npm ci
+              \\  echo \\"NO_START=true is passed. Existing...\\"
 
-              npm run build -w packages/agent-core
+              \\  exit 0
+
+              fi
 
 
               # Set up dynamic environment variables
 
-              TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
+              TOKEN=$(curl -s -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
 
-              export WORKER_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+              export WORKER_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
-              export SLACK_CHANNEL_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
+              export SLACK_CHANNEL_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
 
-              export SLACK_THREAD_TS=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
+              export SLACK_THREAD_TS=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
 
               export SLACK_BOT_TOKEN=$(aws ssm get-parameter --name /remote-swe/slack/bot-token --query \\"Parameter.Value\\" --output text)
 
@@ -2306,6 +2256,11 @@ phases:
               chmod +x /opt/scripts/start-app.sh
 
               chown ubuntu:ubuntu /opt/scripts/start-app.sh
+
+
+              # cache worker files
+
+              sudo -u ubuntu bash -i -c \\"NO_START=true /opt/scripts/start-app.sh\\"
 
 
               cat << EOF > /etc/systemd/system/myapp.service
@@ -2449,9 +2404,9 @@ phases:
               #!/bin/bash
 
 
-              TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
+              TOKEN=$(curl -s -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
 
-              export WORKER_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+              export WORKER_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
 
               exec /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
@@ -2817,7 +2772,7 @@ phases:
 
               cat << 'EOF' > /opt/scripts/start-app.sh
 
-              #!/bin/bash -l
+              #!/bin/bash
 
 
               # Set S3 bucket name
@@ -2830,8 +2785,6 @@ phases:
 
               ETAG_FILE=\\"/opt/myapp/.source_etag\\"
 
-              SOURCE_EXTRACTED_DIR=\\"/opt/myapp/extracted_source\\"
-
               SOURCE_TAR_NAME=\\"source.tar.gz\\"
 
 
@@ -2840,88 +2793,11 @@ phases:
               set -e
 
 
-              # Get current ETag from S3
+              # Function to download and extract fresh source files
 
-              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+              download_fresh_files() {
 
-
-              # Check if we can use cached source code
-
-              if [ -f \\"$ETAG_FILE\\" ] && [ -d \\"$SOURCE_EXTRACTED_DIR\\" ]; then
-
-              \\  CACHED_ETAG=$(cat $ETAG_FILE)
-
-              \\ \\ 
-
-              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
-
-              \\    echo \\"ETag matches. Using cached source files.\\"
-
-              \\    # Clean up existing files first
-
-              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
-
-              \\    # Copy cached source files to current directory
-
-              \\    cp -r $SOURCE_EXTRACTED_DIR/* ./
-
-              \\    # Copy hidden files separately to avoid errors with . and ..
-
-              \\    find $SOURCE_EXTRACTED_DIR -name \\".*\\" -type f -exec cp {} ./ ;
-
-              \\  else
-
-              \\    echo \\"ETag different. Downloading fresh source files.\\"
-
-              \\    # Perform full download and extraction
-
-              \\    # Clean up existing files
-
-              \\    rm -rf ./{*,.*} 2>/dev/null || echo \\"Cleaning up existing files\\"
-
-              \\   \\ 
-
-              \\    # Download source code from S3
-
-              \\    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
-
-              \\   \\ 
-
-              \\    # Extract and clean up
-
-              \\    tar -xvzf $SOURCE_TAR_NAME
-
-              \\    rm -f $SOURCE_TAR_NAME
-
-              \\   \\ 
-
-              \\    # Cache the extracted files
-
-              \\    rm -rf \\"$SOURCE_EXTRACTED_DIR\\"
-
-              \\    mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
-
-              \\   \\ 
-
-              \\    # Copy files to cache directory
-
-              \\    cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
-
-              \\    # Copy hidden files separately to avoid errors
-
-              \\    find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
-
-              \\   \\ 
-
-              \\    # Save the ETag only after successful operations
-
-              \\    echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
-
-              \\  fi
-
-              else
-
-              \\  echo \\"No cached source files. Downloading fresh source files.\\"
+              \\  echo \\"Downloading fresh source files.\\"
 
               \\  # Clean up existing files
 
@@ -2943,45 +2819,74 @@ phases:
 
               \\ \\ 
 
-              \\  # Create cache directory and copy extracted files
+              \\  # Install dependencies and build
 
-              \\  mkdir -p \\"$SOURCE_EXTRACTED_DIR\\"
+              \\  npm ci
 
-              \\ \\ 
+              \\  npm run build -w packages/agent-core
 
-              \\  # Copy files to cache directory
 
-              \\  cp -r ./* \\"$SOURCE_EXTRACTED_DIR\\"/\\ 
-
-              \\  # Copy hidden files separately to avoid errors
-
-              \\  find . -maxdepth 1 -name \\".*\\" -type f -exec cp {} \\"$SOURCE_EXTRACTED_DIR\\"/ ;
-
-              \\ \\ 
-
-              \\  # Save the ETag only after successful operations
+              \\  # Save the ETag
 
               \\  echo \\"$CURRENT_ETAG\\" > \\"$ETAG_FILE\\"
+
+              }
+
+
+              # Get current ETag from S3
+
+              CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+
+
+              # Check if we can use cached source code
+
+              if [ -f \\"$ETAG_FILE\\" ]; then
+
+              \\  CACHED_ETAG=$(cat $ETAG_FILE)
+
+              \\ \\ 
+
+              \\  if [ \\"$CURRENT_ETAG\\" == \\"$CACHED_ETAG\\" ]; then
+
+              \\    echo \\"ETag matches. Using existing source files.\\"
+
+              \\    # Files are already in place, no need to do anything
+
+              \\  else
+
+              \\    # ETag doesn't match, need to download fresh files
+
+              \\    download_fresh_files
+
+              \\  fi
+
+              else
+
+              \\  # No ETAG file, need to download fresh files
+
+              \\  download_fresh_files
 
               fi
 
 
-              # Install dependencies and build
+              if [ \\"$NO_START\\" == \\"true\\" ]; then
 
-              npm ci
+              \\  echo \\"NO_START=true is passed. Existing...\\"
 
-              npm run build -w packages/agent-core
+              \\  exit 0
+
+              fi
 
 
               # Set up dynamic environment variables
 
-              TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
+              TOKEN=$(curl -s -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
 
-              export WORKER_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+              export WORKER_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
-              export SLACK_CHANNEL_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
+              export SLACK_CHANNEL_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
 
-              export SLACK_THREAD_TS=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
+              export SLACK_THREAD_TS=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
 
               export SLACK_BOT_TOKEN=$(aws ssm get-parameter --name /remote-swe/slack/bot-token --query \\"Parameter.Value\\" --output text)
 
@@ -3002,6 +2907,11 @@ phases:
               chmod +x /opt/scripts/start-app.sh
 
               chown ubuntu:ubuntu /opt/scripts/start-app.sh
+
+
+              # cache worker files
+
+              sudo -u ubuntu bash -i -c \\"NO_START=true /opt/scripts/start-app.sh\\"
 
 
               cat << EOF > /etc/systemd/system/myapp.service
@@ -3145,9 +3055,9 @@ phases:
               #!/bin/bash
 
 
-              TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
+              TOKEN=$(curl -s -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 900\\")
 
-              export WORKER_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+              export WORKER_ID=$(curl -s -H \\"X-aws-ec2-metadata-token: $TOKEN\\" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
 
               exec /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
@@ -3356,7 +3266,7 @@ sudo -u ubuntu bash -c "gh config set prompt disabled"
 # Create setup script
 mkdir -p /opt/scripts
 cat << 'EOF' > /opt/scripts/start-app.sh
-#!/bin/bash -l
+#!/bin/bash
 
 # Set S3 bucket name
 S3_BUCKET_NAME="",
@@ -3365,54 +3275,14 @@ S3_BUCKET_NAME="",
                   },
                   ""
 ETAG_FILE="/opt/myapp/.source_etag"
-SOURCE_EXTRACTED_DIR="/opt/myapp/extracted_source"
 SOURCE_TAR_NAME="source.tar.gz"
 
 # Enable strict mode for safety
 set -e
 
-# Get current ETag from S3
-CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
-
-# Check if we can use cached source code
-if [ -f "$ETAG_FILE" ] && [ -d "$SOURCE_EXTRACTED_DIR" ]; then
-  CACHED_ETAG=$(cat $ETAG_FILE)
-  
-  if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
-    echo "ETag matches. Using cached source files."
-    # Clean up existing files first
-    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
-    # Copy cached source files to current directory
-    cp -r $SOURCE_EXTRACTED_DIR/* ./
-    # Copy hidden files separately to avoid errors with . and ..
-    find $SOURCE_EXTRACTED_DIR -name ".*" -type f -exec cp {} ./ ;
-  else
-    echo "ETag different. Downloading fresh source files."
-    # Perform full download and extraction
-    # Clean up existing files
-    rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
-    
-    # Download source code from S3
-    aws s3 cp s3://$S3_BUCKET_NAME/source/$SOURCE_TAR_NAME ./$SOURCE_TAR_NAME
-    
-    # Extract and clean up
-    tar -xvzf $SOURCE_TAR_NAME
-    rm -f $SOURCE_TAR_NAME
-    
-    # Cache the extracted files
-    rm -rf "$SOURCE_EXTRACTED_DIR"
-    mkdir -p "$SOURCE_EXTRACTED_DIR"
-    
-    # Copy files to cache directory
-    cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
-    # Copy hidden files separately to avoid errors
-    find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ ;
-    
-    # Save the ETag only after successful operations
-    echo "$CURRENT_ETAG" > "$ETAG_FILE"
-  fi
-else
-  echo "No cached source files. Downloading fresh source files."
+# Function to download and extract fresh source files
+download_fresh_files() {
+  echo "Downloading fresh source files."
   # Clean up existing files
   rm -rf ./{*,.*} 2>/dev/null || echo "Cleaning up existing files"
   
@@ -3423,27 +3293,43 @@ else
   tar -xvzf $SOURCE_TAR_NAME
   rm -f $SOURCE_TAR_NAME
   
-  # Create cache directory and copy extracted files
-  mkdir -p "$SOURCE_EXTRACTED_DIR"
-  
-  # Copy files to cache directory
-  cp -r ./* "$SOURCE_EXTRACTED_DIR"/ 
-  # Copy hidden files separately to avoid errors
-  find . -maxdepth 1 -name ".*" -type f -exec cp {} "$SOURCE_EXTRACTED_DIR"/ ;
-  
-  # Save the ETag only after successful operations
+  # Install dependencies and build
+  npm ci
+  npm run build -w packages/agent-core
+
+  # Save the ETag
   echo "$CURRENT_ETAG" > "$ETAG_FILE"
+}
+
+# Get current ETag from S3
+CURRENT_ETAG=$(aws s3api head-object --bucket $S3_BUCKET_NAME --key source/$SOURCE_TAR_NAME --query ETag --output text)
+
+# Check if we can use cached source code
+if [ -f "$ETAG_FILE" ]; then
+  CACHED_ETAG=$(cat $ETAG_FILE)
+  
+  if [ "$CURRENT_ETAG" == "$CACHED_ETAG" ]; then
+    echo "ETag matches. Using existing source files."
+    # Files are already in place, no need to do anything
+  else
+    # ETag doesn't match, need to download fresh files
+    download_fresh_files
+  fi
+else
+  # No ETAG file, need to download fresh files
+  download_fresh_files
 fi
 
-# Install dependencies and build
-npm ci
-npm run build -w packages/agent-core
+if [ "$NO_START" == "true" ]; then
+  echo "NO_START=true is passed. Existing..."
+  exit 0
+fi
 
 # Set up dynamic environment variables
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
-export WORKER_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
-export SLACK_CHANNEL_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
-export SLACK_THREAD_TS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
+export WORKER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+export SLACK_CHANNEL_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/SlackChannelId)
+export SLACK_THREAD_TS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/SlackThreadTs)
 export SLACK_BOT_TOKEN=$(aws ssm get-parameter --name /remote-swe/slack/bot-token --query "Parameter.Value" --output text)
 export GITHUB_PERSONAL_ACCESS_TOKEN=""
 
@@ -3455,6 +3341,9 @@ EOF
 # Make script executable and set ownership
 chmod +x /opt/scripts/start-app.sh
 chown ubuntu:ubuntu /opt/scripts/start-app.sh
+
+# cache worker files
+sudo -u ubuntu bash -i -c "NO_START=true /opt/scripts/start-app.sh"
 
 cat << EOF > /etc/systemd/system/myapp.service
 [Unit]
@@ -3541,8 +3430,8 @@ EOF
 cat << 'EOF' > /opt/scripts/start-fluent-bit.sh
 #!/bin/bash
 
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
-export WORKER_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 900")
+export WORKER_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/RemoteSweWorkerId)
 
 exec /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
 EOF


### PR DESCRIPTION
# Cache source.tar.gz using S3 ETag

This PR implements caching for source.tar.gz file based on S3 ETag values to improve myapp service startup performance.

## Changes

- Added logic to check S3 ETag before downloading source.tar.gz
- Implemented caching mechanism to store extracted files locally
- Added conditional logic to use cached files when ETag hasn't changed
- Added ETag storage at /opt/myapp/.source_etag to track file changes

## Implementation

The implementation follows these steps:
1. When myapp starts, check if a cached ETag exists
2. If it exists, compare with current S3 ETag using head-object API call
3. If ETags match, use the cached extracted files instead of downloading again
4. If ETags differ or no cache exists, download the file and update the cache

This change should significantly improve startup time when source.tar.gz hasn't changed.

Fixes #54