### PR TITLE
Add link to Japanese README in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an example implementation of a fully autonomous software development AI agent. The agent works in its own dedicated development environment, freeing you from being tied to your laptop!
 
+*日本語版のREADMEは[こちら](README_ja.md)をご覧ください。*
+
 ![Concept](./docs/imgs/concept.png)
 
 ## Key Features


### PR DESCRIPTION
# Add link to Japanese README

This PR adds a link to the Japanese version of the README (README_ja.md) in the original README.md file.

## Changes
- Added a link to the Japanese README in the introduction section (just before the concept image)
- Implemented the link with the text: \"*日本語版のREADMEは[こちら](README_ja.md)をご覧ください。*\" (Japanese README is available [here])

This makes it easier for Japanese-speaking users to find the Japanese version of the README.