### PR TITLE
feat: add longRunningProcess option to executeCommand tool

### DIFF
--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -8,16 +8,17 @@ import { ToolDefinition, truncate, zodToJsonSchemaBody } from '../../private/com
 const inputSchema = z.object({
   command: z.string().describe('The command to execute.'),
   cwd: z.string().optional().describe('The current working directory to execute the command in.'),
+  longRunningProcess: z.boolean().optional().describe('If true, do not wait for the process to exit; leave the process running and return control after 10 seconds.'),
 });
 
 export const DefaultWorkingDirectory = join(homedir(), `.remote-swe-workspace`);
 spawn('mkdir', ['-p', DefaultWorkingDirectory]);
 
-export const executeCommand = async (command: string, cwd?: string, timeout = 60000) => {
+export const executeCommand = async (command: string, cwd?: string, timeout = 60000, longRunningProcess = false) => {
   const token = await authorizeGitHubCli();
   cwd = cwd ?? DefaultWorkingDirectory;
 
-  return new Promise<{ stdout: string; stderr: string; error?: string; exitCode?: number }>((resolve) => {
+  return new Promise<{ stdout: string; stderr: string; error?: string; exitCode?: number; isLongRunning?: boolean }>((resolve) => {
     console.log(`Executing command: ${command} in ${cwd}`);
     const childProcess = spawn(command, [], {
       cwd,
@@ -31,23 +32,44 @@ export const executeCommand = async (command: string, cwd?: string, timeout = 60
     let stdout = '';
     let stderr = '';
     let timer: NodeJS.Timeout;
+    let longRunningTimer: NodeJS.Timeout | undefined;
+    let hasExited = false;
 
     const resetTimer = () => {
       clearTimeout(timer);
       timer = setTimeout(() => {
-        childProcess.kill();
-        resolve({
-          error: `Command execution timed out after ${Math.round(timeout / 1000)} seconds of inactivity`,
-          stdout: truncate(stdout, 40e3),
-          stderr: truncate(stderr),
-        });
+        // Only kill the process if it's not a long-running one
+        if (!longRunningProcess) {
+          childProcess.kill();
+          resolve({
+            error: `Command execution timed out after ${Math.round(timeout / 1000)} seconds of inactivity`,
+            stdout: truncate(stdout, 40e3),
+            stderr: truncate(stderr),
+          });
+        }
       }, timeout);
     };
 
     resetTimer();
 
+    // For long-running processes, we wait for 10 seconds and then return control to the agent
+    if (longRunningProcess) {
+      longRunningTimer = setTimeout(() => {
+        if (!hasExited) {
+          console.log(`Returning control to agent after 10 seconds for long-running process: ${command}`);
+          resolve({
+            stdout: truncate(stdout, 40e3),
+            stderr: truncate(stderr),
+            isLongRunning: true,
+          });
+        }
+      }, 10000); // 10 seconds
+    }
+
     childProcess.on('error', (error) => {
       clearTimeout(timer);
+      if (longRunningTimer) clearTimeout(longRunningTimer);
+      hasExited = true;
       resolve({
         error: `Failed to interact with the process: ${error.message}`,
         stdout: truncate(stdout, 40e3),
@@ -67,6 +89,11 @@ export const executeCommand = async (command: string, cwd?: string, timeout = 60
 
     childProcess.on('close', (code) => {
       clearTimeout(timer);
+      if (longRunningTimer) clearTimeout(longRunningTimer);
+      hasExited = true;
+      
+      // If the process exits within the 10 seconds window for long-running processes,
+      // we should report that instead of leaving it running
       if (code === 0) {
         resolve({
           stdout: truncate(stdout, 40e3),
@@ -84,8 +111,8 @@ export const executeCommand = async (command: string, cwd?: string, timeout = 60
   });
 };
 
-const handler = async (input: { command: string; cwd?: string }) => {
-  const res = await executeCommand(input.command, input.cwd);
+const handler = async (input: { command: string; cwd?: string; longRunningProcess?: boolean }) => {
+  const res = await executeCommand(input.command, input.cwd, 60000, input.longRunningProcess);
   return JSON.stringify(res, undefined, 1);
 };
 
@@ -98,6 +125,8 @@ export const commandExecutionTool: ToolDefinition<z.infer<typeof inputSchema>> =
   toolSpec: async () => ({
     name,
     description: `Execute any shell command. If you need to run a command in a specific directory, set \`cwd\` argument (optional).
+
+If you need to run a daemon or long-running process like \`npm run dev\` or \`docker compose up\`, set \`longRunningProcess: true\`. This will start the process, wait for 10 seconds to allow it to initialize, and return control to you while keeping the process running in the background.
 
 IMPORTANT: When your command contains special characters (like backticks, quotes, dollar signs), they need to be properly escaped to prevent shell interpretation. Common approaches:
 1. Use single quotes to prevent variable expansion and most interpretations: 'text with $HOME and \`backticks\`'


### PR DESCRIPTION
# Support for long-running processes in executeCommand tool

## Description
This PR addresses [Issue #21](https://github.com/aws-samples/remote-swe-agents/issues/21) by adding support for daemon-like processes (e.g., `npm run dev` or `docker compose up`) in the executeCommand tool.

## Changes
- Added a new property `longRunningProcess: boolean` to the existing `executeCommand` tool
- When `longRunningProcess: true`, the tool does not wait for the process to exit; instead, it leaves the process running in the background
- The tool waits for 10 seconds before returning control to allow for process initialization
- Any output generated during those 10 seconds is captured and returned to the agent
- If the process fails within the 10-second initialization period, an error is returned

## Tests
- Built successfully with `npm run build`

## Additional Notes
- This enables the agent to start development servers and other daemon processes that would otherwise time out
- Users need to explicitly set `longRunningProcess: true` to activate this behavior