### PR TITLE
Fix message event handler to process messages with image attachments

### DIFF
--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -388,7 +388,7 @@ app.event('message', async ({ event, client, logger }) => {
   }
 
   // Skip if message mentions this bot (will be handled by app_mention)
-  if (botId && messageEvent.text.includes(`<@${botId}>`)) {
+  if (botId && messageEvent.text && messageEvent.text.includes(`<@${botId}>`)) {
     console.log('Message contains mention to this bot, skipping to avoid duplication');
     return;
   }

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -397,7 +397,7 @@ app.event('message', async ({ event, client, logger }) => {
   const safeEvent = {
     ...messageEvent,
     // Ensure text is always a string (fallback to empty string if undefined)
-    text: messageEvent.text || "",
+    text: messageEvent.text || '',
   };
 
   // Process thread replies

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -372,8 +372,18 @@ app.event('message', async ({ event, client, logger }) => {
     files?: any[];
   };
 
-  // Skip if message has no text, is from a bot, or has a subtype
-  if (!messageEvent.text || messageEvent.bot_id || messageEvent.subtype) {
+  // Skip if from a bot
+  if (messageEvent.bot_id) {
+    return;
+  }
+
+  // Skip if no text AND no files (empty message)
+  if (!messageEvent.text && !messageEvent.files?.length) {
+    return;
+  }
+
+  // Skip certain subtypes but allow those with files
+  if (messageEvent.subtype && !messageEvent.files?.length) {
     return;
   }
 

--- a/packages/slack-bolt-app/src/app.ts
+++ b/packages/slack-bolt-app/src/app.ts
@@ -396,7 +396,8 @@ app.event('message', async ({ event, client, logger }) => {
   // Create event object with guaranteed non-undefined text property
   const safeEvent = {
     ...messageEvent,
-    text: messageEvent.text,
+    // Ensure text is always a string (fallback to empty string if undefined)
+    text: messageEvent.text || "",
   };
 
   // Process thread replies


### PR DESCRIPTION
## Problem
In the current implementation, message events with image attachments are not being processed because the code skips messages with a subtype (which include messages with file attachments).

## Solution
This PR modifies the message event handler to:
1. Separate the bot message check from other conditions
2. Only skip messages that have no text AND no files
3. Allow messages with subtypes if they contain files

This ensures that the app properly processes messages with image attachments while still filtering out irrelevant messages.