### PR TITLE
feat: show total cost of each session

### DIFF
--- a/packages/webapp/src/app/(root)/actions.ts
+++ b/packages/webapp/src/app/(root)/actions.ts
@@ -25,6 +25,7 @@ export const getSessions = authActionClient.schema(z.object({})).action(async ({
     lastMessage: item.initialMessage || '対話を開始してください',
     updatedAt: new Date(item.createdAt).toISOString(),
     instanceStatus: item.instanceStatus || 'terminated',
+    sessionCost: item.sessionCost, // 各セッションのコスト情報を追加
   }));
 
   return { sessions };

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -6,9 +6,6 @@ import { Plus, MessageSquare, Clock, DollarSign } from 'lucide-react';
 import { getSessions } from '@/app/(root)/actions';
 
 export default async function SessionsPage() {
-  const { userId } = await getSession();
-
-  // セッション一覧を取得
   const result = await getSessions({});
   const sessions = result?.data?.sessions || [];
 
@@ -44,40 +41,32 @@ export default async function SessionsPage() {
                           <Clock className="w-4 h-4" />
                           {new Date(session.updatedAt).toLocaleString('en-US')}
                         </div>
-                        {session.instanceStatus && (
-                          <div className="flex items-center gap-2">
-                            <span
-                              className={`inline-block w-2 h-2 rounded-full ${
-                                session.instanceStatus === 'running'
-                                  ? 'bg-green-500'
-                                  : session.instanceStatus === 'starting'
-                                    ? 'bg-yellow-500'
-                                    : session.instanceStatus === 'stopped'
-                                      ? 'bg-blue-500'
-                                      : 'bg-gray-500'
-                              }`}
-                            />
-                            <span>
-                              {session.instanceStatus === 'running'
-                                ? 'Running'
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-block w-2 h-2 rounded-full ${
+                              session.instanceStatus === 'running'
+                                ? 'bg-green-500'
                                 : session.instanceStatus === 'starting'
-                                  ? 'Starting'
+                                  ? 'bg-yellow-500'
                                   : session.instanceStatus === 'stopped'
-                                    ? 'Stopped'
-                                    : 'Terminated'}
-                            </span>
-                          </div>
-                        )}
-                        {session.sessionCost !== undefined && (
-                          <div className="flex items-center gap-2">
-                            <DollarSign className="w-4 h-4" />
-                            <span>
-                              {typeof session.sessionCost === 'number'
-                                ? `${session.sessionCost.toFixed(2)}`
-                                : `${Number(session.sessionCost).toFixed(2)}`}
-                            </span>
-                          </div>
-                        )}
+                                    ? 'bg-blue-500'
+                                    : 'bg-gray-500'
+                            }`}
+                          />
+                          <span>
+                            {session.instanceStatus === 'running'
+                              ? 'Running'
+                              : session.instanceStatus === 'starting'
+                                ? 'Starting'
+                                : session.instanceStatus === 'stopped'
+                                  ? 'Stopped'
+                                  : 'Terminated'}
+                          </span>
+                        </div>
+                        <div className="flex items-center">
+                           <DollarSign className="w-4 h-4" />
+                          <span>{(session.sessionCost ?? 0).toFixed(2)}</span>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -2,7 +2,7 @@ import { getSession } from '@/lib/auth';
 import Header from '@/components/Header';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Plus, MessageSquare, Clock } from 'lucide-react';
+import { Plus, MessageSquare, Clock, DollarSign } from 'lucide-react';
 import { getSessions } from '@/app/(root)/actions';
 
 export default async function SessionsPage() {
@@ -65,6 +65,16 @@ export default async function SessionsPage() {
                                   : session.instanceStatus === 'stopped'
                                     ? 'Stopped'
                                     : 'Terminated'}
+                            </span>
+                          </div>
+                        )}
+                        {session.sessionCost !== undefined && (
+                          <div className="flex items-center gap-2">
+                            <DollarSign className="w-4 h-4" />
+                            <span>
+                              {typeof session.sessionCost === 'number'
+                                ? `${session.sessionCost.toFixed(2)}`
+                                : `${Number(session.sessionCost).toFixed(2)}`}
                             </span>
                           </div>
                         )}

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -64,7 +64,7 @@ export default async function SessionsPage() {
                           </span>
                         </div>
                         <div className="flex items-center">
-                           <DollarSign className="w-4 h-4" />
+                          <DollarSign className="w-4 h-4" />
                           <span>{(session.sessionCost ?? 0).toFixed(2)}</span>
                         </div>
                       </div>


### PR DESCRIPTION
Resolves #112

## What changed?
- Added display of session cost in USD to each session card in the sessions list
- Added DollarSign icon from lucide-react
- Cost values are formatted to show 2 decimal places with dollar sign prefix

## Note
This PR assumes that session.sessionCost field is available from DynamoDB as mentioned in the issue.

![image](https://github.com/user-attachments/assets/c2f9657f-96ed-4068-9a07-c43abab4fdf4)
