### PR TITLE
Add session storage feature for DynamoDB

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -86,3 +86,4 @@ cd slack-bolt-app && npm run build
 
 - **Build errors**: Check that dependencies are up to date (`npm ci` to update)
 - **TypeScript errors**: Ensure type definitions are accurate and use type assertions when necessary
+- **CDK Snapshot Test Failures**: When modifying infrastructure in CDK, snapshot tests may fail. Update snapshots using `cd cdk && npm run test -- -u`

--- a/cdk/lib/constructs/storage.ts
+++ b/cdk/lib/constructs/storage.ts
@@ -1,5 +1,5 @@
 import { CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
-import { AttributeType, Billing, TableV2 } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, Billing, TableV2, ProjectionType } from 'aws-cdk-lib/aws-dynamodb';
 import { BlockPublicAccess, Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
@@ -20,6 +20,13 @@ export class Storage extends Construct {
       billing: Billing.onDemand(),
       timeToLiveAttribute: 'TTL',
       removalPolicy: RemovalPolicy.DESTROY,
+      localSecondaryIndexes: [
+        {
+          indexName: 'LSI1',
+          sortKey: { name: 'LSI1', type: AttributeType.STRING },
+          projectionType: ProjectionType.ALL,
+        },
+      ],
     });
 
     const bucket = new Bucket(this, 'ImageBucket', {

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -972,12 +972,28 @@ exports.handler = async function (event, context) {
                 "dynamodb:UpdateItem",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "StorageHistory251A3AE8",
-                  "Arn",
-                ],
-              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "StorageHistory251A3AE8",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "StorageHistory251A3AE8",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [
@@ -1203,12 +1219,28 @@ exports.handler = async function (event, context) {
                 "dynamodb:UpdateItem",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "StorageHistory251A3AE8",
-                  "Arn",
-                ],
-              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "StorageHistory251A3AE8",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "StorageHistory251A3AE8",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [
@@ -1290,6 +1322,10 @@ exports.handler = async function (event, context) {
             "AttributeName": "SK",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "LSI1",
+            "AttributeType": "S",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
@@ -1300,6 +1336,24 @@ exports.handler = async function (event, context) {
           {
             "AttributeName": "SK",
             "KeyType": "RANGE",
+          },
+        ],
+        "LocalSecondaryIndexes": [
+          {
+            "IndexName": "LSI1",
+            "KeySchema": [
+              {
+                "AttributeName": "PK",
+                "KeyType": "HASH",
+              },
+              {
+                "AttributeName": "LSI1",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
           },
         ],
         "Replicas": [
@@ -3642,12 +3696,28 @@ systemctl start myapp",
                 "dynamodb:UpdateItem",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "StorageHistory251A3AE8",
-                  "Arn",
-                ],
-              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "StorageHistory251A3AE8",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "StorageHistory251A3AE8",
+                          "Arn",
+                        ],
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2640,6 +2640,46 @@ phases:
       "Type": "Custom::ImageBuilderVersioning",
       "UpdateReplacePolicy": "Delete",
     },
+    "WorkerImageBuilderPurgeAmiCacheBF0FB7E9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "WorkerImageBuilderPurgeAmiCacheCustomResourcePolicy864B61A7",
+      ],
+      "Properties": {
+        "Create": "{"service":"@aws-sdk/client-ssm","action":"DeleteParameter","parameters":{"Name":"/remote-swe/worker/ami-id"},"ignoreErrorCodesMatching":"ParameterNotFound","physicalResourceId":{"id":"v1"}}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{"service":"@aws-sdk/client-ssm","action":"DeleteParameter","parameters":{"Name":"/remote-swe/worker/ami-id"},"ignoreErrorCodesMatching":"ParameterNotFound","physicalResourceId":{"id":"v1"}}",
+      },
+      "Type": "Custom::AWS",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "WorkerImageBuilderPurgeAmiCacheCustomResourcePolicy864B61A7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:DeleteParameter",
+              "Effect": "Allow",
+              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/remote-swe/worker/ami-id",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "WorkerImageBuilderPurgeAmiCacheCustomResourcePolicy864B61A7",
+        "Roles": [
+          {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "WorkerImageBuilderRunPipelineA153A00F": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -2664,7 +2704,7 @@ phases:
                   "version",
                 ],
               },
-              ""}}",
+              "#v1"}}",
             ],
           ],
         },
