### PR TITLE
Fix URL auto-linking in Slack messages

### DIFF
--- a/packages/agent-core/src/lib/slack.ts
+++ b/packages/agent-core/src/lib/slack.ts
@@ -35,12 +35,16 @@ export const sendMessageToSlack = async (message: string, progress = false) => {
     thread_ts: threadTs,
     // limit to 40000 chars https://api.slack.com/methods/chat.postMessage#truncating
     text: message.slice(0, 40000),
+    parse: 'full',
     blocks: [
       {
-        type: 'markdown',
-        // limit to 12000 chars https://api.slack.com/reference/block-kit/blocks#markdown
-        text: message.slice(0, 12000),
-      } as any,
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          // limit to 12000 chars https://api.slack.com/reference/block-kit/blocks#markdown
+          text: message.slice(0, 12000),
+        },
+      },
     ],
   });
 };


### PR DESCRIPTION
# Fix URL auto-linking in Slack messages

## Changes
- Changed Slack message format from 'markdown' to 'mrkdwn' type inside a section block
- Added 'parse: full' option to the Slack API call
- URLs will now be automatically converted to clickable links in Slack messages

## Why
Currently URLs in Slack messages are not being converted to clickable links, making it difficult for users to access linked resources. This change fixes that issue by using the proper Slack Block Kit format and parsing options.