### PR TITLE
Add EC2 instance status tracking and display

### DIFF
--- a/packages/agent-core/src/lib/worker-manager.ts
+++ b/packages/agent-core/src/lib/worker-manager.ts
@@ -29,13 +29,13 @@ export async function updateInstanceStatus(workerId: string, status: 'starting' 
         },
       })
     );
-    
+
     // Send event to webapp
     await sendWebappEvent(workerId, {
       type: 'instanceStatusChanged',
       status,
     });
-    
+
     console.log(`Instance status updated to ${status}`);
   } catch (error) {
     console.error(`Error updating instance status for workerId ${workerId}:`, error);
@@ -172,8 +172,6 @@ async function createWorkerInstance(
     throw error;
   }
 }
-
-
 
 export async function getOrCreateWorkerInstance(
   workerId: string,

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -20,11 +20,7 @@ export const webappEventSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('instanceStatusChanged'),
-    status: z.union([
-      z.literal('starting'),
-      z.literal('running'),
-      z.literal('sleeping')
-    ]),
+    status: z.union([z.literal('starting'), z.literal('running'), z.literal('sleeping')]),
     timestamp: z.number(),
   }),
 ]);

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -18,4 +18,13 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     toolName: z.string(),
     timestamp: z.number(),
   }),
+  z.object({
+    type: z.literal('instanceStatusChanged'),
+    status: z.union([
+      z.literal('starting'),
+      z.literal('running'),
+      z.literal('sleeping')
+    ]),
+    timestamp: z.number(),
+  }),
 ]);

