### PR TITLE
Fix tool JSON toggle button behavior

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -200,9 +200,9 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
             {getToolIcon(toolName)}
             <button
               onClick={() => {
-                // If either one is visible, hide both. Otherwise, don't change anything.
+                // If either one is visible, hide both. Otherwise, show both.
                 if (visibleInputJsonMessages.has(messageId) || visibleOutputJsonMessages.has(messageId)) {
-                  // Create new sets without this messageId
+                  // Create new sets without this messageId (hide both)
                   setVisibleInputJsonMessages((prev) => {
                     const newSet = new Set(prev);
                     newSet.delete(messageId);
@@ -211,6 +211,18 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                   setVisibleOutputJsonMessages((prev) => {
                     const newSet = new Set(prev);
                     newSet.delete(messageId);
+                    return newSet;
+                  });
+                } else {
+                  // Both are hidden, so show both
+                  setVisibleInputJsonMessages((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.add(messageId);
+                    return newSet;
+                  });
+                  setVisibleOutputJsonMessages((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.add(messageId);
                     return newSet;
                   });
                 }

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -200,9 +200,8 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
             {getToolIcon(toolName)}
             <button
               onClick={() => {
-                // If either one is visible, hide both. Otherwise, show both.
+                // If either one is visible, hide both. Otherwise, usual toggle behavior.
                 if (visibleInputJsonMessages.has(messageId) || visibleOutputJsonMessages.has(messageId)) {
-                  // Create new sets without this messageId (hide both)
                   setVisibleInputJsonMessages((prev) => {
                     const newSet = new Set(prev);
                     newSet.delete(messageId);
@@ -214,17 +213,8 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
                     return newSet;
                   });
                 } else {
-                  // Both are hidden, so show both
-                  setVisibleInputJsonMessages((prev) => {
-                    const newSet = new Set(prev);
-                    newSet.add(messageId);
-                    return newSet;
-                  });
-                  setVisibleOutputJsonMessages((prev) => {
-                    const newSet = new Set(prev);
-                    newSet.add(messageId);
-                    return newSet;
-                  });
+                  toggleInputJsonVisibility(messageId);
+                  toggleOutputJsonVisibility(messageId);
                 }
               }}
               className="text-gray-600 dark:text-gray-400 hover:underline cursor-pointer"

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -200,8 +200,20 @@ export default function MessageList({ messages, isAgentTyping, instanceStatus }:
             {getToolIcon(toolName)}
             <button
               onClick={() => {
-                toggleInputJsonVisibility(messageId);
-                toggleOutputJsonVisibility(messageId);
+                // If either one is visible, hide both. Otherwise, don't change anything.
+                if (visibleInputJsonMessages.has(messageId) || visibleOutputJsonMessages.has(messageId)) {
+                  // Create new sets without this messageId
+                  setVisibleInputJsonMessages((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.delete(messageId);
+                    return newSet;
+                  });
+                  setVisibleOutputJsonMessages((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.delete(messageId);
+                    return newSet;
+                  });
+                }
               }}
               className="text-gray-600 dark:text-gray-400 hover:underline cursor-pointer"
             >


### PR DESCRIPTION
## Description

This PR fixes the behavior of the tool name button in MessageList.tsx when toggling JSON visibility. 

### Current behavior
- Clicking the tool name button simply toggles both input and output JSON visibility states.

### New behavior
- If either input or output JSON is visible (true), clicking the tool name button will hide both (set both to false).
- If both are already hidden, the button does nothing.

This makes the UI behavior more intuitive when users want to collapse all JSON panels with a single click.