### PR TITLE
Add tool result JSON display in webapp

### DIFF
--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -16,6 +16,7 @@ export const webappEventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('toolResult'),
     toolName: z.string(),
+    output: z.string().optional(),
     timestamp: z.number(),
   }),
   z.object({

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -16,7 +16,7 @@ export const webappEventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('toolResult'),
     toolName: z.string(),
-    output: z.string().optional(),
+    output: z.string(),
     timestamp: z.number(),
   }),
   z.object({

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -8,12 +8,12 @@ import { toast } from 'sonner';
 import { sendMessageToAgent } from '../actions';
 import { sendMessageToAgentSchema } from '../schemas';
 import { KeyboardEventHandler } from 'react';
-import { Message } from './MessageList';
+import { MessageView } from './MessageList';
 import { useTranslations } from 'next-intl';
 import ImageUploader from '@/components/ImageUploader';
 
 type MessageFormProps = {
-  onSubmit: (message: Message) => void;
+  onSubmit: (message: MessageView) => void;
   workerId: string;
 };
 

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -19,6 +19,7 @@ export type Message = {
   output?: string; // Added for toolResult output JSON
   timestamp: Date;
   type: 'message' | 'toolResult' | 'toolUse';
+  toolUseIds?: string[]; // Added to help match toolUse with toolResult
 };
 
 type MessageListProps = {

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -19,7 +19,6 @@ export type Message = {
   output?: string; // Added for toolResult output JSON
   timestamp: Date;
   type: 'message' | 'toolResult' | 'toolUse';
-  toolUseIds?: string[]; // Added to help match toolUse with toolResult
 };
 
 type MessageListProps = {

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -166,9 +166,12 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 onClick={() => toggleInputJsonVisibility(messageId)}
                 className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 hover:underline text-xs ml-2"
               >
-                <Info className="w-3 h-3" />
-                <span>{visibleInputJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}</span>
-                <span className="ml-1">({t('input')})</span>
+                {visibleInputJsonMessages.has(messageId) ? (
+                  <span className="transform rotate-90">&#9654;</span>
+                ) : (
+                  <span>&#9654;</span>
+                )}
+                <span>{t('input')}</span>
               </button>
             )}
             {output && (
@@ -176,9 +179,12 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 onClick={() => toggleOutputJsonVisibility(messageId)}
                 className="flex items-center gap-1 text-green-600 dark:text-green-400 hover:underline text-xs ml-2"
               >
-                <Info className="w-3 h-3" />
-                <span>{visibleOutputJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}</span>
-                <span className="ml-1">({t('output')})</span>
+                {visibleOutputJsonMessages.has(messageId) ? (
+                  <span className="transform rotate-90">&#9654;</span>
+                ) : (
+                  <span>&#9654;</span>
+                )}
+                <span>{t('output')}</span>
               </button>
             )}
           </div>

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Bot, User, Loader2, Clock, Info, Settings, Code, Terminal } from 'lucide-react';
+import { Bot, User, Loader2, Clock, Info, Settings, Code, Terminal, ChevronRight, ChevronDown } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -167,9 +167,9 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 hover:underline text-xs ml-2"
               >
                 {visibleInputJsonMessages.has(messageId) ? (
-                  <span className="transform rotate-90">&#9654;</span>
+                  <ChevronDown className="w-3 h-3" />
                 ) : (
-                  <span>&#9654;</span>
+                  <ChevronRight className="w-3 h-3" />
                 )}
                 <span>{t('input')}</span>
               </button>
@@ -180,9 +180,9 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 className="flex items-center gap-1 text-green-600 dark:text-green-400 hover:underline text-xs ml-2"
               >
                 {visibleOutputJsonMessages.has(messageId) ? (
-                  <span className="transform rotate-90">&#9654;</span>
+                  <ChevronDown className="w-3 h-3" />
                 ) : (
-                  <span>&#9654;</span>
+                  <ChevronRight className="w-3 h-3" />
                 )}
                 <span>{t('output')}</span>
               </button>

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { useScrollPosition } from '@/hooks/use-scroll-position';
 
-export type Message = {
+export type MessageView = {
   id: string;
   role: 'user' | 'assistant';
   content: string;
@@ -22,7 +22,7 @@ export type Message = {
 };
 
 type MessageListProps = {
-  messages: Message[];
+  messages: MessageView[];
   isAgentTyping: boolean;
   instanceStatus?: 'starting' | 'running' | 'stopped' | 'terminated';
 };

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -46,7 +46,7 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
       return newSet;
     });
   };
