### PR TITLE
Fix header responsiveness on mobile devices

### DIFF
--- a/packages/webapp/src/components/Header.tsx
+++ b/packages/webapp/src/components/Header.tsx
@@ -26,15 +26,15 @@ export default function Header() {
   const { localeOptions, currentLocale, changeLocale } = useLanguageSwitcher();
 
   return (
-    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16 items-center">
-          <div className="flex-shrink-0">
-            <Link href="/" className="text-xl font-bold text-gray-900 dark:text-white">
+    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm w-full">
+      <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8 w-full">
+        <div className="flex justify-between h-16 items-center w-full">
+          <div className="flex-shrink-0 min-w-0">
+            <Link href="/" className="text-xl font-bold text-gray-900 dark:text-white truncate">
               {t('title')}
             </Link>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 sm:gap-2">
             <ThemeToggle />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -42,7 +42,7 @@ export default function Header() {
                   <Menu className="h-5 w-5" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuContent align="end" className="w-56 z-50">
                 <DropdownMenuLabel>{t('menu')}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
 


### PR DESCRIPTION
## 概要
モバイルデバイスでヘッダーの表示が崩れる問題を修正しました。

## 変更内容
- ヘッダーに  を追加して幅を100%に設定
- コンテナにも  を追加してコンテンツがはみ出さないように調整
- モバイル表示時の余白を調整（ に変更）
- ドロップダウンメニューに  を追加して表示問題を修正
- 要素間の間隔をモバイル向けに調整（）
- タイトルに  クラスを追加し、スペースが狭い場合に省略されるようにしました

これらの変更により、モバイル表示時のレイアウト崩れが解消されます。