### PR TITLE
fix: improve empty account handling in BEDROCK_AWS_ACCOUNTS

### DIFF
--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -11,7 +11,7 @@ import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
 
 const sts = new STSClient();
-const awsAccounts = (process.env.BEDROCK_AWS_ACCOUNTS ?? '').split(',');
+const awsAccounts = (process.env.BEDROCK_AWS_ACCOUNTS ?? '').split(',').filter((account) => account.trim() !== '');
 const roleName = process.env.BEDROCK_AWS_ROLE_NAME || 'bedrock-remote-swe-role';
 
 // State management for persistent account selection and retry


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Filter out empty strings when parsing `BEDROCK_AWS_ACCOUNTS` environment variable.

*Problem*

`''.split(',')` creates `['']` instead of `[]`, causing the array to contain an invalid empty account ID.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
