### PR TITLE
Change stopped instance indicator color from blue to gray

### DIFF
--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -49,7 +49,7 @@ export default async function SessionsPage() {
                                 : session.instanceStatus === 'starting'
                                   ? 'bg-yellow-500'
                                   : session.instanceStatus === 'stopped'
-                                    ? 'bg-blue-500'
+                                    ? 'bg-gray-500'
                                     : 'bg-gray-500'
                             }`}
                           />

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -47,7 +47,7 @@ export default async function SessionsPage() {
                               session.instanceStatus === 'running'
                                 ? 'bg-green-500'
                                 : session.instanceStatus === 'starting'
-                                  ? 'bg-yellow-500'
+                                  ? 'bg-blue-500'
                                   : session.instanceStatus === 'stopped'
                                     ? 'bg-gray-500'
                                     : 'bg-gray-500'


### PR DESCRIPTION
Changed the instance status indicator colors to be more intuitive:
1. Changed 'stopped' status indicator from blue to gray to better represent an inactive state
2. Changed 'starting' status indicator from yellow to blue as it's not a warning state and doesn't require caution

This makes the status indicators more intuitive and less confusing.