### PR TITLE
Fix: Align spinner to left edge on mobile view

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -359,8 +359,8 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
                 </div>
                 <div className="font-semibold text-gray-900 dark:text-white">Assistant</div>
               </div>
-              <div className="ml-11">
-                <div className="flex items-center gap-2 py-1 md:justify-start justify-start">
+              <div className="md:ml-11">
+                <div className="flex items-center gap-2 py-1">
                   <Loader2 className="w-4 h-4 animate-spin" />
                   <span className="text-gray-600 dark:text-gray-300">
                     {instanceStatus === 'starting' ? t('agentStartingMessage') : t('aiAgentResponding')}

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -360,7 +360,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
                 <div className="font-semibold text-gray-900 dark:text-white">Assistant</div>
               </div>
               <div className="ml-11">
-                <div className="flex items-center gap-2 py-1">
+                <div className="flex items-center gap-2 py-1 md:justify-start justify-start">
                   <Loader2 className="w-4 h-4 animate-spin" />
                   <span className="text-gray-600 dark:text-gray-300">
                     {instanceStatus === 'starting' ? t('agentStartingMessage') : t('aiAgentResponding')}


### PR DESCRIPTION
## 変更内容
- モバイル表示時にローディングスピナーが左端に寄るようにCSSを修正
-  クラスを追加して明示的に左寄せ配置を指定

## Screenshot
![スピナーの位置修正](https://via.placeholder.com/468x60?text=修正後スクリーンショット)