### PR TITLE
Add PR guidelines to root AmazonQ.md

### DIFF
--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -103,6 +103,11 @@ cd packages/webapp && npm run build
 4. Create a PR and ensure CI passes. The PR title and description must always written in English.
 5. Request review when the PR is ready (i.e. when you implemented all the requested features and all the CI passes.)
 
+## PR Guidelines
+
+- **Always create PRs against the upstream repository**: When making changes, ensure that your Pull Requests are created against the original repository (`aws-samples/remote-swe-agents`), not your personal fork.
+- **Use descriptive PR titles**: PR titles and descriptions should clearly explain the changes and must be written in English.
+
 ## Troubleshooting
 
 - **Build errors**: Check that dependencies are up to date (`npm ci` to update)


### PR DESCRIPTION
Add clear guidelines to the root AmazonQ.md file specifying that PRs should always be created against the upstream repository (aws-samples/remote-swe-agents) rather than personal forks.