### PR TITLE
Add support for additional AWS managed policies to worker instance

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,7 @@ env:
   AWS_ACCOUNT_ID_LIST_FOR_LB: ${{ secrets.PROD_AWS_ACCOUNT_ID_LIST_FOR_LB }}
   ADMIN_USER_ID_LIST: ${{ vars.PROD_ADMIN_USER_ID_LIST }}
   ROLE_NAME_FOR_LB: ${{ vars.PROD_ROLE_NAME_FOR_LB }}
+  WORKER_ADDITIONAL_POLICIES: ${{ secrets.PROD_WORKER_ADDITIONAL_POLICIES }}
 jobs:
   Deploy-cdk:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ export GITHUB_APP_ID=your-github-app-id
 export GITHUB_INSTALLATION_ID=your-github-installation-id
 ```
 
+#### For Worker Instance Configuration:
+
+You can configure additional AWS managed policies to be attached to the worker instance role:
+
+```sh
+export WORKER_ADDITIONAL_POLICIES=AmazonS3ReadOnlyAccess,AmazonDynamoDBReadOnlyAccess
+```
+
 > [!NOTE]
 > We use environment variables here to inject configuration from GitHub Actions variables. If this isn't convenient for you, you can simply hard-code the values in [`bin/cdk.ts`](cdk/bin/cdk.ts).
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -17,8 +17,10 @@ const virginia = new UsEast1Stack(app, `RemoteSweUsEast1Stack-${targetEnv}`, {
 });
 
 // Parse additional AWS managed policies from environment variable if provided
-const additionalAwsManagedPolicies = process.env.WORKER_ADDITIONAL_POLICIES 
-  ? process.env.WORKER_ADDITIONAL_POLICIES.split(',').map(p => p.trim()).filter(p => p) 
+const additionalAwsManagedPolicies = process.env.WORKER_ADDITIONAL_POLICIES
+  ? process.env.WORKER_ADDITIONAL_POLICIES.split(',')
+      .map((p) => p.trim())
+      .filter((p) => p)
   : undefined;
 
 const props: MainStackProps = {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -16,6 +16,11 @@ const virginia = new UsEast1Stack(app, `RemoteSweUsEast1Stack-${targetEnv}`, {
   crossRegionReferences: true,
 });
 
+// Parse additional AWS managed policies from environment variable if provided
+const additionalAwsManagedPolicies = process.env.WORKER_ADDITIONAL_POLICIES 
+  ? process.env.WORKER_ADDITIONAL_POLICIES.split(',').map(p => p.trim()).filter(p => p) 
+  : undefined;
+
 const props: MainStackProps = {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -48,6 +53,7 @@ const props: MainStackProps = {
         },
       }
     : {}),
+  ...(additionalAwsManagedPolicies ? { additionalAwsManagedPolicies } : {}),
 };
 
 new MainStack(app, `RemoteSweStack-${targetEnv}`, {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -39,6 +39,7 @@ export interface MainStackProps extends cdk.StackProps {
     roleName: string;
   };
   readonly workerAmiIdParameterName: string;
+  readonly additionalAwsManagedPolicies?: string[];
 }
 
 export class MainStack extends cdk.Stack {
@@ -116,6 +117,7 @@ export class MainStack extends cdk.Stack {
       loadBalancing: props.loadBalancing,
       accessLogBucket,
       amiIdParameterName: workerAmiIdParameter.parameterName,
+      additionalAwsManagedPolicies: props.additionalAwsManagedPolicies,
     });
 
     new SlackBolt(this, 'SlackBolt', {

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -28,6 +28,7 @@ export interface WorkerProps {
   };
   accessLogBucket: IBucket;
   amiIdParameterName: string;
+  additionalAwsManagedPolicies?: string[];
 }
 
 export class Worker extends Construct {
@@ -90,9 +91,19 @@ export class Worker extends Construct {
       ],
     });
 
+    // Create a list of managed policies with the base SSM policy
+    const managedPolicies = [iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')];
+    
+    // Add any additional AWS managed policies if specified
+    if (props.additionalAwsManagedPolicies && props.additionalAwsManagedPolicies.length > 0) {
+      props.additionalAwsManagedPolicies.forEach(policyName => {
+        managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName(policyName));
+      });
+    }
+    
     const role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')],
+      managedPolicies: managedPolicies,
     });
 
     const launchTemplate = new ec2.LaunchTemplate(this, 'LaunchTemplate', {

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -93,14 +93,14 @@ export class Worker extends Construct {
 
     // Create a list of managed policies with the base SSM policy
     const managedPolicies = [iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')];
-    
+
     // Add any additional AWS managed policies if specified
     if (props.additionalAwsManagedPolicies && props.additionalAwsManagedPolicies.length > 0) {
-      props.additionalAwsManagedPolicies.forEach(policyName => {
+      props.additionalAwsManagedPolicies.forEach((policyName) => {
         managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName(policyName));
       });
     }
-    
+
     const role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
       managedPolicies: managedPolicies,

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -5654,6 +5654,30 @@ systemctl start myapp",
               ],
             ],
           },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonS3ReadOnlyAccess",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonDynamoDBReadOnlyAccess",
+              ],
+            ],
+          },
         ],
       },
       "Type": "AWS::IAM::Role",

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -41,6 +41,7 @@ test('Snapshot test', () => {
       installationId: '9876543',
     },
     workerAmiIdParameterName: '/remote-swe/worker/ami-id',
+    additionalAwsManagedPolicies: ['AmazonS3ReadOnlyAccess', 'AmazonDynamoDBReadOnlyAccess'],
   });
 
   // Test both stacks


### PR DESCRIPTION
This PR adds support for configuring additional AWS managed policies to be attached to the worker EC2 instance role.

## Changes:

- Added additionalAwsManagedPolicies parameter to WorkerProps interface 
- Modified worker role creation to include additional AWS managed policies specified via the new parameter
- Added environment variable parsing in CDK app to read policy names from WORKER_ADDITIONAL_POLICIES
- Updated README with documentation for the new feature

## Usage:

New environment variable WORKER_ADDITIONAL_POLICIES can be used to specify comma-separated list of AWS managed policy names to attach to worker instance. For example:

