### PR TITLE
Fix showRawJson state reset issue in MessageList component

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -30,6 +30,19 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
   const { theme } = useTheme();
   const t = useTranslations('sessions');
   const positionRatio = useScrollPosition();
+  const [visibleRawJsonMessages, setVisibleRawJsonMessages] = useState<Set<string>>(new Set());
+
+  const toggleRawJsonVisibility = (messageId: string) => {
+    setVisibleRawJsonMessages(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(messageId)) {
+        newSet.delete(messageId);
+      } else {
+        newSet.add(messageId);
+      }
+      return newSet;
+    });
+  };
 
   useEffect(() => {
     if (positionRatio > 0.95) {
@@ -106,9 +119,7 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
     </ReactMarkdown>
   );
 
-  const ToolUseRenderer = ({ content, input }: { content: string; input: string | undefined }) => {
-    const [showRawJson, setShowRawJson] = useState(false);
-
+  const ToolUseRenderer = ({ content, input, messageId }: { content: string; input: string | undefined; messageId: string }) => {
     const toolName = content;
 
     const getToolIcon = (name: string) => {
@@ -126,16 +137,16 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
           </span>
           {input && (
             <button
-              onClick={() => setShowRawJson(!showRawJson)}
+              onClick={() => toggleRawJsonVisibility(messageId)}
               className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 hover:underline text-xs ml-2"
             >
               <Info className="w-3 h-3" />
-              {showRawJson ? t('hideRawJson') : t('showRawJson')}
+              {visibleRawJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}
             </button>
           )}
         </div>
 
-        {input && showRawJson && (
+        {input && visibleRawJsonMessages.has(messageId) && (
           <div className="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded overflow-auto max-h-60">
             <pre className="text-xs">{input}</pre>
           </div>
@@ -172,7 +183,7 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 }`}
               >
                 {message.type === 'toolUse' ? (
-                  <ToolUseRenderer content={message.content} input={message.detail} />
+                  <ToolUseRenderer content={message.content} input={message.detail} messageId={message.id} />
                 ) : (
                   <MarkdownRenderer content={message.content} />
                 )}

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -33,7 +33,7 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
   const [visibleRawJsonMessages, setVisibleRawJsonMessages] = useState<Set<string>>(new Set());
 
   const toggleRawJsonVisibility = (messageId: string) => {
-    setVisibleRawJsonMessages(prev => {
+    setVisibleRawJsonMessages((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(messageId)) {
         newSet.delete(messageId);
@@ -119,7 +119,15 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
     </ReactMarkdown>
   );
 
-  const ToolUseRenderer = ({ content, input, messageId }: { content: string; input: string | undefined; messageId: string }) => {
+  const ToolUseRenderer = ({
+    content,
+    input,
+    messageId,
+  }: {
+    content: string;
+    input: string | undefined;
+    messageId: string;
+  }) => {
     const toolName = content;
 
     const getToolIcon = (name: string) => {


### PR DESCRIPTION
## Problem

The showRawJson state in the ToolUseRenderer component of MessageList.tsx was being reset every time an event was received from the eventBus. This caused the JSON display to close whenever a new event occurred, even if the user had explicitly opened it.

## Solution

1. Manage the showRawJson state at the component level using a Set called visibleRawJsonMessages in the MessageList component
2. Track which messages have their JSON display open using message IDs as keys
3. Add a toggleRawJsonVisibility function to manage state toggling

With these changes, the JSON display remains open even when new events occur, preserving the user's viewing preferences.