### PR TITLE
Improve mobile layout by showing only icons on small screens

### DIFF
--- a/packages/webapp/src/app/(root)/page.tsx
+++ b/packages/webapp/src/app/(root)/page.tsx
@@ -29,7 +29,7 @@ export default async function Home() {
               <Link href="/sessions/new">
                 <Button variant="outline" size="lg" className="flex items-center gap-2">
                   <Zap className="w-5 h-5" />
-                  {sessionsT('newSession')}
+                  <span className="hidden sm:inline">{sessionsT('newSession')}</span>
                 </Button>
               </Link>
             </div>

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -124,7 +124,7 @@ export default function SessionPageClient({
                 className="inline-flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
               >
                 <ArrowLeft className="w-4 h-4" />
-                {t('sessionList')}
+                <span className="hidden sm:inline">{t('sessionList')}</span>
               </Link>
               <h1 className="text-lg font-semibold text-gray-900 dark:text-white">{workerId}</h1>
               {instanceStatus && (
@@ -155,16 +155,22 @@ export default function SessionPageClient({
                   className="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
                   title={showTodoModal ? t('hideTodoList') : t('showTodoList')}
                 >
-                  <ListChecks className="h-4 w-4 mr-2" />
-                  {t('todoList')} ({todoList.items.filter((item) => item.status === 'completed').length}/
-                  {todoList.items.length})
+                  <ListChecks className="h-4 w-4 sm:mr-2" />
+                  <span className="hidden sm:inline">
+                    {t('todoList')} ({todoList.items.filter((item) => item.status === 'completed').length}/
+                    {todoList.items.length})
+                  </span>
+                  <span className="inline sm:hidden">
+                    {todoList.items.filter((item) => item.status === 'completed').length}/{todoList.items.length}
+                  </span>
                 </button>
               )}
               <Link
                 href="/sessions/new"
                 className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
-                {t('newSession')}
+                <Plus className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">{t('newSession')}</span>
               </Link>
             </div>
           </div>

--- a/packages/webapp/src/app/sessions/page.tsx
+++ b/packages/webapp/src/app/sessions/page.tsx
@@ -22,7 +22,7 @@ export default async function SessionsPage() {
             <Link href="/sessions/new">
               <Button className="flex items-center gap-2">
                 <Plus className="w-4 h-4" />
-                {t('newSession')}
+                <span className="hidden sm:inline">{t('newSession')}</span>
               </Button>
             </Link>
           </div>
@@ -85,7 +85,7 @@ export default async function SessionsPage() {
               <Link href="/sessions/new">
                 <Button>
                   <Plus className="w-4 h-4 mr-2" />
-                  {t('newSession')}
+                  <span className="hidden sm:inline">{t('newSession')}</span>
                 </Button>
               </Link>
             </div>

--- a/packages/webapp/src/components/Header.tsx
+++ b/packages/webapp/src/components/Header.tsx
@@ -26,15 +26,15 @@ export default function Header() {
   const { localeOptions, currentLocale, changeLocale } = useLanguageSwitcher();
 
   return (
-    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16 items-center">
-          <div className="flex-shrink-0">
-            <Link href="/" className="text-xl font-bold text-gray-900 dark:text-white">
+    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm w-full">
+      <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8 w-full">
+        <div className="flex justify-between h-16 items-center w-full">
+          <div className="flex-shrink-0 min-w-0">
+            <Link href="/" className="text-xl font-bold text-gray-900 dark:text-white truncate">
               {t('title')}
             </Link>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 sm:gap-2">
             <ThemeToggle />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -42,7 +42,7 @@ export default function Header() {
                   <Menu className="h-5 w-5" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuContent align="end" className="w-56 z-50">
                 <DropdownMenuLabel>{t('menu')}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
 


### PR DESCRIPTION
## Overview
This PR improves the mobile layout by showing only icons instead of full text for buttons on small screens.

## Changes
- Modified "New Session" buttons to show only '+' icon on mobile devices
- Changed Todo List button to show only the icon and completion count on mobile
- Modified Session List link to show only back arrow on mobile
- Used responsive classes to show/hide text content based on screen size:
  -  for text that should only appear on desktop
  -  for elements that should only appear on mobile

This prevents UI elements from overflowing on small screens while maintaining full functionality.