### PR TITLE
Disable message sending during image upload

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -54,7 +54,7 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
   const message = watch('message');
 
   const enterPost: KeyboardEventHandler = (keyEvent) => {
-    if (isExecuting) return;
+    if (isExecuting || uploadingImages.some(img => !img.key)) return;
     if (keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.altKey)) {
       handleSubmitWithAction();
     }
@@ -76,10 +76,10 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
           <div className="flex gap-4">
             <textarea
               {...register('message')}
-              placeholder={t('enterYourMessage')}
+              placeholder={uploadingImages.some(img => !img.key) ? t('waitingForImageUpload') : t('enterYourMessage')}
               className="flex-1 resize-none border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               rows={3}
-              disabled={isExecuting}
+              disabled={isExecuting || uploadingImages.some(img => !img.key)}
               onKeyDown={enterPost}
               onPaste={handlePaste}
             />
@@ -87,8 +87,14 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
               <Button type="button" onClick={handleImageSelect} disabled={isExecuting} size="icon" variant="outline">
                 <ImageIcon className="w-4 h-4" />
               </Button>
-              <Button type="submit" disabled={!message.trim() || isExecuting} size="icon">
-                {isExecuting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+              <Button type="submit" disabled={!message.trim() || isExecuting || uploadingImages.some(img => !img.key)} size="icon">
+                {isExecuting ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : uploadingImages.some(img => !img.key) ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Send className="w-4 h-4" />
+                )}
               </Button>
             </div>
           </div>

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -54,7 +54,7 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
   const message = watch('message');
 
   const enterPost: KeyboardEventHandler = (keyEvent) => {
-    if (isExecuting || uploadingImages.some(img => !img.key)) return;
+    if (isExecuting || uploadingImages.some((img) => !img.key)) return;
     if (keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.altKey)) {
       handleSubmitWithAction();
     }
@@ -76,10 +76,10 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
           <div className="flex gap-4">
             <textarea
               {...register('message')}
-              placeholder={uploadingImages.some(img => !img.key) ? t('waitingForImageUpload') : t('enterYourMessage')}
+              placeholder={uploadingImages.some((img) => !img.key) ? t('waitingForImageUpload') : t('enterYourMessage')}
               className="flex-1 resize-none border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               rows={3}
-              disabled={isExecuting || uploadingImages.some(img => !img.key)}
+              disabled={isExecuting || uploadingImages.some((img) => !img.key)}
               onKeyDown={enterPost}
               onPaste={handlePaste}
             />
@@ -87,10 +87,14 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
               <Button type="button" onClick={handleImageSelect} disabled={isExecuting} size="icon" variant="outline">
                 <ImageIcon className="w-4 h-4" />
               </Button>
-              <Button type="submit" disabled={!message.trim() || isExecuting || uploadingImages.some(img => !img.key)} size="icon">
+              <Button
+                type="submit"
+                disabled={!message.trim() || isExecuting || uploadingImages.some((img) => !img.key)}
+                size="icon"
+              >
                 {isExecuting ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
-                ) : uploadingImages.some(img => !img.key) ? (
+                ) : uploadingImages.some((img) => !img.key) ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
                 ) : (
                   <Send className="w-4 h-4" />

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -54,7 +54,7 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
   const message = watch('message');
 
   const enterPost: KeyboardEventHandler = (keyEvent) => {
-    if (isExecuting || uploadingImages.some((img) => !img.key)) return;
+    if (isExecuting || isUploading) return;
     if (keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.altKey)) {
       handleSubmitWithAction();
     }
@@ -67,6 +67,8 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
     },
   });
 
+  const isUploading = uploadingImages.some((img) => !img.key);
+
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
       <div className="max-w-4xl mx-auto px-4 py-4">
@@ -76,10 +78,10 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
           <div className="flex gap-4">
             <textarea
               {...register('message')}
