### PR TITLE
Store and display initial message in sessions

### DIFF
--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -222,7 +222,7 @@ app.event('app_mention', async ({ event, client, logger }) => {
 
       // スレッドの開始時のみ、メッセージを送信し、セッション情報を保存する
       if (event.thread_ts === undefined) {
-        promises.push(saveSessionInfo(workerId));
+        promises.push(saveSessionInfo(workerId, message));
       }
 
       await Promise.all([

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -19,6 +19,7 @@ type SessionItem = {
   workerId: string;
   createdAt: number;
   LSI1: string;
+  initialMessage?: string;
 };
 
 export const saveConversationHistory = async (
@@ -99,7 +100,7 @@ export const getTokenUsage = async (workerId: string) => {
   return res.Items ?? [];
 };
 
-export const saveSessionInfo = async (workerId: string) => {
+export const saveSessionInfo = async (workerId: string, initialMessage?: string) => {
   const now = Date.now();
   const timestamp = String(now).padStart(15, '0');
 
@@ -112,6 +113,7 @@ export const saveSessionInfo = async (workerId: string) => {
         workerId,
         createdAt: now,
         LSI1: timestamp,
+        initialMessage,
       } satisfies SessionItem,
     })
   );

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -19,7 +19,7 @@ type SessionItem = {
   workerId: string;
   createdAt: number;
   LSI1: string;
-  initialMessage?: string;
+  initialMessage: string;
 };
 
 export const saveConversationHistory = async (
@@ -100,7 +100,7 @@ export const getTokenUsage = async (workerId: string) => {
   return res.Items ?? [];
 };
 
-export const saveSessionInfo = async (workerId: string, initialMessage?: string) => {
+export const saveSessionInfo = async (workerId: string, initialMessage: string) => {
   const now = Date.now();
   const timestamp = String(now).padStart(15, '0');
 

--- a/packages/webapp/src/app/(root)/actions.ts
+++ b/packages/webapp/src/app/(root)/actions.ts
@@ -22,7 +22,7 @@ export const getSessions = authActionClient.schema(z.object({})).action(async ({
     workerId: item.workerId,
     createdAt: item.createdAt,
     title: `セッション ${item.workerId}`, // TODO: 最初のメッセージから生成
-    lastMessage: '対話を開始してください',
+    lastMessage: item.initialMessage || '対話を開始してください',
     updatedAt: new Date(item.createdAt).toISOString(),
   }));
 


### PR DESCRIPTION
closes #97.

## Changes
1. Store initial message when creating a session item in  function
2. Updated  to return the initial message in the web app
3. Modified SessionItem type to include initialMessage field

## Testing
- Verified that webapp can show initial message instead of last message in session list