### PR TITLE
Add support for multiple AI agent rule formats

### DIFF
--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -156,7 +156,7 @@ Users will primarily request software engineering assistance including bug fixes
 
         // Find repository knowledge files
         const { content: knowledgeContent, found: foundKnowledgeFile } = findRepositoryKnowledge(repoDirectory);
-        
+
         if (foundKnowledgeFile) {
           systemPrompt = `${baseSystemPrompt}\n## Repository Knowledge\n${knowledgeContent}`;
         }

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -15,8 +15,8 @@ import {
 import pRetry, { AbortError } from 'p-retry';
 import { bedrockConverse } from '@remote-swe-agents/agent-core/lib';
 import { getMcpToolSpecs, tryExecuteMcpTool } from './mcp';
-import { join } from 'path';
-import { existsSync, readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import {
   ciTool,
   cloneRepositoryTool,
@@ -153,23 +153,109 @@ Users will primarily request software engineering assistance including bug fixes
       if (repo && repo.repoDirectory) {
         const repoDirectory = repo.repoDirectory as string;
 
-        // Check for knowledge files
-        const knowledgeFiles = ['AmazonQ.md', '.clinerules', 'CLAUDE.md', '.cursorrules'];
-        for (const fileName of knowledgeFiles) {
-          const filePath = join(repoDirectory, fileName);
-          if (existsSync(filePath)) {
-            // Read knowledge file content
-            const knowledgeContent = readFileSync(filePath, 'utf-8');
-            console.log(`Found knowledge file: ${fileName}`);
-            systemPrompt = `${baseSystemPrompt}\n## Repository Knowledge\n${knowledgeContent}`;
-            break;
+        // Define knowledge files and directories
+        const knowledgeFiles = [
+          // Original supported files
+          'AmazonQ.md',
+          '.clinerules', 
+          'CLAUDE.md', 
+          '.cursorrules',
+          // Additional AI agent rule formats
+          'agent-rules.md',
+          'agent-protocol.md',
+          '.anthropic',
+          'anthropic.md',
+          '.openai',
+          'openai.md',
+          'assistant-rules.md',
+          'agent.md',
+          'ai-rules.md',
+          'knowledge.md',
+          'prompt.md',
+          '.promptrc',
+          // Directories (ending with /)
+          '.knowledge/',
+          'docs/knowledge/',
+          '.agent/',
+          'agent/',
+          'ai/',
+          'docs/agent/',
+          'docs/ai/',
+        ];
+        
+        let knowledgeContent = '';
+        let foundKnowledgeFile = false;
+        
+        for (const item of knowledgeFiles) {
+          const itemPath = join(repoDirectory, item);
+          
+          // Check if path exists
+          if (existsSync(itemPath)) {
+            // If item ends with '/', it's a directory - process all .md files
+            if (item.endsWith('/')) {
+              const mdFiles = findMdFiles(itemPath);
+              if (mdFiles.length > 0) {
+                console.log(`Found knowledge directory: ${item} with ${mdFiles.length} markdown files`);
+                // Concatenate all found markdown files
+                for (const mdFile of mdFiles) {
+                  try {
+                    const content = readFileSync(mdFile, 'utf-8');
+                    knowledgeContent += `\n\n# ${mdFile.replace(repoDirectory, '')}\n${content}`;
+                    foundKnowledgeFile = true;
+                  } catch (error) {
+                    console.error(`Error reading markdown file ${mdFile}:`, error);
+                  }
+                }
+              }
+            } else {
+              // It's a regular file
+              try {
+                const content = readFileSync(itemPath, 'utf-8');
+                console.log(`Found knowledge file: ${item}`);
+                knowledgeContent = content;
+                foundKnowledgeFile = true;
+                break; // Stop at first found file if it's not a directory
+              } catch (error) {
+                console.error(`Error reading knowledge file ${item}:`, error);
+              }
+            }
           }
+        }
+        
+        if (foundKnowledgeFile) {
+          systemPrompt = `${baseSystemPrompt}\n## Repository Knowledge\n${knowledgeContent}`;
         }
       }
     } catch (error) {
       console.error('Error retrieving repository metadata or knowledge file:', error);
     }
   };
+  // Helper function to find markdown files recursively
+  function findMdFiles(dir: string): string[] {
+    const results: string[] = [];
+    
+    try {
+      const files = readdirSync(dir);
+      
+      for (const file of files) {
+        const filePath = join(dir, file);
+        const stat = statSync(filePath);
+        
+        if (stat.isDirectory()) {
+          // Recursive call for subdirectories
+          results.push(...findMdFiles(filePath));
+        } else if (file.toLowerCase().endsWith('.md')) {
+          // Add markdown files
+          results.push(filePath);
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading directory ${dir}:`, error);
+    }
+    
+    return results;
+  }
+  
   await tryAppendRepositoryKnowledge();
 
   const tools = [

--- a/packages/worker/src/agent/lib/knowledge.ts
+++ b/packages/worker/src/agent/lib/knowledge.ts
@@ -22,14 +22,14 @@ export const knowledgeFilePatterns = [
  */
 export function findMdFiles(dir: string): string[] {
   const results: string[] = [];
-  
+
   try {
     const files = readdirSync(dir);
-    
+
     for (const file of files) {
       const filePath = join(dir, file);
       const stat = statSync(filePath);
-      
+
       if (stat.isDirectory()) {
         // Recursive call for subdirectories
         results.push(...findMdFiles(filePath));
@@ -41,7 +41,7 @@ export function findMdFiles(dir: string): string[] {
   } catch (error) {
     console.error(`Error reading directory ${dir}:`, error);
   }
-  
+
   return results;
 }
 
@@ -50,13 +50,13 @@ export function findMdFiles(dir: string): string[] {
  * @param repoDirectory Repository directory path
  * @returns Object containing knowledge content and whether any files were found
  */
-export function findRepositoryKnowledge(repoDirectory: string): { content: string, found: boolean } {
+export function findRepositoryKnowledge(repoDirectory: string): { content: string; found: boolean } {
   let knowledgeContent = '';
   let foundKnowledgeFile = false;
-  
+
   for (const item of knowledgeFilePatterns) {
     const itemPath = join(repoDirectory, item);
-    
+
     // Check if path exists
     if (existsSync(itemPath)) {
       // If item ends with '/', it's a directory - process all .md files
@@ -89,9 +89,9 @@ export function findRepositoryKnowledge(repoDirectory: string): { content: strin
       }
     }
   }
-  
+
   return {
     content: knowledgeContent,
-    found: foundKnowledgeFile
+    found: foundKnowledgeFile,
   };
 }

--- a/packages/worker/src/agent/lib/knowledge.ts
+++ b/packages/worker/src/agent/lib/knowledge.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * List of knowledge file patterns to search for
+ */
+export const knowledgeFilePatterns = [
+  // Original supported files
+  '.cursorrules',
+  // Additional files
+  '.github/copilot-instructions.md',
+  'AGENT.md',
+  'AGENTS.md',
+  // Directories (ending with /)
+  '.cursor/rules/',
+];
+
+/**
+ * Finds all markdown files in a directory recursively
+ * @param dir Directory to search in
+ * @returns Array of full paths to markdown files
+ */
+export function findMdFiles(dir: string): string[] {
+  const results: string[] = [];
+  
+  try {
+    const files = readdirSync(dir);
+    
+    for (const file of files) {
+      const filePath = join(dir, file);
+      const stat = statSync(filePath);
+      
+      if (stat.isDirectory()) {
+        // Recursive call for subdirectories
+        results.push(...findMdFiles(filePath));
+      } else if (file.toLowerCase().endsWith('.md')) {
+        // Add markdown files
+        results.push(filePath);
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading directory ${dir}:`, error);
+  }
+  
+  return results;
+}
+
+/**
+ * Finds and reads knowledge files in a repository
+ * @param repoDirectory Repository directory path
+ * @returns Object containing knowledge content and whether any files were found
+ */
+export function findRepositoryKnowledge(repoDirectory: string): { content: string, found: boolean } {
+  let knowledgeContent = '';
+  let foundKnowledgeFile = false;
+  
+  for (const item of knowledgeFilePatterns) {
+    const itemPath = join(repoDirectory, item);
+    
+    // Check if path exists
+    if (existsSync(itemPath)) {
+      // If item ends with '/', it's a directory - process all .md files
+      if (item.endsWith('/')) {
+        const mdFiles = findMdFiles(itemPath);
+        if (mdFiles.length > 0) {
+          console.log(`Found knowledge directory: ${item} with ${mdFiles.length} markdown files`);
+          // Concatenate all found markdown files
+          for (const mdFile of mdFiles) {
+            try {
+              const content = readFileSync(mdFile, 'utf-8');
+              knowledgeContent += `\n\n# ${mdFile.replace(repoDirectory, '')}\n${content}`;
+              foundKnowledgeFile = true;
+            } catch (error) {
+              console.error(`Error reading markdown file ${mdFile}:`, error);
+            }
+          }
+        }
+      } else {
+        // It's a regular file
+        try {
+          const content = readFileSync(itemPath, 'utf-8');
+          console.log(`Found knowledge file: ${item}`);
+          knowledgeContent = content;
+          foundKnowledgeFile = true;
+          break; // Stop at first found file if it's not a directory
+        } catch (error) {
+          console.error(`Error reading knowledge file ${item}:`, error);
+        }
+      }
+    }
+  }
+  
+  return {
+    content: knowledgeContent,
+    found: foundKnowledgeFile
+  };
+}

--- a/packages/worker/src/agent/lib/knowledge.ts
+++ b/packages/worker/src/agent/lib/knowledge.ts
@@ -6,6 +6,9 @@ import { join } from 'path';
  */
 export const knowledgeFilePatterns = [
   // Original supported files
+  'AmazonQ.md',
+  '.clinerules',
+  'CLAUDE.md',
   '.cursorrules',
   // Additional files
   '.github/copilot-instructions.md',


### PR DESCRIPTION
## Overview
This PR extends the knowledge file handling functionality to support multiple AI agent rule formats, inspired by the observation that there are now multiple competing standards for AI agent rules.

Reference: [Tweet by Aiden Bai](https://x.com/aidenybai/status/1923781810820968857) highlighting that 'there are now 9 competing standards for AI agent rules'

## Changes
1. Added support for more knowledge file formats:
   - Original formats: '.cursorrules'
   - Additional formats: '.github/copilot-instructions.md', 'AGENT.md', 'AGENTS.md', '.cursor/rules/' directory

2. Added directory support:
   - Paths ending with '/' are treated as directories
   - All '.md' files in these directories are recursively searched
   - Content from all found files is concatenated

3. Code improvements:
   - Extracted knowledge file handling to a separate module ('worker/src/agent/lib/knowledge.ts')
   - Improved error handling for file reading operations
   - Added proper documentation for functions

## Testing
- Test with repositories containing various supported file formats
- Verify both single file and directory-based knowledge files are properly loaded