### PR TITLE
worker: apply middle out when token count exceeds a threshold in agent's turn

### DIFF
--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -22,6 +22,7 @@ type ModelType = z.infer<typeof modelTypeSchema>;
 
 const modelConfigSchema = z.object({
   maxOutputTokens: z.number().default(4096),
+  maxInputTokens: z.number(),
   cacheSupport: z.array(z.enum(['system', 'tool', 'message'])).default([]),
   reasoningSupport: z.boolean().default(false),
   toolChoiceSupport: z.array(z.enum(['any', 'auto', 'tool'])).default([]),
@@ -30,35 +31,42 @@ const modelConfigSchema = z.object({
 const modelConfigs: Record<ModelType, Partial<z.infer<typeof modelConfigSchema>>> = {
   'sonnet3.5v1': {
     maxOutputTokens: 4096,
+    maxInputTokens: 200_000,
     toolChoiceSupport: ['any', 'auto', 'tool'],
   },
   'sonnet3.5': {
     maxOutputTokens: 4096,
+    maxInputTokens: 200_000,
     toolChoiceSupport: ['any', 'auto', 'tool'],
   },
   'sonnet3.7': {
     maxOutputTokens: 8192,
+    maxInputTokens: 200_000,
     cacheSupport: ['system', 'message', 'tool'],
     reasoningSupport: true,
     toolChoiceSupport: ['any', 'auto', 'tool'],
   },
   'haiku3.5': {
     maxOutputTokens: 4096,
+    maxInputTokens: 200_000,
     toolChoiceSupport: ['any', 'auto', 'tool'],
   },
   'nova-pro': {
     maxOutputTokens: 5000,
+    maxInputTokens: 300_000,
     cacheSupport: ['system'],
     toolChoiceSupport: ['auto'],
   },
   opus4: {
     maxOutputTokens: 8192,
+    maxInputTokens: 200_000,
     cacheSupport: ['system', 'message', 'tool'],
     reasoningSupport: true,
     toolChoiceSupport: ['any', 'auto', 'tool'],
   },
   sonnet4: {
     maxOutputTokens: 8192,
+    maxInputTokens: 200_000,
     cacheSupport: ['system', 'message', 'tool'],
     reasoningSupport: true,
     toolChoiceSupport: ['any', 'auto', 'tool'],

--- a/packages/agent-core/src/lib/cost.ts
+++ b/packages/agent-core/src/lib/cost.ts
@@ -58,10 +58,6 @@ async function calculateTotalSessionCost(workerId: string) {
       const modelCost = calculateCost(modelId, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens);
 
       totalCost += modelCost;
-
-      console.log(
-        `Model ${modelId}: ${inputTokens} input, ${outputTokens} output, ${cacheReadTokens} cache read, ${cacheWriteTokens} cache write tokens = ${modelCost.toFixed(6)}`
-      );
     }
 
     return totalCost;

--- a/packages/agent-core/src/lib/messages.ts
+++ b/packages/agent-core/src/lib/messages.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import { tmpdir } from 'os';
 import { ddb, TableName } from './aws/ddb';
 import { writeBytesToKey, getBytesFromKey } from './aws/s3';
-import { renderUserMessage } from './prompt';
 import { sendWebappEvent } from './events';
 import { sendMessageToSlack } from './slack';
 

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -15,7 +15,6 @@ import {
   renderToolResult,
   sendSystemMessage,
   updateSessionCost,
-  MAX_INPUT_TOKEN,
 } from '@remote-swe-agents/agent-core/lib';
 import pRetry, { AbortError } from 'p-retry';
 import { bedrockConverse } from '@remote-swe-agents/agent-core/lib';
@@ -201,6 +200,10 @@ Users will primarily request software engineering assistance including bug fixes
     ],
   };
 
+  // We would use model-specific tokens here, but for now we'll use a default value
+  const maxInputTokens = 200000; // Default to 200k tokens
+  const middleOutMaxTokens = maxInputTokens * 0.4; // Use 40% of max input tokens as specified
+  
   const { items: initialItems } = await middleOutFiltering(allItems);
   // usually cache was created with the last user message (including toolResult), so try to get at(-3) here.
   // at(-1) is usually the latest user message received, at(-2) is usually the last assistant output
@@ -213,8 +216,8 @@ Users will primarily request software engineering assistance including bug fixes
     if (cancellationToken.isCancelled) break;
     const items = [...initialItems, ...appendedItems];
 
-    // Check if token count exceeds the threshold (95% of MAX_INPUT_TOKEN)
-    const tokenThreshold = MAX_INPUT_TOKEN * 0.95;
+    // Check if token count exceeds the threshold (95% of maxInputTokens)
+    const tokenThreshold = maxInputTokens * 0.95;
     const totalBeforeFiltering = items.reduce((sum: number, item) => sum + item.tokenCount, 0);
 
     let result;

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -203,7 +203,7 @@ Users will primarily request software engineering assistance including bug fixes
   // We would use model-specific tokens here, but for now we'll use a default value
   const maxInputTokens = 200000; // Default to 200k tokens
   const middleOutMaxTokens = maxInputTokens * 0.4; // Use 40% of max input tokens as specified
-  
+
   const { items: initialItems } = await middleOutFiltering(allItems);
   // usually cache was created with the last user message (including toolResult), so try to get at(-3) here.
   // at(-1) is usually the latest user message received, at(-2) is usually the last assistant output

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -212,21 +212,23 @@ Users will primarily request software engineering assistance including bug fixes
   while (true) {
     if (cancellationToken.isCancelled) break;
     const items = [...initialItems, ...appendedItems];
-    
+
     // Check if token count exceeds the threshold (95% of MAX_INPUT_TOKEN)
     const tokenThreshold = MAX_INPUT_TOKEN * 0.95;
     const totalBeforeFiltering = items.reduce((sum: number, item) => sum + item.tokenCount, 0);
-    
+
     let result;
     if (totalBeforeFiltering > tokenThreshold) {
       // Apply middle out filtering if token count exceeds threshold
-      console.log(`Applying middle-out during agent turn. Total tokens: ${totalBeforeFiltering}, threshold: ${tokenThreshold}`);
+      console.log(
+        `Applying middle-out during agent turn. Total tokens: ${totalBeforeFiltering}, threshold: ${tokenThreshold}`
+      );
       result = await middleOutFiltering(items);
     } else {
       // Otherwise use noOpFiltering as before
       result = await noOpFiltering(items);
     }
-    
+
     const { totalTokenCount, messages } = result;
     secondCachePoint = messages.length - 1;
     [...new Set([firstCachePoint, secondCachePoint])].forEach((cp) => {

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -223,6 +223,9 @@ Users will primarily request software engineering assistance including bug fixes
         `Applying middle-out during agent turn. Total tokens: ${totalBeforeFiltering}, threshold: ${tokenThreshold}`
       );
       result = await middleOutFiltering(items);
+      // cache was purged anyway after middle-out
+      firstCachePoint = result.messages.length - 1;
+      secondCachePoint = firstCachePoint;
     } else {
       // Otherwise use noOpFiltering as before
       result = await noOpFiltering(items);

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -200,10 +200,6 @@ Users will primarily request software engineering assistance including bug fixes
     ],
   };
 
-  // We would use model-specific tokens here, but for now we'll use a default value
-  const maxInputTokens = 200000; // Default to 200k tokens
-  const middleOutMaxTokens = maxInputTokens * 0.4; // Use 40% of max input tokens as specified
-
   const { items: initialItems } = await middleOutFiltering(allItems);
   // usually cache was created with the last user message (including toolResult), so try to get at(-3) here.
   // at(-1) is usually the latest user message received, at(-2) is usually the last assistant output
@@ -217,7 +213,7 @@ Users will primarily request software engineering assistance including bug fixes
     const items = [...initialItems, ...appendedItems];
 
     // Check if token count exceeds the threshold (95% of maxInputTokens)
-    const tokenThreshold = maxInputTokens * 0.95;
+    const tokenThreshold = 190_000; // TODO: use model specific parameters
     const totalBeforeFiltering = items.reduce((sum: number, item) => sum + item.tokenCount, 0);
 
     let result;


### PR DESCRIPTION
## Description

This PR addresses issue #148 by implementing middle out filtering during the agent's turn when the token count exceeds a threshold (95% of MAX_INPUT_TOKEN).

Currently, middle out filtering is only applied when starting an agent's turn, but it might lead to max token exceeded error when a turn continues for a long time. This change applies middle out even in the middle of a turn when token count exceeds the threshold.

## Changes Made

- Added a token threshold check inside the while loop in agent/index.ts
- Applied middle out filtering when the token count exceeds 95% of MAX_INPUT_TOKEN
- Added more descriptive logging when middle out is applied during agent's turn

Fixes #148