### PR TITLE
Remove progress header from Slack messages

### DIFF
--- a/packages/agent-core/src/lib/slack.ts
+++ b/packages/agent-core/src/lib/slack.ts
@@ -36,19 +36,6 @@ export const sendMessageToSlack = async (message: string, progress = false) => {
     // limit to 40000 chars https://api.slack.com/methods/chat.postMessage#truncating
     text: message.slice(0, 40000),
     blocks: [
-      ...(progress
-        ? [
-            {
-              type: 'context',
-              elements: [
-                {
-                  type: 'mrkdwn',
-                  text: 'progress',
-                },
-              ],
-            },
-          ]
-        : []),
       {
         type: 'markdown',
         // limit to 12000 chars https://api.slack.com/reference/block-kit/blocks#markdown
@@ -58,7 +45,7 @@ export const sendMessageToSlack = async (message: string, progress = false) => {
   });
 };
 
-export const sendFileToSlack = async (imagePath: string, message: string, progress = false) => {
+export const sendFileToSlack = async (imagePath: string, message: string) => {
   if (disableSlack) {
     console.log(`[Slack] Image: ${imagePath}, Message: ${message}`);
     return;

--- a/packages/agent-core/src/tools/report-progress/index.ts
+++ b/packages/agent-core/src/tools/report-progress/index.ts
@@ -14,7 +14,7 @@ export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,
   handler: async (input: z.infer<typeof inputSchema>) => {
     if (!input.message) return 'No message was sent.';
-    await sendMessageToSlack(input.message, true);
+    await sendMessageToSlack(input.message);
     return 'Successfully sent a message.';
   },
   schema: inputSchema,


### PR DESCRIPTION
# Remove progress header from Slack messages

## Changes
- Removed the progress header ('progress' text) that appears in Slack message notifications
- Simplified the message display in Slack for better readability
- Modified related functions to no longer use the progress parameter

## Why
The progress header in Slack messages was unnecessary and removing it improves the message display.

Without this header, we add `@mention` to the final message in the agent's turn. 