### PR TITLE
docs: add --all option to deploy section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Then you can run cdk deploy. Note that the above parameter names are referenced 
 ```bash
 cd cdk && npm ci
 npx cdk bootstrap
-npx cdk deploy
+npx cdk deploy --all
 ```
 
 Deployment usually takes about 5 minutes. After the deployment, you should see the endpoint of your Slack Bolt app. Make note of the `SlackBoltEndpointUrl` from the CDK output as you'll need it in the next step.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Add  --all option to deploy section in README.md. Currently, this application deploy to us-east-1 region and user region. AWS CDK require --all options when deploy to multiple regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