-              placeholder={uploadingImages.some((img) => !img.key) ? t('waitingForImageUpload') : t('enterYourMessage')}
+              placeholder={isUploading ? t('waitingForImageUpload') : t('enterYourMessage')}
               className="flex-1 resize-none border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               rows={3}
-              disabled={isExecuting || uploadingImages.some((img) => !img.key)}
+              disabled={isExecuting || isUploading}
               onKeyDown={enterPost}
               onPaste={handlePaste}
             />
@@ -87,14 +89,10 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
               <Button type="button" onClick={handleImageSelect} disabled={isExecuting} size="icon" variant="outline">
                 <ImageIcon className="w-4 h-4" />
               </Button>
-              <Button
-                type="submit"
-                disabled={!message.trim() || isExecuting || uploadingImages.some((img) => !img.key)}
-                size="icon"
-              >
+              <Button type="submit" disabled={!message.trim() || isExecuting || isUploading} size="icon">
                 {isExecuting ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
-                ) : uploadingImages.some((img) => !img.key) ? (
+                ) : isUploading ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
                 ) : (
                   <Send className="w-4 h-4" />

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -48,6 +48,8 @@ export default function NewSessionPage() {
       },
     });
 
+  const isUploading = uploadingImages.some((img) => !img.key);
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       <Header />
@@ -112,7 +114,7 @@ export default function NewSessionPage() {
                       placeholder={t('placeholder')}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
                       rows={4}
-                      disabled={isExecuting || uploadingImages.some((img) => !img.key)}
+                      disabled={isExecuting || isUploading}
                       onPaste={handlePaste}
                       onKeyDown={(e) => {
                         if (
@@ -120,7 +122,7 @@ export default function NewSessionPage() {
                           (e.ctrlKey || e.altKey) &&
                           !isExecuting &&
                           formState.isValid &&
-                          !uploadingImages.some((img) => !img.key)
+                          !isUploading
                         ) {
                           handleSubmitWithAction();
                         }
@@ -132,13 +134,13 @@ export default function NewSessionPage() {
                   </div>
                   <Button
                     type="submit"
-                    disabled={isExecuting || !formState.isValid || uploadingImages.some((img) => !img.key)}
+                    disabled={isExecuting || !formState.isValid || isUploading}
                     className="w-full"
                     size="lg"
                   >
                     {isExecuting
                       ? t('creatingSession')
-                      : uploadingImages.some((img) => !img.key)
+                      : isUploading
                         ? t('waitingForImageUpload')
                         : t('createSessionButton')}
                   </Button>

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -112,10 +112,16 @@ export default function NewSessionPage() {
                       placeholder={t('placeholder')}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
                       rows={4}
-                      disabled={isExecuting || uploadingImages.some(img => !img.key)}
+                      disabled={isExecuting || uploadingImages.some((img) => !img.key)}
                       onPaste={handlePaste}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' && (e.ctrlKey || e.altKey) && !isExecuting && formState.isValid && !uploadingImages.some(img => !img.key)) {
+                        if (
+                          e.key === 'Enter' &&
+                          (e.ctrlKey || e.altKey) &&
+                          !isExecuting &&
+                          formState.isValid &&
+                          !uploadingImages.some((img) => !img.key)
+                        ) {
                           handleSubmitWithAction();
                         }
                       }}
@@ -124,18 +130,17 @@ export default function NewSessionPage() {
                       <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.message.message}</p>
                     )}
                   </div>
-                  <Button 
-                    type="submit" 
-                    disabled={isExecuting || !formState.isValid || uploadingImages.some(img => !img.key)} 
-                    className="w-full" 
+                  <Button
+                    type="submit"
+                    disabled={isExecuting || !formState.isValid || uploadingImages.some((img) => !img.key)}
+                    className="w-full"
                     size="lg"
                   >
-                    {isExecuting 
-                      ? t('creatingSession') 
-                      : uploadingImages.some(img => !img.key)
+                    {isExecuting
+                      ? t('creatingSession')
+                      : uploadingImages.some((img) => !img.key)
                         ? t('waitingForImageUpload')
-                        : t('createSessionButton')
-                    }
+                        : t('createSessionButton')}
                   </Button>
                 </form>
               </div>

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -112,10 +112,10 @@ export default function NewSessionPage() {
                       placeholder={t('placeholder')}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
                       rows={4}
-                      disabled={isExecuting}
+                      disabled={isExecuting || uploadingImages.some(img => !img.key)}
                       onPaste={handlePaste}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' && (e.ctrlKey || e.altKey) && !isExecuting && formState.isValid) {
+                        if (e.key === 'Enter' && (e.ctrlKey || e.altKey) && !isExecuting && formState.isValid && !uploadingImages.some(img => !img.key)) {
                           handleSubmitWithAction();
                         }
                       }}
@@ -124,8 +124,18 @@ export default function NewSessionPage() {
                       <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.message.message}</p>
                     )}
                   </div>
