### PR TITLE
fix image builder instance cannot access worker code in s3

### DIFF
--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -389,6 +389,7 @@ systemctl start myapp
       vpc,
       installDependenciesCommand,
       amiIdParameterName: props.amiIdParameterName,
+      sourceBucket,
     });
 
     role.addToPrincipalPolicy(

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -1737,6 +1737,48 @@ exports.handler = async function (event, context) {
       },
       "Type": "AWS::AppSync::ChannelNamespace",
     },
+    "WorkerImageBuilderAdditionalInstancePolicy4F8E90CE": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetBucket*",
+                "s3:GetObject*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "WorkerSourceBucket539ACD15",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "WorkerSourceBucket539ACD15",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
     "WorkerImageBuilderImagePipelineV2ImageBuilderTopic1FBB0EDA": {
       "Properties": {
         "DisplayName": "Image Builder Notify",
@@ -1888,6 +1930,9 @@ exports.handler = async function (event, context) {
                 ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
+          },
+          {
+            "Ref": "WorkerImageBuilderAdditionalInstancePolicy4F8E90CE",
           },
         ],
       },


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

We got the error below during AMI build. This PR fixes the problem by adding required IAM policy to the instance profile.

> An error occurred (403) when calling the HeadObject operation: Forbidden


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
