### PR TITLE
Enhance URL detection and linking in Slack messages

### DIFF
--- a/packages/agent-core/src/lib/slack.ts
+++ b/packages/agent-core/src/lib/slack.ts
@@ -25,22 +25,47 @@ const getApp = () => {
   return app;
 };
 
+// URL detection regex pattern - matches http/https URLs
+const urlPattern = /https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
+
+/**
+ * Processes message text to ensure URLs are properly formatted for Slack linking
+ * Converts URLs to Slack's explicit link format <url>
+ */
+const processMessageForLinks = (message: string): string => {
+  // Ensure URLs are wrapped in Slack's link syntax <url>
+  return message.replace(urlPattern, (url) => {
+    // Only wrap if not already wrapped
+    if (url.startsWith('<') && url.endsWith('>')) {
+      return url;
+    }
+    return `<${url}>`;
+  });
+};
+
 export const sendMessageToSlack = async (message: string, progress = false) => {
   if (disableSlack) {
     console.log(`[Slack] ${message}`);
     return;
   }
+
+  // Process message to ensure proper URL linking
+  const processedMessage = processMessageForLinks(message);
+
   await getApp().client.chat.postMessage({
     channel: channelID,
     thread_ts: threadTs,
     // limit to 40000 chars https://api.slack.com/methods/chat.postMessage#truncating
-    text: message.slice(0, 40000),
+    text: processedMessage.slice(0, 40000),
     blocks: [
       {
-        type: 'markdown',
-        // limit to 12000 chars https://api.slack.com/reference/block-kit/blocks#markdown
-        text: message.slice(0, 12000),
-      } as any,
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          // limit to 12000 chars https://api.slack.com/reference/block-kit/blocks#markdown
+          text: processedMessage.slice(0, 12000),
+        },
+      },
     ],
   });
 };
@@ -54,10 +79,13 @@ export const sendFileToSlack = async (imagePath: string, message: string) => {
   const fileName = imagePath.split('/').pop() || 'image';
   const imageBuffer = readFileSync(imagePath);
 
+  // Process message to ensure proper URL linking
+  const processedMessage = processMessageForLinks(message);
+
   const result = await getApp().client.filesUploadV2({
     channel_id: channelID,
     thread_ts: threadTs,
-    initial_comment: message,
+    initial_comment: processedMessage,
     filename: fileName,
     file: imageBuffer,
   });

--- a/packages/agent-core/src/lib/slack.ts
+++ b/packages/agent-core/src/lib/slack.ts
@@ -25,22 +25,31 @@ const getApp = () => {
   return app;
 };
 
-// URL detection regex pattern - matches http/https URLs
-const urlPattern = /https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
-
 /**
- * Processes message text to ensure URLs are properly formatted for Slack linking
- * Converts URLs to Slack's explicit link format <url>
+ * Processes message text to ensure URLs are properly linked in Slack messages
+ * Adds a space before http:// or https:// if it's not preceded by a whitespace or newline
  */
 const processMessageForLinks = (message: string): string => {
-  // Ensure URLs are wrapped in Slack's link syntax <url>
-  return message.replace(urlPattern, (url) => {
-    // Only wrap if not already wrapped
-    if (url.startsWith('<') && url.endsWith('>')) {
-      return url;
+  // Look for http:// or https://
+  const parts = message.split(/(https?:\/\/)/g);
+  let result = '';
+
+  for (let i = 0; i < parts.length; i++) {
+    // If this part is http:// or https://
+    if (parts[i] === 'http://' || parts[i] === 'https://') {
+      // If not at the beginning and previous character isn't whitespace or newline
+      if (i > 0 && result.length > 0) {
+        const lastChar = result[result.length - 1];
+        if (lastChar !== ' ' && lastChar !== '\n' && lastChar !== '\t') {
+          // Add space before the URL protocol
+          result += ' ';
+        }
+      }
     }
-    return `<${url}>`;
-  });
+    result += parts[i];
+  }
+
+  return result;
 };
 
 export const sendMessageToSlack = async (message: string, progress = false) => {


### PR DESCRIPTION
# Enhance URL detection and linking in Slack messages

## Changes
- Changed URL processing strategy to add spaces before URLs when needed
- Added function to automatically insert spaces before URLs that follow punctuation
- Applied this processing to both regular messages and file upload comments
- Changed message blocks from 'markdown' to 'section' with 'mrkdwn' type for better formatting

## Why
URLs in Slack messages are not being properly linked, especially when they appear directly after colons (e.g., '説明：https://example.com'). 

This change ensures that:
1. URLs are properly spaced from preceding punctuation
2. Slack's auto-linking can correctly identify URLs in the text
3. Links will be clickable even when they follow punctuation without spaces

The implementation detects URL protocol patterns ('http://' or 'https://') and adds a space before them if they are preceded by punctuation or other non-whitespace characters.