### PR TITLE
feat: store total cost of a session

### DIFF
--- a/packages/agent-core/src/lib/cost/index.ts
+++ b/packages/agent-core/src/lib/cost/index.ts
@@ -1,0 +1,23 @@
+const modelPricing = {
+  '3-7-sonnet': { input: 0.003, output: 0.015, cacheRead: 0.0003, cacheWrite: 0.00375 },
+  '3-5-sonnet': { input: 0.003, output: 0.015, cacheRead: 0.0003, cacheWrite: 0.00375 },
+  '3-5-haiku': { input: 0.0008, output: 0.004, cacheRead: 0.00008, cacheWrite: 0.001 },
+};
+
+export const calculateCost = (
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens: number,
+  cacheWriteTokens: number
+) => {
+  const pricing = Object.entries(modelPricing).find(([key]) => modelId.includes(key))?.[1];
+  if (pricing == null) return 0;
+  return (
+    (inputTokens * pricing.input +
+      outputTokens * pricing.output +
+      cacheReadTokens * pricing.cacheRead +
+      cacheWriteTokens * pricing.cacheWrite) /
+    1000
+  );
+};

--- a/packages/agent-core/src/lib/index.ts
+++ b/packages/agent-core/src/lib/index.ts
@@ -5,3 +5,4 @@ export * from './metadata';
 export * from './converse';
 export * from './worker-manager';
 export * from './events';
+export * from './cost';

--- a/packages/slack-bolt-app/src/util/cost.ts
+++ b/packages/slack-bolt-app/src/util/cost.ts
@@ -1,23 +1,5 @@
-const modelPricing = {
-  '3-7-sonnet': { input: 0.003, output: 0.015, cacheRead: 0.0003, cacheWrite: 0.00375 },
-  '3-5-sonnet': { input: 0.003, output: 0.015, cacheRead: 0.0003, cacheWrite: 0.00375 },
-  '3-5-haiku': { input: 0.0008, output: 0.004, cacheRead: 0.00008, cacheWrite: 0.001 },
-};
+// Import from agent-core to ensure we use the same cost calculation logic
+import { calculateCost } from '@remote-swe-agents/agent-core/lib';
 
-export const calculateCost = (
-  modelId: string,
-  inputTokens: number,
-  outputTokens: number,
-  cacheReadTokens: number,
-  cacheWriteTokens: number
-) => {
-  const pricing = Object.entries(modelPricing).find(([key]) => modelId.includes(key))?.[1];
-  if (pricing == null) return 0;
-  return (
-    (inputTokens * pricing.input +
-      outputTokens * pricing.output +
-      cacheReadTokens * pricing.cacheRead +
-      cacheWriteTokens * pricing.cacheWrite) /
-    1000
-  );
-};
+// Re-export for backwards compatibility
+export { calculateCost };

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -14,6 +14,7 @@ import {
   readMetadata,
   renderToolResult,
   sendSystemMessage,
+  updateSessionCost,
 } from '@remote-swe-agents/agent-core/lib';
 import pRetry, { AbortError } from 'p-retry';
 import { bedrockConverse } from '@remote-swe-agents/agent-core/lib';
@@ -255,6 +256,12 @@ Users will primarily request software engineering assistance including bug fixes
 
     console.log(JSON.stringify(res.usage));
     const outputTokenCount = res.usage?.outputTokens ?? 0;
+    const inputTokenCount = res.usage?.inputTokens ?? 0;
+    const cacheReadTokenCount = res.usage?.cacheReadInputTokens ?? 0;
+    const cacheWriteTokenCount = res.usage?.cacheWriteInputTokens ?? 0;
+    
+    // Update session cost in DynamoDB
+    await updateSessionCost(workerId, 'sonnet3.7', inputTokenCount, outputTokenCount, cacheReadTokenCount, cacheWriteTokenCount);
 
     if (res.stopReason == 'tool_use') {
       if (res.output?.message == null) {


### PR DESCRIPTION
## 概要
Issue #110 に対する実装。セッションごとの消費コスト（USD）をDynamoDBのセッションアイテムに保存する機能を追加。

## 変更内容
1. コスト計算関数を  に移動
2.  関数を  に追加
3. エージェントターン終了時にコスト更新関数を呼び出すように  を修正
4.  を更新して共通ライブラリからインポートするように変更

close #110