### PR TITLE
(worker): generate a title for each session when starting a conversation

### DIFF
--- a/packages/agent-core/src/lib/sessions.ts
+++ b/packages/agent-core/src/lib/sessions.ts
@@ -2,7 +2,7 @@ import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/li
 import { ddb, TableName } from './aws';
 
 import { AgentStatus, SessionItem } from '../schema';
-import { bedrockConverse } from './bedrock';
+import { bedrockConverse } from './converse';
 
 export const saveSessionInfo = async (workerId: string, initialMessage: string) => {
   const now = Date.now();
@@ -114,7 +114,7 @@ Important: The title must be 10 characters or fewer. Do not include any explanat
     });
 
     const title = res.output?.message?.content?.at(0)?.text?.trim() || 'New Chat';
-    
+
     // Ensure the title is not longer than 10 characters
     return title.length > 10 ? title.substring(0, 10) : title;
   } catch (error) {

--- a/packages/agent-core/src/schema/session.ts
+++ b/packages/agent-core/src/schema/session.ts
@@ -20,4 +20,5 @@ export const sessionItemSchema = z.object({
   instanceStatus: instanceStatusSchema,
   sessionCost: z.number(),
   agentStatus: agentStatusSchema,
+  generatedTitle: z.string().optional(),
 });

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -57,7 +57,7 @@ export const onMessageReceived = async (workerId: string, cancellationToken: Can
     { retries: 5, minTimeout: 100, maxTimeout: 1000 }
   );
   if (!allItems) return;
-  
+
   // Generate session title if this is the first user message
   if (allItems.length === 1 && allItems[0].messageType === 'userMessage') {
     try {


### PR DESCRIPTION
## Related Issue
Closes aws-samples/remote-swe-agents#185

## Description
This PR implements session title generation when starting a new conversation.

## Changes
- Add `generatedTitle` field to SessionItem schema
- Implement `generateSessionTitle` function using Bedrock Claude Haiku model
- Implement `saveSessionTitle` function to save title to DynamoDB
- Update `onMessageReceived` to generate title for the first user message

## Implementation details
- Title is generated only for the first user message in a session
- Title is limited to a maximum of 10 characters as per requirements
- Default title is 'New Chat' if generation fails