### PR TITLE
Fix: Slack message parsing when mention is not at beginning

### DIFF
--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -34,7 +34,8 @@ const app = new App({
 app.event('app_mention', async ({ event, client, logger }) => {
   console.log('app_mention event received');
   console.log(JSON.stringify(event));
-  const message = event.text.slice(event.text.indexOf('>') + 1).trim();
+  // Replace all mentions in the format <@USER_ID> with empty string, then trim whitespace
+  const message = event.text.replace(/<@[A-Z0-9]+>\s*/g, '').trim();
   const userId = event.user ?? '';
   const channel = event.channel;
   try {


### PR DESCRIPTION
## Description
This PR fixes issue #120, which addresses a bug in the Slack message parsing logic where the app cannot correctly parse user messages if the mention is not at the beginning of the message.

### Changes
1. Changed the parsing logic to use regex replacement instead of string slicing
2. Now correctly parses messages regardless of the position of the mention

The new implementation uses a regular expression to remove all mentions from the message text and properly handle whitespace.

Fixes #120