### PR TITLE
Filter out Slack mention strings from messages

### DIFF
--- a/packages/webapp/src/utils/message-formatter.ts
+++ b/packages/webapp/src/utils/message-formatter.ts
@@ -1,0 +1,27 @@
+/**
+ * Utility functions for formatting and cleaning message content
+ */
+
+/**
+ * Removes Slack mention strings (e.g. <@U07UDD582EA>) from a message
+ * If the resulting string is empty (or only whitespace), returns null
+ * 
+ * @param message The message content to process
+ * @returns The cleaned message or null if empty
+ */
+export function removeSlackMentions(message: string): string | null {
+  if (!message) return null;
+  
+  // Regular expression to match Slack mention format: <@USERID>
+  const mentionRegex = /<@[A-Z0-9]+>/g;
+  
+  // Remove all Slack mentions
+  const cleanedMessage = message.replace(mentionRegex, '');
+  
+  // Check if the resulting string is empty or only contains whitespace
+  if (!cleanedMessage.trim()) {
+    return null;
+  }
+  
+  return cleanedMessage;
+}


### PR DESCRIPTION
This PR adds functionality to filter out Slack mention strings (like <@U07UDD582EA>) from messages in the webapp.

Changes:
- Created a utility function 'removeSlackMentions' that uses regex to filter out Slack mention strings
- Updated MessageList.tsx to use this utility function when rendering messages
- Updated SessionPageClient.tsx to filter messages from both DB and real-time events
- When a message contains only Slack mentions and becomes empty after filtering, it will be ignored

The implementation ensures that both messages loaded from the database and those coming in real-time through events are properly filtered.