### PR TITLE
Use LSI1 index to sort sessions by createdAt in descending order

### DIFF
--- a/packages/agent-core/src/lib/sessions.ts
+++ b/packages/agent-core/src/lib/sessions.ts
@@ -60,11 +60,12 @@ export const getSessions = async (): Promise<SessionItem[]> => {
   const res = await ddb.send(
     new QueryCommand({
       TableName,
+      IndexName: 'LSI1',
       KeyConditionExpression: 'PK = :pk',
       ExpressionAttributeValues: {
         ':pk': 'sessions',
       },
-      ScanIndexForward: false,
+      ScanIndexForward: false, // DESC order
       Limit: 50,
     })
   );


### PR DESCRIPTION
This PR modifies the getSessions function to use the LSI1 index for time-based sorting of sessions.\n\n- Added IndexName: 'LSI1' to the DynamoDB QueryCommand\n- The LSI1 index contains the createdAt timestamp in string format\n- ScanIndexForward: false ensures descending order (newest first)