### PR TITLE
Fix i18n support for add image button in sessions/new page

### DIFF
--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -101,7 +101,9 @@ export default function NewSessionPage() {
                         className="flex gap-2 items-center"
                       >
                         <ImageIcon className="w-4 h-4" />
-                        {uploadingImages.length > 0 ? `${uploadingImages.length} 枚の画像` : '画像を追加'}
+                        {uploadingImages.length > 0 
+                          ? t('imagesCount', { count: uploadingImages.length }) 
+                          : t('addImage')}
                       </Button>
                     </div>
 

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -73,6 +73,8 @@
     "initialMessage": "Initial Message",
     "placeholder": "Enter your initial message to the AI agent (e.g., 'Help me create a React component' or 'Review my code for bugs')...",
     "creatingSession": "Creating Session...",
-    "createSessionButton": "Create Session & Start Conversation"
+    "createSessionButton": "Create Session & Start Conversation",
+    "addImage": "Add Image",
+    "imagesCount": "{count} images"
   }
 }

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -73,6 +73,8 @@
     "initialMessage": "初期メッセージ",
     "placeholder": "AIエージェントへの初期メッセージを入力してください（例：「Reactコンポーネントの作成を手伝って」や「コードのバグをレビューして」など）...",
     "creatingSession": "セッション作成中...",
-    "createSessionButton": "セッションを作成して会話を開始"
+    "createSessionButton": "セッションを作成して会話を開始",
+    "addImage": "画像を追加",
+    "imagesCount": "{count} 枚の画像"
   }
 }


### PR DESCRIPTION
## Problem\n\nThe 'Add Image' button in the sessions/new page was hardcoded in Japanese ('画像を追加') and not internationalized. Similarly, the text showing the number of uploaded images ('X 枚の画像') was also hardcoded in Japanese.\n\n## Solution\n\n1. Added new translation keys in both en.json and ja.json:\n   - 'addImage': 'Add Image' / '画像を追加'  \n   - 'imagesCount': '{count} images' / '{count} 枚の画像'\n\n2. Updated the page.tsx file to use these translation keys with the t() function instead of hardcoded strings.\n\nThis ensures the button text is properly displayed in the user's selected language.