### PR TITLE
Fix: Use resolvedTheme to apply correct syntax highlighting in dark mode on mobile

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -33,7 +33,7 @@ type MessageListProps = {
 };
 
 export default function MessageList({ messages, instanceStatus, agentStatus }: MessageListProps) {
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
   const t = useTranslations('sessions');
   const locale = useLocale();
   const localeForDate = locale === 'ja' ? 'ja-JP' : 'en-US';
@@ -128,7 +128,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
           const isInline = !match;
           return !isInline ? (
             <SyntaxHighlighter
-              style={theme === 'dark' ? oneDark : oneLight}
+              style={(theme === 'dark' || resolvedTheme === 'dark') ? oneDark : oneLight}
               lineProps={{ style: { wordBreak: 'break-word', whiteSpace: 'pre-wrap' } }}
               language={match[1]}
               PreTag="div"

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -128,7 +128,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
           const isInline = !match;
           return !isInline ? (
             <SyntaxHighlighter
-              style={(theme === 'dark' || resolvedTheme === 'dark') ? oneDark : oneLight}
+              style={theme === 'dark' || resolvedTheme === 'dark' ? oneDark : oneLight}
               lineProps={{ style: { wordBreak: 'break-word', whiteSpace: 'pre-wrap' } }}
               language={match[1]}
               PreTag="div"

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -128,7 +128,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
           const isInline = !match;
           return !isInline ? (
             <SyntaxHighlighter
-              style={theme === 'dark' || resolvedTheme === 'dark' ? oneDark : oneLight}
+              style={resolvedTheme === 'dark' ? oneDark : oneLight}
               lineProps={{ style: { wordBreak: 'break-word', whiteSpace: 'pre-wrap' } }}
               language={match[1]}
               PreTag="div"


### PR DESCRIPTION
## Description

This PR fixes a bug where syntax highlighting appears in light mode on mobile devices even when the system theme is set to dark mode.

### Issue Details
- When the theme is set to "system" (following system preferences) and the device is using dark mode, syntax highlighting still shows in light mode on mobile devices

### Solution
- Modified the useTheme hook to retrieve resolvedTheme in addition to theme
- Updated the syntax highlighter style selection logic to use only the resolvedTheme value to determine whether to apply dark theme styling

### Testing
- Verified that syntax highlighting correctly displays in dark theme when the system is set to dark mode on mobile devices