### PR TITLE
fix playwright mcp fails to run

### DIFF
--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -196,6 +196,10 @@ chown -R ubuntu:ubuntu /opt/myapp
 # Install Playwright dependencies
 sudo -u ubuntu bash -i -c "npx playwright install-deps"
 sudo -u ubuntu bash -i -c "npx playwright install chromium"
+# Disable Ubuntu security feature to get chromium working
+# https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+echo 0 | tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+echo kernel.apparmor_restrict_unprivileged_userns=0 | tee /etc/sysctl.d/60-apparmor-namespace.conf
 
 # Configure GitHub CLI
 sudo -u ubuntu bash -c "gh config set prompt disabled"

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2422,6 +2422,14 @@ phases:
 
               sudo -u ubuntu bash -i -c \\"npx playwright install chromium\\"
 
+              # Disable Ubuntu security feature to get chromium working
+
+              # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+
+              echo 0 | tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+              echo kernel.apparmor_restrict_unprivileged_userns=0 | tee /etc/sysctl.d/60-apparmor-namespace.conf
+
 
               # Configure GitHub CLI
 
@@ -3115,6 +3123,14 @@ phases:
 
               sudo -u ubuntu bash -i -c \\"npx playwright install chromium\\"
 
+              # Disable Ubuntu security feature to get chromium working
+
+              # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+
+              echo 0 | tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+              echo kernel.apparmor_restrict_unprivileged_userns=0 | tee /etc/sysctl.d/60-apparmor-namespace.conf
+
 
               # Configure GitHub CLI
 
@@ -3616,6 +3632,10 @@ chown -R ubuntu:ubuntu /opt/myapp
 # Install Playwright dependencies
 sudo -u ubuntu bash -i -c "npx playwright install-deps"
 sudo -u ubuntu bash -i -c "npx playwright install chromium"
+# Disable Ubuntu security feature to get chromium working
+# https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+echo 0 | tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+echo kernel.apparmor_restrict_unprivileged_userns=0 | tee /etc/sysctl.d/60-apparmor-namespace.conf
 
 # Configure GitHub CLI
 sudo -u ubuntu bash -c "gh config set prompt disabled"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9053,9 +9053,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -10332,13 +10332,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -10512,18 +10512,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"


### PR DESCRIPTION
*Issue #, if available:*
closes #84

also updating some dependencies with npm audit fix.


*Description of changes:*

We chose the first approach described in the doc. https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