--- a/packages/webapp/src/app/(root)/actions.ts
+++ b/packages/webapp/src/app/(root)/actions.ts
@@ -24,6 +24,7 @@ export const getSessions = authActionClient.schema(z.object({})).action(async ({
     title: `セッション ${item.workerId}`, // TODO: 最初のメッセージから生成
     lastMessage: '対話を開始してください',
     updatedAt: new Date(item.createdAt).toISOString(),
+    instanceStatus: item.instanceStatus || 'terminated',
   }));
 
   return { sessions };

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -18,15 +18,18 @@ export type Message = {
 type MessageListProps = {
   messages: Message[];
   isAgentTyping: boolean;
+  instanceStatus?: 'starting' | 'running' | 'sleeping';
 };
 
-export default function MessageList({ messages, isAgentTyping }: MessageListProps) {
+export default function MessageList({ messages, isAgentTyping, instanceStatus }: MessageListProps) {
   const { theme } = useTheme();
 
-  // Check if there are any assistant messages and the last message was within 10 minutes
+  // Show waiting message when instance is starting or 
+  // when we don't have status info but there are no assistant messages yet
   const showWaitingMessage =
-    !messages.some((msg) => msg.role === 'assistant') &&
-    new Date(messages.at(-1)?.timestamp ?? new Date()).getTime() - Date.now() < 10 * 60 * 1000;
+    instanceStatus === 'starting' || 
+    (!instanceStatus && !messages.some((msg) => msg.role === 'assistant') &&
+    new Date(messages.at(-1)?.timestamp ?? new Date()).getTime() - Date.now() < 10 * 60 * 1000);
   const MarkdownRenderer = ({ content }: { content: string }) => (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -24,12 +24,13 @@ type MessageListProps = {
 export default function MessageList({ messages, isAgentTyping, instanceStatus }: MessageListProps) {
   const { theme } = useTheme();
 
-  // Show waiting message when instance is starting or 
+  // Show waiting message when instance is starting or
   // when we don't have status info but there are no assistant messages yet
   const showWaitingMessage =
-    instanceStatus === 'starting' || 
-    (!instanceStatus && !messages.some((msg) => msg.role === 'assistant') &&
-    new Date(messages.at(-1)?.timestamp ?? new Date()).getTime() - Date.now() < 10 * 60 * 1000);
+    instanceStatus === 'starting' ||
+    (!instanceStatus &&
+      !messages.some((msg) => msg.role === 'assistant') &&
+      new Date(messages.at(-1)?.timestamp ?? new Date()).getTime() - Date.now() < 10 * 60 * 1000);
   const MarkdownRenderer = ({ content }: { content: string }) => (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -103,18 +103,20 @@ export default function SessionPageClient({ workerId, initialMessages }: Session
                 <p className="text-sm text-gray-600 dark:text-gray-300">Chat with AI Agent</p>
                 {instanceStatus && (
                   <div className="flex items-center gap-2 ml-4">
-                    <span className={`inline-block w-2 h-2 rounded-full ${
-                      instanceStatus === 'running' 
-                        ? 'bg-green-500' 
-                        : instanceStatus === 'starting' 
-                          ? 'bg-yellow-500' 
-                          : 'bg-blue-500'
-                    }`} />
+                    <span
+                      className={`inline-block w-2 h-2 rounded-full ${
+                        instanceStatus === 'running'
+                          ? 'bg-green-500'
+                          : instanceStatus === 'starting'
+                            ? 'bg-yellow-500'
+                            : 'bg-blue-500'
+                      }`}
+                    />
                     <span className="text-sm font-medium">
-                      {instanceStatus === 'running' 
-                        ? 'Instance running' 
-                        : instanceStatus === 'starting' 
-                          ? 'Instance starting' 
+                      {instanceStatus === 'running'
+                        ? 'Instance running'
+                        : instanceStatus === 'starting'
+                          ? 'Instance starting'
                           : 'Instance sleeping'}
                     </span>
                   </div>

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -17,6 +17,7 @@ interface SessionPageClientProps {
 export default function SessionPageClient({ workerId, initialMessages }: SessionPageClientProps) {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [isAgentTyping, setIsAgentTyping] = useState(false);
+  const [instanceStatus, setInstanceStatus] = useState<'starting' | 'running' | 'sleeping' | undefined>(undefined);
 
   // Real-time communication via event bus
   useEventBus({
@@ -40,6 +41,10 @@ export default function SessionPageClient({ workerId, initialMessages }: Session
             ]);
           }
           setIsAgentTyping(false);
+          break;
+        case 'instanceStatusChanged':
+          console.log('Instance status changed:', event.status);
+          setInstanceStatus(event.status);
           break;
         case 'toolResult':
           break;
@@ -94,12 +99,32 @@ export default function SessionPageClient({ workerId, initialMessages }: Session
             </Link>
             <div className="flex-1">
               <h1 className="text-lg font-semibold text-gray-900 dark:text-white">Session: {workerId}</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-300">Chat with AI Agent</p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm text-gray-600 dark:text-gray-300">Chat with AI Agent</p>
+                {instanceStatus && (
+                  <div className="flex items-center gap-2 ml-4">
+                    <span className={`inline-block w-2 h-2 rounded-full ${
+                      instanceStatus === 'running' 
+                        ? 'bg-green-500' 
+                        : instanceStatus === 'starting' 
+                          ? 'bg-yellow-500' 
+                          : 'bg-blue-500'
+                    }`} />
+                    <span className="text-sm font-medium">
+                      {instanceStatus === 'running' 
+                        ? 'Instance running' 
+                        : instanceStatus === 'starting' 
+                          ? 'Instance starting' 
+                          : 'Instance sleeping'}
+                    </span>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
 
-        <MessageList messages={messages} isAgentTyping={isAgentTyping} />
+        <MessageList messages={messages} isAgentTyping={isAgentTyping} instanceStatus={instanceStatus} />
 
         <MessageForm onSubmit={onSendMessage} workerId={workerId} />
       </main>

--- a/packages/webapp/src/app/sessions/new/actions.ts
+++ b/packages/webapp/src/app/sessions/new/actions.ts
@@ -30,6 +30,7 @@ export const createNewWorker = authActionClient.schema(createNewWorkerSchema).ac
               initialMessage: message,
               createdAt: now,
               LSI1: String(now).padStart(15, '0'),
+              instanceStatus: 'starting',
             },
           },
         },

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -46,22 +46,24 @@ export default async function SessionsPage() {
                         </div>
                         {session.instanceStatus && (
                           <div className="flex items-center gap-2">
-                            <span className={`inline-block w-2 h-2 rounded-full ${
-                              session.instanceStatus === 'running' 
-                                ? 'bg-green-500' 
-                                : session.instanceStatus === 'starting' 
-                                  ? 'bg-yellow-500' 
-                                  : session.instanceStatus === 'sleeping' 
-                                    ? 'bg-blue-500' 
-                                    : 'bg-gray-500'
-                            }`} />
+                            <span
+                              className={`inline-block w-2 h-2 rounded-full ${
+                                session.instanceStatus === 'running'
+                                  ? 'bg-green-500'
+                                  : session.instanceStatus === 'starting'
+                                    ? 'bg-yellow-500'
+                                    : session.instanceStatus === 'sleeping'
+                                      ? 'bg-blue-500'
+                                      : 'bg-gray-500'
+                              }`}
+                            />
                             <span>
-                              {session.instanceStatus === 'running' 
-                                ? 'Running' 
-                                : session.instanceStatus === 'starting' 
-                                  ? 'Starting' 
-                                  : session.instanceStatus === 'sleeping' 
-                                    ? 'Sleeping' 
+                              {session.instanceStatus === 'running'
+                                ? 'Running'
+                                : session.instanceStatus === 'starting'
+                                  ? 'Starting'
+                                  : session.instanceStatus === 'sleeping'
+                                    ? 'Sleeping'
                                     : 'Terminated'}
                             </span>
                           </div>

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -39,9 +39,33 @@ export default async function SessionsPage() {
                         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{session.title}</h3>
                       </div>
                       <p className="text-gray-600 dark:text-gray-300 mb-3">{session.lastMessage}</p>
-                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                        <Clock className="w-4 h-4" />
-                        {new Date(session.updatedAt).toLocaleString('en-US')}
+                      <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+                        <div className="flex items-center gap-2">
+                          <Clock className="w-4 h-4" />
+                          {new Date(session.updatedAt).toLocaleString('en-US')}
+                        </div>
+                        {session.instanceStatus && (
+                          <div className="flex items-center gap-2">
+                            <span className={`inline-block w-2 h-2 rounded-full ${
+                              session.instanceStatus === 'running' 
+                                ? 'bg-green-500' 
+                                : session.instanceStatus === 'starting' 
+                                  ? 'bg-yellow-500' 
+                                  : session.instanceStatus === 'sleeping' 
+                                    ? 'bg-blue-500' 
+                                    : 'bg-gray-500'
+                            }`} />
+                            <span>
+                              {session.instanceStatus === 'running' 
+                                ? 'Running' 
+                                : session.instanceStatus === 'starting' 
+                                  ? 'Starting' 
+                                  : session.instanceStatus === 'sleeping' 
+                                    ? 'Sleeping' 
+                                    : 'Terminated'}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/packages/webapp/src/app/sign-in/page.tsx
+++ b/packages/webapp/src/app/sign-in/page.tsx
@@ -16,7 +16,7 @@ export default function SignInPage() {
             <p className="mb-6 text-center text-sm text-gray-600 dark:text-gray-300">
               Please sign in with your Cognito account to continue
             </p>
-            
+
             {/* use a instead of Link because Link uses fetch to navigate  */}
             <a
               href="/api/auth/sign-in?lang=ja"

--- a/packages/webapp/src/app/sign-in/page.tsx
+++ b/packages/webapp/src/app/sign-in/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function SignInPage() {
   return (

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -5,8 +5,10 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import './common/signal-handler';
 import { setKillTimer, pauseKillTimer, restartKillTimer } from './common/kill-timer';
 import { CancellationToken } from './common/cancellation-token';
-import { sendMessageToSlack, sendSystemMessage } from '@remote-swe-agents/agent-core/lib';
+import { sendMessageToSlack, sendSystemMessage, sendWebappEvent } from '@remote-swe-agents/agent-core/lib';
 import { WorkerId } from '@remote-swe-agents/agent-core/env';
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
 
 Object.assign(global, { WebSocket: require('ws') });
 
@@ -93,6 +95,38 @@ class ConverseSessionTracker {
   }
 }
 
+/**
+ * Updates the instance status in DynamoDB and sends a webapp event
+ */
+async function updateInstanceStatus(workerId: string, status: 'running' | 'starting' | 'sleeping') {
+  try {
+    // Update instanceStatus in DynamoDB
+    await ddb.send(
+      new UpdateCommand({
+        TableName,
+        Key: {
+          PK: 'sessions',
+          SK: workerId,
+        },
+        UpdateExpression: 'SET instanceStatus = :status',
+        ExpressionAttributeValues: {
+          ':status': status,
+        },
+      })
+    );
+
+    // Send event to webapp
+    await sendWebappEvent(workerId, {
+      type: 'instanceStatusChanged',
+      status,
+    });
+
+    console.log(`Instance status updated to ${status}`);
+  } catch (error) {
+    console.error(`Error updating instance status for workerId ${workerId}:`, error);
+  }
+}
+
 const main = async () => {
   const tracker = new ConverseSessionTracker(workerId);
   const broadcast = await events.connect('/event-bus/broadcast');
@@ -118,6 +152,9 @@ const main = async () => {
   setKillTimer();
 
   try {
+    // Update instance status to "running" in DynamoDB
+    await updateInstanceStatus(workerId, 'running');
+
     await sendSystemMessage(workerId, 'the instance has successfully launched!');
     tracker.startResume();
   } catch (e) {

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -93,8 +93,6 @@ class ConverseSessionTracker {
   }
 }
 
-
-
 const main = async () => {
   const tracker = new ConverseSessionTracker(workerId);
   const broadcast = await events.connect('/event-bus/broadcast');


### PR DESCRIPTION
This PR implements the EC2 instance status tracking and display feature as requested in issue #95.

## Changes
- Add instanceStatus field to DynamoDB session records
- Add instanceStatusChanged event type to webapp event schema
- Update worker-manager to track and update instance status
- Add UI components to display instance status
- Update SessionPageClient to handle instanceStatus changes
- Send instanceStatus updates from EC2 instances via UserData script

Fixes #95