@@ -2693,7 +2733,7 @@ phases:
                   "version",
                 ],
               },
-              ""}}",
+              "#v1"}}",
             ],
           ],
         },

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -13,6 +13,13 @@ type MessageItem = {
   slackUserId: string;
 };
 
+type SessionItem = {
+  PK: string;
+  SK: string;
+  workerId: string;
+  createdAt: string;
+};
+
 export const saveConversationHistory = async (
   workerId: string,
   message: string,
@@ -89,4 +96,19 @@ export const getTokenUsage = async (workerId: string) => {
     })
   );
   return res.Items ?? [];
+};
+
+export const saveSessionInfo = async (workerId: string) => {
+  const now = new Date();
+  await ddb.send(
+    new PutCommand({
+      TableName,
+      Item: {
+        PK: 'sessions',
+        SK: `${String(Date.now()).padStart(20, '0')}`,
+        workerId,
+        createdAt: now.toISOString(),
+      } satisfies SessionItem,
+    })
+  );
 };

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -17,7 +17,7 @@ type SessionItem = {
   PK: string;
   SK: string;
   workerId: string;
-  createdAt: string;
+  createdAt: number;
   LSI1: string;
 };
 
@@ -100,8 +100,8 @@ export const getTokenUsage = async (workerId: string) => {
 };
 
 export const saveSessionInfo = async (workerId: string) => {
-  const now = new Date();
-  const timestamp = String(Date.now()).padStart(20, '0');
+  const now = Date.now();
+  const timestamp = String(now).padStart(15, '0');
 
   await ddb.send(
     new PutCommand({
@@ -110,7 +110,7 @@ export const saveSessionInfo = async (workerId: string) => {
         PK: 'sessions',
         SK: workerId,
         workerId,
-        createdAt: now.toISOString(),
+        createdAt: now,
         LSI1: timestamp,
       } satisfies SessionItem,
     })

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -18,6 +18,7 @@ type SessionItem = {
   SK: string;
   workerId: string;
   createdAt: string;
+  LSI1: string;
 };
 
 export const saveConversationHistory = async (
@@ -100,14 +101,17 @@ export const getTokenUsage = async (workerId: string) => {
 
 export const saveSessionInfo = async (workerId: string) => {
   const now = new Date();
+  const timestamp = String(Date.now()).padStart(20, '0');
+
   await ddb.send(
     new PutCommand({
       TableName,
       Item: {
         PK: 'sessions',
-        SK: `${String(Date.now()).padStart(20, '0')}`,
+        SK: workerId,
         workerId,
         createdAt: now.toISOString(),
+        LSI1: timestamp,
       } satisfies SessionItem,
     })
   );


### PR DESCRIPTION
Implements issue #74: Allow to list all the previous sessions with DynamoDB query

BREAKING CHANGE: This PR replaces the DynamoDB table schema. We accept this since currently there should not be many users for this.

## Implementation Details

When creating a new session (i.e. new Slack thread), we store the following item in the DynamoDB table:
- PK: sessions
- SK: workerId
- workerId
- createdAt
- LSI1: Date.now().toString() (padded with 0 to 20 length)

## Changes

1. packages/slack-bolt-app/src/util/history.ts
   - Added type definition and function to store session information

2. packages/slack-bolt-app/src/app.ts
   - Modified to save session information only when a new thread is created (when thread_ts === undefined)

3. cdk/lib/constructs/storage.ts
   - Added LocalSecondaryIndex (LSI1) to the DynamoDB table definition
   - This enables time-based queries for sessions

Closes #74