### PR TITLE
Update instance status indicator colors in SessionPageClient for consistency

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -118,8 +118,8 @@ export default function SessionPageClient({
                         instanceStatus === 'running'
                           ? 'bg-green-500'
                           : instanceStatus === 'starting'
-                            ? 'bg-yellow-500'
-                            : 'bg-blue-500'
+                            ? 'bg-blue-500'
+                            : 'bg-gray-500'
                       }`}
                     />
                     <span className="text-sm font-medium">


### PR DESCRIPTION
Updated the SessionPageClient.tsx component to match the instance status indicator colors in the main sessions listing page:

- Changed 'starting' status indicator from yellow to blue
- Changed 'stopped' status indicator from blue to gray

This makes the status indicators consistent across all views in the application.