-  
+
   const toggleOutputJsonVisibility = (messageId: string) => {
     setVisibleOutputJsonMessages((prev) => {
       const newSet = new Set(prev);
@@ -227,11 +227,11 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 }`}
               >
                 {message.type === 'toolUse' ? (
-                  <ToolUseRenderer 
-                    content={message.content} 
-                    input={message.detail} 
+                  <ToolUseRenderer
+                    content={message.content}
+                    input={message.detail}
                     output={message.output}
-                    messageId={message.id} 
+                    messageId={message.id}
                   />
                 ) : (
                   <MarkdownRenderer content={message.content} />

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -16,6 +16,7 @@ export type Message = {
   role: 'user' | 'assistant';
   content: string;
   detail?: string;
+  output?: string; // Added for toolResult output JSON
   timestamp: Date;
   type: 'message' | 'toolResult' | 'toolUse';
 };
@@ -30,10 +31,24 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
   const { theme } = useTheme();
   const t = useTranslations('sessions');
   const positionRatio = useScrollPosition();
-  const [visibleRawJsonMessages, setVisibleRawJsonMessages] = useState<Set<string>>(new Set());
+  // Track visibility of input and output JSON for each message
+  const [visibleInputJsonMessages, setVisibleInputJsonMessages] = useState<Set<string>>(new Set());
+  const [visibleOutputJsonMessages, setVisibleOutputJsonMessages] = useState<Set<string>>(new Set());
 
-  const toggleRawJsonVisibility = (messageId: string) => {
-    setVisibleRawJsonMessages((prev) => {
+  const toggleInputJsonVisibility = (messageId: string) => {
+    setVisibleInputJsonMessages((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(messageId)) {
+        newSet.delete(messageId);
+      } else {
+        newSet.add(messageId);
+      }
+      return newSet;
+    });
+  };
+  
+  const toggleOutputJsonVisibility = (messageId: string) => {
+    setVisibleOutputJsonMessages((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(messageId)) {
         newSet.delete(messageId);
@@ -122,10 +137,12 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
   const ToolUseRenderer = ({
     content,
     input,
+    output,
     messageId,
   }: {
     content: string;
     input: string | undefined;
+    output: string | undefined;
     messageId: string;
   }) => {
     const toolName = content;
@@ -143,20 +160,39 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
           <span className="font-semibold">
             {t('usingTool')}: {toolName}
           </span>
-          {input && (
-            <button
-              onClick={() => toggleRawJsonVisibility(messageId)}
-              className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 hover:underline text-xs ml-2"
-            >
-              <Info className="w-3 h-3" />
-              {visibleRawJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {input && (
+              <button
+                onClick={() => toggleInputJsonVisibility(messageId)}
+                className="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 hover:underline text-xs ml-2"
+              >
+                <Info className="w-3 h-3" />
+                <span>{visibleInputJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}</span>
+                <span className="ml-1">({t('input')})</span>
+              </button>
+            )}
+            {output && (
+              <button
+                onClick={() => toggleOutputJsonVisibility(messageId)}
+                className="flex items-center gap-1 text-green-600 dark:text-green-400 hover:underline text-xs ml-2"
+              >
+                <Info className="w-3 h-3" />
+                <span>{visibleOutputJsonMessages.has(messageId) ? t('hideRawJson') : t('showRawJson')}</span>
+                <span className="ml-1">({t('output')})</span>
+              </button>
+            )}
+          </div>
         </div>
 
-        {input && visibleRawJsonMessages.has(messageId) && (
+        {input && visibleInputJsonMessages.has(messageId) && (
           <div className="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded overflow-auto max-h-60">
             <pre className="text-xs">{input}</pre>
+          </div>
+        )}
+
+        {output && visibleOutputJsonMessages.has(messageId) && (
+          <div className="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded overflow-auto max-h-60">
+            <pre className="text-xs">{output}</pre>
           </div>
         )}
       </div>
@@ -191,7 +227,12 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                 }`}
               >
                 {message.type === 'toolUse' ? (
-                  <ToolUseRenderer content={message.content} input={message.detail} messageId={message.id} />
+                  <ToolUseRenderer 
+                    content={message.content} 
+                    input={message.detail} 
+                    output={message.output}
+                    messageId={message.id} 
+                  />
                 ) : (
                   <MarkdownRenderer content={message.content} />
                 )}

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -56,6 +56,17 @@ export default function SessionPageClient({
           setInstanceStatus(event.status);
           break;
         case 'toolResult':
+          // Update corresponding toolUse message with output
+          if (event.output) {
+            setMessages((prev) => 
+              prev.map((msg) => {
+                if (msg.type === 'toolUse' && msg.content === event.toolName) {
+                  return { ...msg, output: event.output };
+                }
+                return msg;
+              })
+            );
+          }
           break;
         case 'toolUse':
           if (['sendMessageToUser', 'sendMessageToUserIfNecessary'].includes(event.toolName)) {

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -55,15 +55,13 @@ export default function SessionPageClient({
           setInstanceStatus(event.status);
           break;
         case 'toolResult':
-          if (event.output) {
-            setMessages((prev) => {
-              const toolUse = prev.findLast((msg) => msg.type == 'toolUse');
-              if (toolUse) {
-                toolUse.output = event.output;
-              }
-              return prev;
-            });
-          }
+          setMessages((prev) => {
+            const toolUse = prev.findLast((msg) => msg.type == 'toolUse');
+            if (toolUse && toolUse.output == undefined) {
+              toolUse.output = event.output;
+            }
+            return prev;
+          });
           break;
         case 'toolUse':
           if (['sendMessageToUser', 'sendMessageToUserIfNecessary'].includes(event.toolName)) {

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -58,7 +58,7 @@ export default function SessionPageClient({
         case 'toolResult':
           // Update corresponding toolUse message with output
           if (event.output) {
-            setMessages((prev) => 
+            setMessages((prev) =>
               prev.map((msg) => {
                 if (msg.type === 'toolUse' && msg.content === event.toolName) {
                   return { ...msg, output: event.output };

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -9,7 +9,6 @@ import MessageForm from './MessageForm';
 import MessageList, { MessageView } from './MessageList';
 import { webappEventSchema } from '@remote-swe-agents/agent-core/schema';
 import { useTranslations } from 'next-intl';
-import { useScrollPosition } from '@/hooks/use-scroll-position';
 
 interface SessionPageClientProps {
   workerId: string;
@@ -56,16 +55,14 @@ export default function SessionPageClient({
           setInstanceStatus(event.status);
           break;
         case 'toolResult':
-          // Update corresponding toolUse message with output
           if (event.output) {
-            setMessages((prev) =>
-              prev.map((msg) => {
-                if (msg.type === 'toolUse' && msg.content === event.toolName) {
-                  return { ...msg, output: event.output };
-                }
-                return msg;
-              })
-            );
+            setMessages((prev) => {
+              const toolUse = prev.findLast((msg) => msg.type == 'toolUse');
+              if (toolUse) {
+                toolUse.output = event.output;
+              }
+              return prev;
+            });
           }
           break;
         case 'toolUse':

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -6,14 +6,14 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useEventBus } from '@/hooks/use-event-bus';
 import MessageForm from './MessageForm';
-import MessageList, { Message } from './MessageList';
+import MessageList, { MessageView } from './MessageList';
 import { webappEventSchema } from '@remote-swe-agents/agent-core/schema';
 import { useTranslations } from 'next-intl';
 import { useScrollPosition } from '@/hooks/use-scroll-position';
 
 interface SessionPageClientProps {
   workerId: string;
-  initialMessages: Message[];
+  initialMessages: MessageView[];
   initialInstanceStatus?: 'starting' | 'running' | 'stopped' | 'terminated';
 }
 
@@ -23,7 +23,7 @@ export default function SessionPageClient({
   initialInstanceStatus,
 }: SessionPageClientProps) {
   const t = useTranslations('sessions');
-  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [messages, setMessages] = useState<MessageView[]>(initialMessages);
   const [isAgentTyping, setIsAgentTyping] = useState(false);
   const [instanceStatus, setInstanceStatus] = useState<'starting' | 'running' | 'stopped' | 'terminated' | undefined>(
     initialInstanceStatus
@@ -99,7 +99,7 @@ export default function SessionPageClient({
     }, []),
   });
 
-  const onSendMessage = async (message: Message) => {
+  const onSendMessage = async (message: MessageView) => {
     setMessages((prev) => [...prev, message]);
     setIsAgentTyping(true);
   };

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -48,6 +48,9 @@ export default async function SessionPage({ params }: SessionPageProps) {
           .map((block) => `${block.toolUse?.name}\n${JSON.stringify(block.toolUse?.input, undefined, 2)}`)
           .join('\n\n');
         if (tools && tools.length > 0) {
+          // Store toolUseIds for later matching with toolResults
+          const toolUseIds = tools.map((block) => block.toolUse?.toolUseId).filter(Boolean) as string[];
+
           ret.push({
             id: `${item.SK}-${i}`,
             role: 'assistant',
@@ -55,21 +58,40 @@ export default async function SessionPage({ params }: SessionPageProps) {
             detail,
             timestamp: new Date(parseInt(item.SK)),
             type: 'toolUse',
+            toolUseIds: toolUseIds, // Add toolUseIds to help matching later
           });
         }
         return ret;
       }
       case 'toolResult': {
+        // Extract tool use id and content
+        const toolUseId = message.content?.find((c) => c.toolResult)?.toolResult?.toolUseId;
+        const toolContent = message.content?.find((c) => c.toolResult)?.toolResult?.content;
+
+        if (!toolUseId) return [];
+
+        // toolResult content could be a string or an array of objects with text property
+        const toolResultOutput =
+          Array.isArray(toolContent) && toolContent.length > 0 && toolContent[0].text
+            ? toolContent[0].text
+            : typeof toolContent === 'string'
+              ? toolContent
+              : JSON.stringify(toolContent);
+
+        // Find corresponding toolUse message by toolUseId and attach the output
+        // First, find all toolUse messages in our current result set
+        const toolUseMessages = messages.filter(
+          (msg) => msg.type === 'toolUse' && msg.toolUseIds && msg.toolUseIds.includes(toolUseId)
+        );
+
+        // If we found a matching toolUse message, add output to it
+        if (toolUseMessages.length > 0) {
+          // Just add output to the first matched message
+          toolUseMessages[0].output = toolResultOutput;
+        }
+
+        // We don't add a message for toolResult, just update the corresponding toolUse
         return [];
-        return [
-          {
-            id: `${item.SK}-${i}`,
-            role: 'assistant',
-            content: 'toolResult',
-            timestamp: new Date(parseInt(item.SK)),
-            type: 'toolResult',
-          },
-        ];
       }
       case 'userMessage': {
         const text = (message.content?.map((c) => c.text).filter((c) => c) ?? []).join('\n');

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -41,6 +41,8 @@
     "usingTool": "Using Tool",
     "showRawJson": "Show raw JSON",
     "hideRawJson": "Hide raw JSON",
+    "input": "input",
+    "output": "output",
     "scrollToTop": "Scroll to top",
     "scrollToBottom": "Scroll to bottom"
   },

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -41,6 +41,8 @@
     "usingTool": "ツール使用中",
     "showRawJson": "JSONを表示",
     "hideRawJson": "JSONを隠す",
+    "input": "入力",
+    "output": "出力",
     "scrollToTop": "一番上までスクロール",
     "scrollToBottom": "一番下までスクロール"
   },

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -363,7 +363,7 @@ Users will primarily request software engineering assistance including bug fixes
         await sendWebappEvent(workerId, {
           type: 'toolResult',
           toolName: toolUse.name ?? '',
-          output: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResultObject),
+          output: toolResult ? toolResult : (toolResultObject?.map((r) => r.text).join('\n') ?? ''),
         });
       }
 

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -360,7 +360,11 @@ Users will primarily request software engineering assistance including bug fixes
             ],
           },
         });
-        await sendWebappEvent(workerId, { type: 'toolResult', toolName: toolUse.name ?? '' });
+        await sendWebappEvent(workerId, { 
+          type: 'toolResult', 
+          toolName: toolUse.name ?? '',
+          output: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResultObject) 
+        });
       }
 
       // Save both tool use and tool result messages atomically to DynamoDB

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -360,10 +360,10 @@ Users will primarily request software engineering assistance including bug fixes
             ],
           },
         });
-        await sendWebappEvent(workerId, { 
-          type: 'toolResult', 
+        await sendWebappEvent(workerId, {
+          type: 'toolResult',
           toolName: toolUse.name ?? '',
-          output: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResultObject) 
+          output: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResultObject),
         });
       }
 


### PR DESCRIPTION
Fixes #144

## Changes

1. Updated  to support showing toolResult JSON:
   - Extended the state to track input and output JSON visibility separately
   - Modified ToolUseRenderer to display both input and output JSON with separate buttons

2. Updated i18n files to support new labels:
   - Added 'input' and 'output' labels to English and Japanese translations

3. Enhanced  to send toolResult output JSON in WebppEvent:
   - Modified the schema to include optional output field
   - Updated the event dispatch to include the tool result output

4. Updated SessionPageClient to process toolResult events:
   - Implemented logic to update corresponding toolUse messages with output data
   
5. Updated page.tsx to handle toolResult data from DynamoDB:
   - Added toolUseIds to Message type to help matching toolUse and toolResult
   - Implemented logic to match toolResult with their corresponding toolUse messages
   - This ensures output JSON is displayed even when loading from DB history