-                  <Button type="submit" disabled={isExecuting || !formState.isValid} className="w-full" size="lg">
-                    {isExecuting ? t('creatingSession') : t('createSessionButton')}
+                  <Button 
+                    type="submit" 
+                    disabled={isExecuting || !formState.isValid || uploadingImages.some(img => !img.key)} 
+                    className="w-full" 
+                    size="lg"
+                  >
+                    {isExecuting 
+                      ? t('creatingSession') 
+                      : uploadingImages.some(img => !img.key)
+                        ? t('waitingForImageUpload')
+                        : t('createSessionButton')
+                    }
                   </Button>
                 </form>
               </div>

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -44,6 +44,7 @@
     "agentStartingMessage": "The AI agent is starting up. This may take up to 2 minutes. Please wait...",
     "aiAgentResponding": "AI Agent is responding...",
     "enterYourMessage": "Enter your message...",
+    "waitingForImageUpload": "Waiting for image upload...",
     "noSessionsFound": "No sessions found",
     "createSessionToStart": "Create a new session to start chatting with AI agents",
     "usingTool": "Using Tool",
@@ -95,6 +96,7 @@
     "creatingSession": "Creating Session...",
     "createSessionButton": "Create Session & Start Conversation",
     "addImage": "Add Image",
-    "imagesCount": "{count} images"
+    "imagesCount": "{count} images",
+    "waitingForImageUpload": "Waiting for image upload..."
   }
 }

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -44,6 +44,7 @@
     "agentStartingMessage": "AIエージェントが起動中です。最大で2分ほどかかる場合があります。しばらくお待ちください...",
     "aiAgentResponding": "AIエージェントが応答中...",
     "enterYourMessage": "メッセージを入力...",
+    "waitingForImageUpload": "画像アップロード中...",
     "noSessionsFound": "セッションが見つかりません",
     "createSessionToStart": "AIエージェントとチャットするには新規セッションを作成してください",
     "usingTool": "ツール使用",
@@ -95,6 +96,7 @@
     "creatingSession": "セッション作成中...",
     "createSessionButton": "セッションを作成して会話を開始",
     "addImage": "画像を追加",
-    "imagesCount": "{count} 枚の画像"
+    "imagesCount": "{count} 枚の画像",
+    "waitingForImageUpload": "画像アップロード中..."
   }
 }


### PR DESCRIPTION
# Disable message sending during image upload

## Summary

This PR implements functionality to disable message sending while images are being uploaded.

## Changes

### sessions/new page:
- Disable textarea during image upload
- Disable submit button during image upload and change text to "Waiting for image upload..."
- Disable keyboard shortcut (Enter) for sending messages during image upload

### sessions/[workerId] page:
- Disable textarea during image upload and update placeholder text to "Waiting for image upload..."
- Disable send button and change icon to loading indicator during image upload
- Disable keyboard shortcut (Enter) for sending messages during image upload

## Testing

1. Access the sessions/new page and upload an image
2. Verify that the textarea and submit button are disabled during upload
3. Access the sessions/[workerId] page and upload an image
4. Verify that the textarea and send button are disabled during upload