### PR TITLE
Allow sending messages without mentioning the slack app

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Now, you need to set up a Slack App to control agents through the Slack interfac
 
 #### Create a Slack App
 
-1. Go to [Slack API Dashboard](https://api.slack.com/apps)
+1. Go to [Slack Apps Dashboard](https://api.slack.com/apps)
 2. Click "Create New App"
 3. Choose "From manifest"
 4. Use the provided Slack app manifest YAML file: [manifest.json](./resources/slack-app-manifest.json)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Now, you need to set up a Slack App to control agents through the Slack interfac
 2. Click "Create New App"
 3. Choose "From manifest"
 4. Use the provided Slack app manifest YAML file: [manifest.json](./resources/slack-app-manifest.json)
+   - If your Slack workspace administrator permits granting broader permissions to bots, you can also use [slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json). This allows users to converse with the agent in Slack threads without having to mention the bot.
    - Please replace the endpoint URL (`https://redacted.execute-api.us-east-1.amazonaws.com`) with your actual URL
    - You can find your actual URL in the CDK deployment outputs as `SlackBoltEndpointUrl`
 5. Please make note of the following values:
@@ -106,8 +107,6 @@ Now, you need to set up a Slack App to control agents through the Slack interfac
    - Bot Token (found in OAuth & Permissions, after installing to your workspace)
 
 Please also refer to this document for more details: [Create and configure apps with manifests](https://api.slack.com/reference/manifests)
-
-If your Slack workspace administrator permits granting broader permissions to bots, you can also use [slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json). This allows users to converse with the agent in Slack threads without having to mention the bot.
 
 > [!NOTE]
 > If you're using a shared (rather than personal) Slack workspace, consider setting the `ADMIN_USER_ID_LIST` environment variable (see below) to control agent access. Without this restriction, anyone in the workspace can access the agents and potentially your GitHub content.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Now, you need to set up a Slack App to control agents through the Slack interfac
 
 Please also refer to this document for more details: [Create and configure apps with manifests](https://api.slack.com/reference/manifests)
 
+If your Slack workspace administrator permits granting broader permissions to bots, you can also use [slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json). This allows users to converse with the agent in Slack threads without having to mention the bot.
+
 > [!NOTE]
 > If you're using a shared (rather than personal) Slack workspace, consider setting the `ADMIN_USER_ID_LIST` environment variable (see below) to control agent access. Without this restriction, anyone in the workspace can access the agents and potentially your GitHub content.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -91,7 +91,7 @@ npx cdk deploy --all
 
 #### Slackアプリの作成
 
-1. [Slack APIダッシュボード](https://api.slack.com/apps)にアクセス
+1. [Slack Appsダッシュボード](https://api.slack.com/apps)にアクセス
 2. 「Create New App」（新しいアプリを作成）をクリック
 3. 「From manifest」（マニフェストから）を選択
 4. 提供されているSlackアプリのマニフェストYAMLファイルを使用：[manifest.json](./resources/slack-app-manifest.json)

--- a/README_ja.md
+++ b/README_ja.md
@@ -103,6 +103,8 @@ npx cdk deploy --all
 
 詳細については、こちらのドキュメントを参照してください：[マニフェストでアプリを作成および設定する](https://api.slack.com/reference/manifests)
 
+Slackワークスペース管理者がより広い権限をボットに付与することを許可している場合は、[slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json)も利用できます。これを使うと、botにメンションをしなくても、Slackスレッド内でエージェントと会話することができます。
+
 > [!NOTE]
 > 共有（個人ではなく）Slackワークスペースを使用している場合は、エージェントへのアクセスを制御するために`ADMIN_USER_ID_LIST`環境変数（以下を参照）の設定を検討してください。この制限がないと、ワークスペース内の誰でもエージェントにアクセスでき、潜在的にあなたのGitHubコンテンツにもアクセスできてしまいます。
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -95,6 +95,7 @@ npx cdk deploy --all
 2. 「Create New App」（新しいアプリを作成）をクリック
 3. 「From manifest」（マニフェストから）を選択
 4. 提供されているSlackアプリのマニフェストYAMLファイルを使用：[manifest.json](./resources/slack-app-manifest.json)
+   - Slackワークスペース管理者がより広い権限をボットに付与することを許可している場合は、[slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json)も利用できます。これを使うと、botにメンションをしなくても、Slackスレッド内でエージェントと会話することができます。
    - エンドポイントURL（`https://redacted.execute-api.us-east-1.amazonaws.com`）を実際のURLに置き換えてください
    - 実際のURLはCDKデプロイメント出力の`SlackBoltEndpointUrl`で確認できます
 5. 以下の値を必ずメモしておいてください：
@@ -102,8 +103,6 @@ npx cdk deploy --all
    - ボットトークン（OAuth & Permissions内、ワークスペースにインストール後に確認可能）
 
 詳細については、こちらのドキュメントを参照してください：[マニフェストでアプリを作成および設定する](https://api.slack.com/reference/manifests)
-
-Slackワークスペース管理者がより広い権限をボットに付与することを許可している場合は、[slack-app-manifest-relaxed.json](./resources/slack-app-manifest-relaxed.json)も利用できます。これを使うと、botにメンションをしなくても、Slackスレッド内でエージェントと会話することができます。
 
 > [!NOTE]
 > 共有（個人ではなく）Slackワークスペースを使用している場合は、エージェントへのアクセスを制御するために`ADMIN_USER_ID_LIST`環境変数（以下を参照）の設定を検討してください。この制限がないと、ワークスペース内の誰でもエージェントにアクセスでき、潜在的にあなたのGitHubコンテンツにもアクセスできてしまいます。

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -389,13 +389,24 @@ app.event('message', async ({ event, client, logger }) => {
     return;
   }
 
+  // 安全のために、text プロパティが確実に存在することを確認
+  if (!messageEvent.text) {
+    return;
+  }
+
+  // text プロパティが確実に存在する安全な型のオブジェクトを作成
+  const safeEvent = {
+    ...messageEvent,
+    text: messageEvent.text, // これで text は undefined ではなく string になる
+  };
+
   // スレッド内のメッセージである場合のみ処理（親が存在するメッセージ）
   if (messageEvent.thread_ts) {
-    await processMessage(messageEvent, client, logger, 'message');
+    await processMessage(safeEvent, client, logger, 'message');
   } 
   // DMの場合は常に処理
   else if (messageEvent.channel_type === 'im') {
-    await processMessage(messageEvent, client, logger, 'message');
+    await processMessage(safeEvent, client, logger, 'message');
   }
 });
 

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -47,27 +47,27 @@ let botId: string | undefined;
 
 // 共通の処理を行う関数を定義
 async function processMessage(
-  event: { 
-    text: string; 
-    user?: string; 
-    channel: string; 
-    ts: string; 
+  event: {
+    text: string;
+    user?: string;
+    channel: string;
+    ts: string;
     thread_ts?: string;
     blocks?: any[];
     files?: any[];
-  }, 
-  client: any, 
-  logger: any, 
+  },
+  client: any,
+  logger: any,
   eventType: 'app_mention' | 'message'
 ) {
   console.log(`${eventType} event received`);
   console.log(JSON.stringify(event));
-  
+
   // Replace all mentions in the format <@USER_ID> with empty string, then trim whitespace
   const message = event.text.replace(/<@[A-Z0-9]+>\s*/g, '').trim();
   const userId = event.user ?? '';
   const channel = event.channel;
-  
+
   try {
     // idempotency keyにイベントタイプを含める（重複防止のため）
     await makeIdempotent(async (_: string) => {
@@ -374,10 +374,10 @@ app.event('message', async ({ event, client, logger }) => {
     blocks?: any[];
     files?: any[];
   };
-  
+
   // DMのメッセージ、または特定のスレッド内のメッセージの場合のみ処理
   // ただし、自分自身へのメンションを含むメッセージは除外（app_mentionで処理するため）
-  
+
   if (!messageEvent.text || messageEvent.bot_id || messageEvent.subtype) {
     // botからのメッセージ、またはサブタイプのあるメッセージ（編集など）はスキップ
     return;
@@ -403,7 +403,7 @@ app.event('message', async ({ event, client, logger }) => {
   // スレッド内のメッセージである場合のみ処理（親が存在するメッセージ）
   if (messageEvent.thread_ts) {
     await processMessage(safeEvent, client, logger, 'message');
-  } 
+  }
   // DMの場合は常に処理
   else if (messageEvent.channel_type === 'im') {
     await processMessage(safeEvent, client, logger, 'message');

--- a/resources/slack-app-manifest-relaxed.json
+++ b/resources/slack-app-manifest-relaxed.json
@@ -1,0 +1,49 @@
+{
+    "display_information": {
+        "name": "remoteSWE",
+        "description": "They work hard, you chill.",
+        "background_color": "#070708"
+    },
+    "features": {
+        "bot_user": {
+            "display_name": "remote-swe",
+            "always_online": true
+        }
+    },
+    "oauth_config": {
+        "redirect_urls": [
+            "https://redacted.execute-api.ap-northeast-1.amazonaws.com"
+        ],
+        "scopes": {
+            "bot": [
+                "app_mentions:read",
+                "chat:write",
+                "files:read",
+                "files:write",
+                "reactions:read",
+                "reactions:write",
+                "channels:history",
+                "groups:history",
+                "im:history"
+            ]
+        }
+    },
+    "settings": {
+        "event_subscriptions": {
+            "request_url": "https://redacted.execute-api.ap-northeast-1.amazonaws.com",
+            "bot_events": [
+                "app_mention",
+                "message.channels",
+                "message.groups",
+                "message.im"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true,
+            "request_url": "https://redacted.execute-api.ap-northeast-1.amazonaws.com"
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": false,
+        "token_rotation_enabled": false
+    }
+}


### PR DESCRIPTION
This PR addresses issue #127 by allowing users to send messages to agents in Slack without adding an @mention every time.

## Changes:
- Added detection of the bot's own ID using auth.test() API
- Created a common message processing function shared between event types
- Added message event handler to process messages:
  - In DMs without mention
  - In threads without mention
- Added detection to avoid duplicate processing when a message contains a mention
- Added unique idempotency keys to prevent duplicate processing

## Behavior:
- Users can now continue a thread conversation without mentioning the bot
- In DMs, users can send messages without mentions
- In channels, new conversations still require an @mention to start
- Messages with @mentions are still processed by app_mention handler only