### PR TITLE
notify error in worker manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10830,9 +10830,10 @@
         "@remote-swe-agents/agent-core": "file:../agent-core",
         "@slack/bolt": "^4.0.0",
         "@slack/web-api": "^7.8.0",
-        "@types/aws-lambda": "^8.10.147"
+        "zod": "^3.24.3"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.147",
         "@types/node": "^22.8.6",
         "esbuild": "^0.25.0",
         "prettier": "^3.3.3",

--- a/packages/slack-bolt-app/package.json
+++ b/packages/slack-bolt-app/package.json
@@ -25,9 +25,10 @@
     "@remote-swe-agents/agent-core": "file:../agent-core",
     "@slack/bolt": "^4.0.0",
     "@slack/web-api": "^7.8.0",
-    "@types/aws-lambda": "^8.10.147"
+    "zod": "^3.24.3"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.147",
     "@types/node": "^22.8.6",
     "esbuild": "^0.25.0",
     "prettier": "^3.3.3",

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -11,6 +11,7 @@ import { Message } from '@aws-sdk/client-bedrock-runtime';
 import { s3, BucketName } from '@remote-swe-agents/agent-core/aws';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { IdempotencyAlreadyInProgressError } from '@aws-lambda-powertools/idempotency';
+import { AsyncHandlerEvent } from './async-handler';
 
 const SigningSecret = process.env.SIGNING_SECRET!;
 const BotToken = process.env.BOT_TOKEN!;
@@ -213,7 +214,7 @@ app.event('app_mention', async ({ event, client, logger }) => {
               workerId,
               slackChannelId: event.channel,
               slackThreadTs: event.ts,
-            }),
+            } satisfies AsyncHandlerEvent),
             InvocationType: 'Event',
           })
         ),

--- a/packages/slack-bolt-app/src/async-handler.ts
+++ b/packages/slack-bolt-app/src/async-handler.ts
@@ -1,6 +1,7 @@
 import { Handler } from 'aws-lambda';
 import { getOrCreateWorkerInstance } from './util/worker-manager';
 import { App, AwsLambdaReceiver, LogLevel } from '@slack/bolt';
+import z from 'zod';
 
 const BotToken = process.env.BOT_TOKEN!;
 
@@ -16,25 +17,44 @@ const app = new App({
   socketMode: false,
 });
 
-type Event = { type: 'ensureInstance'; workerId: string; slackChannelId: string; slackThreadTs: string };
+const eventSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('ensureInstance'),
+    workerId: z.string(),
+    slackChannelId: z.string(),
+    slackThreadTs: z.string(),
+  }),
+]);
+
+export type AsyncHandlerEvent = z.infer<typeof eventSchema>;
 
 // slack api timeouts in just a 3 seconds so we run actual process asynchronously
 // we might not need this because idempotency using dynamodb lock almost resolved the problem.
-export const handler: Handler<Event> = async (event, context) => {
+export const handler: Handler<unknown> = async (rawEvent, context) => {
+  const event = eventSchema.parse(rawEvent);
   if (event.type == 'ensureInstance') {
-    const res = await getOrCreateWorkerInstance(event.workerId, event.slackChannelId, event.slackThreadTs);
+    try {
+      const res = await getOrCreateWorkerInstance(event.workerId, event.slackChannelId, event.slackThreadTs);
 
-    if (res.oldStatus == 'stopped') {
+      if (res.oldStatus == 'stopped') {
+        await app.client.chat.postMessage({
+          channel: event.slackChannelId,
+          thread_ts: event.slackThreadTs,
+          text: `Waking up from sleep mode...`,
+        });
+      } else if (res.oldStatus == 'terminated') {
+        await app.client.chat.postMessage({
+          channel: event.slackChannelId,
+          thread_ts: event.slackThreadTs,
+          text: `Preparing for a new instance...`,
+        });
+      }
+    } catch (e) {
+      console.error(e);
       await app.client.chat.postMessage({
         channel: event.slackChannelId,
         thread_ts: event.slackThreadTs,
-        text: `Waking up from sleep mode...`,
-      });
-    } else if (res.oldStatus == 'terminated') {
-      await app.client.chat.postMessage({
-        channel: event.slackChannelId,
-        thread_ts: event.slackThreadTs,
-        text: `Preparing for a new instance...`,
+        text: `An error occurred in worker manager: ${e}`,
       });
     }
   }

--- a/packages/slack-bolt-app/src/util/worker-manager.ts
+++ b/packages/slack-bolt-app/src/util/worker-manager.ts
@@ -14,6 +14,7 @@ export async function findStoppedWorkerInstance(workerId: string) {
 export async function findRunningWorkerInstance(workerId: string) {
   return findWorkerInstanceWithStatus(workerId, ['running', 'pending']);
 }
+
 async function findWorkerInstanceWithStatus(workerId: string, statuses: string[]): Promise<string | null> {
   const describeCommand = new DescribeInstancesCommand({
     Filters: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, if we got any error in worker manager, it fails silently. To let user (or developer) know what's happening more precisely, this PR will make it send error detail to slack.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
