### PR TITLE
fix playwright fails to run after started from a cached ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This way the repository is automatically inferred from the URL, and it can also 
 
 ### Integrating with MCP Servers
 
-As our agent can work as an MCP client, you can easily integrate it with various MCP servers. To configure the integration, you can edit [`claude_desktop_config.json`](./packages/worker/claude_desktop_config.json) and run CDK deploy. For example,
+As our agent can work as an MCP client, you can easily integrate it with various MCP servers. To configure the integration, you can edit [`mcp.json`](./packages/worker/mcp.json) and run CDK deploy. For example,
 
 ```json
   "mcpServers": {

--- a/README_ja.md
+++ b/README_ja.md
@@ -237,7 +237,7 @@ npx cdk deploy
 
 ### MCPサーバーとの統合
 
-エージェントはMCPクライアントとして機能できるため、さまざまなMCPサーバーと簡単に統合できます。統合を設定するには、[`claude_desktop_config.json`](./packages/worker/claude_desktop_config.json)を編集してCDK deployを実行します。例えば、
+エージェントはMCPクライアントとして機能できるため、さまざまなMCPサーバーと簡単に統合できます。統合を設定するには、[`mcp.json`](./packages/worker/mcp.json)を編集してCDK deployを実行します。例えば、
 
 ```json
   "mcpServers": {

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -274,6 +274,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN=${
 
 # Start app
 cd packages/worker
+npx playwright install chromium
 npx tsx src/main.ts
 EOF
 

--- a/cdk/lib/constructs/worker/resources/image-component-template.yml
+++ b/cdk/lib/constructs/worker/resources/image-component-template.yml
@@ -10,6 +10,7 @@ phases:
       - name: InstallDependencies
         action: ExecuteBash
         inputs:
+          # commands will be replaced from CDK
           commands: 
             - dummy
   - name: validate

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2559,6 +2559,8 @@ phases:
 
               cd packages/worker
 
+              npx playwright install chromium
+
               npx tsx src/main.ts
 
               EOF
@@ -3250,6 +3252,8 @@ phases:
 
               cd packages/worker
 
+              npx playwright install chromium
+
               npx tsx src/main.ts
 
               EOF
@@ -3688,6 +3692,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN=""
 
 # Start app
 cd packages/worker
+npx playwright install chromium
 npx tsx src/main.ts
 EOF
 

--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -15,7 +15,7 @@ const awsAccounts = (process.env.BEDROCK_AWS_ACCOUNTS ?? '').split(',');
 const roleName = process.env.BEDROCK_AWS_ROLE_NAME || 'bedrock-remote-swe-role';
 
 // State management for persistent account selection and retry
-let currentAccountIndex: number = 0; // Currently used account index
+let currentAccountIndex = 0; // Currently used account index
 
 const modelTypeSchema = z.enum(['sonnet3.5v1', 'sonnet3.5', 'sonnet3.7', 'haiku3.5', 'nova-pro']);
 type ModelType = z.infer<typeof modelTypeSchema>;
@@ -172,19 +172,12 @@ const preProcessInput = (input: ConverseCommandInput, modelType: ModelType) => {
 
 const getModelClient = async (modelType: ModelType) => {
   const { awsRegion, modelId } = chooseModelAndRegion(modelType);
-  console.log(`awsAccounts: ${awsAccounts}`);
 
-  if (awsAccounts.length === 0 || !awsAccounts[0]) {
+  if (awsAccounts.length === 0) {
     return { client: new BedrockRuntimeClient({ region: awsRegion }), modelId };
   }
 
-  // Improved account selection logic
-  let account: string;
-
-  // Log the current account being used
-  console.log(`Using AWS account: ${awsAccounts[currentAccountIndex]}`);
-
-  account = awsAccounts[currentAccountIndex];
+  const account = awsAccounts[currentAccountIndex];
   const cred = await getCredentials(account);
   const client = new BedrockRuntimeClient({
     region: awsRegion,

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -286,6 +286,15 @@ app.event('app_mention', async ({ event, client, logger }) => {
                             },
                           ],
                         },
+                        {
+                          type: 'rich_text_section',
+                          elements: [
+                            {
+                              type: 'text',
+                              text: 'You can always interrupt and ask them to stop what they are doing.',
+                            },
+                          ],
+                        },
                       ],
                     },
                   ],

--- a/packages/slack-bolt-app/src/async-handler.ts
+++ b/packages/slack-bolt-app/src/async-handler.ts
@@ -46,7 +46,7 @@ export const handler: Handler<unknown> = async (rawEvent, context) => {
         await app.client.chat.postMessage({
           channel: event.slackChannelId,
           thread_ts: event.slackThreadTs,
-          text: `Preparing for a new instance...`,
+          text: `Preparing for a new instance${res.usedCache ? ' (using a cached AMI)' : ''}...`,
         });
       }
     } catch (e) {

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -12,8 +12,8 @@ npm run watch
 ```
 
 ```sh
-export BUCKET_NAME=remoteswestack-sandbox-storageimagebucket99ba9550-lqsrca5cnznn
-export TABLE_NAME=RemoteSweStack-Sandbox-StorageHistory251A3AE8-9XH4C0BO957Q
+export BUCKET_NAME=remoteswestack-sandbox-storageimagebucket99ba9550-xxxxxxx
+export TABLE_NAME=RemoteSweStack-Sandbox-StorageHistory251A3AE8-xxxxxx
 export DISABLE_SLACK=true
 export EVENT_HTTP_ENDPOINT="https://API_ID.appsync-api.ap-northeast-1.amazonaws.com"
 export GITHUB_PERSONAL_ACCESS_TOKEN='dummy'

--- a/packages/worker/mcp.json
+++ b/packages/worker/mcp.json
@@ -6,7 +6,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest", "--headless"]
+      "args": ["@playwright/mcp@latest", "--headless", "--browser=chromium"]
     }
   }
 }

--- a/packages/worker/src/agent/mcp/index.ts
+++ b/packages/worker/src/agent/mcp/index.ts
@@ -17,7 +17,7 @@ const configSchema = z.object({
 let clients: { name: string; client: MCPClient }[] = [];
 
 const initMcp = async () => {
-  const configJson = JSON.parse(readFileSync('./claude_desktop_config.json').toString());
+  const configJson = JSON.parse(readFileSync('./mcp.json').toString());
   const { success, data: config } = configSchema.safeParse(configJson);
   if (!success) {
     // how to handle this?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

browser_install tool from playwright MCP fails to run after launched from a cached AMI.

The suggested workaround here https://github.com/microsoft/playwright-mcp/issues/218#issuecomment-2815992016 seems to fix the issue (adding `--browser=chromium`).

Also including some refactors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
