### PR TITLE
(webapp): add a page for cost analysis

### DIFF
--- a/packages/webapp/src/app/cost/actions.ts
+++ b/packages/webapp/src/app/cost/actions.ts
@@ -1,0 +1,150 @@
+'use server';
+
+import { authActionClient } from '@/lib/safe-action';
+import { fetchCostDataSchema } from './schemas';
+import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
+import { calculateCost, getSessions } from '@remote-swe-agents/agent-core/lib';
+import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+// Function to fetch all token usage data from DynamoDB
+export const fetchCostDataAction = authActionClient
+  .schema(fetchCostDataSchema)
+  .action(async ({ parsedInput: { startDate, endDate } }) => {
+    try {
+      // Get all sessions
+      const sessions = await getSessions();
+      
+      // Filter sessions by date if specified
+      let filteredSessions = sessions;
+      if (startDate && endDate) {
+        filteredSessions = sessions.filter(
+          session => session.createdAt >= startDate && session.createdAt <= endDate
+        );
+      } else if (startDate) {
+        filteredSessions = sessions.filter(session => session.createdAt >= startDate);
+      } else if (endDate) {
+        filteredSessions = sessions.filter(session => session.createdAt <= endDate);
+      }
+
+      // Array to hold token usage data for all sessions
+      const allTokenUsageData = [];
+      let totalCost = 0;
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
+      let totalCacheReadTokens = 0;
+      let totalCacheWriteTokens = 0;
+
+      // For each session, fetch token usage data
+      for (const session of filteredSessions) {
+        const { workerId } = session;
+        
+        // Query token usage records for this session
+        const result = await ddb.send(
+          new QueryCommand({
+            TableName,
+            KeyConditionExpression: 'PK = :pk',
+            ExpressionAttributeValues: {
+              ':pk': `token-${workerId}`,
+            },
+          })
+        );
+
+        const items = result.Items || [];
+        
+        // Process each token usage record
+        for (const item of items) {
+          const modelId = item.SK; // model ID is stored in SK
+          const inputTokens = item.inputToken || 0;
+          const outputTokens = item.outputToken || 0;
+          const cacheReadTokens = item.cacheReadInputTokens || 0;
+          const cacheWriteTokens = item.cacheWriteInputTokens || 0;
+
+          // Calculate cost for this model usage
+          const modelCost = calculateCost(
+            modelId, 
+            inputTokens, 
+            outputTokens, 
+            cacheReadTokens, 
+            cacheWriteTokens
+          );
+
+          // Add to totals
+          totalInputTokens += inputTokens;
+          totalOutputTokens += outputTokens;
+          totalCacheReadTokens += cacheReadTokens;
+          totalCacheWriteTokens += cacheWriteTokens;
+          totalCost += modelCost;
+
+          // Add model data to the result set
+          allTokenUsageData.push({
+            workerId,
+            sessionDetails: session,
+            modelId,
+            inputTokens,
+            outputTokens,
+            cacheReadTokens,
+            cacheWriteTokens,
+            cost: modelCost,
+            timestamp: session.createdAt,
+          });
+        }
+      }
+
+      // Group data by different dimensions
+      const sessionCosts = filteredSessions.map(session => ({
+        workerId: session.workerId,
+        initialMessage: session.initialMessage,
+        sessionCost: session.sessionCost || 0,
+        createdAt: session.createdAt,
+      }));
+
+      // Group data by model
+      const modelCosts = allTokenUsageData.reduce((acc, item) => {
+        const existingModel = acc.find(model => model.modelId === item.modelId);
+        
+        if (existingModel) {
+          existingModel.inputTokens += item.inputTokens;
+          existingModel.outputTokens += item.outputTokens;
+          existingModel.cacheReadTokens += item.cacheReadTokens;
+          existingModel.cacheWriteTokens += item.cacheWriteTokens;
+          existingModel.totalCost += item.cost;
+        } else {
+          acc.push({
+            modelId: item.modelId,
+            inputTokens: item.inputTokens,
+            outputTokens: item.outputTokens,
+            cacheReadTokens: item.cacheReadTokens,
+            cacheWriteTokens: item.cacheWriteTokens,
+            totalCost: item.cost,
+          });
+        }
+        
+        return acc;
+      }, [] as Array<{
+        modelId: string;
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadTokens: number;
+        cacheWriteTokens: number;
+        totalCost: number;
+      }>);
+
+      return {
+        success: true,
+        totalCost,
+        tokenCounts: {
+          input: totalInputTokens,
+          output: totalOutputTokens,
+          cacheRead: totalCacheReadTokens,
+          cacheWrite: totalCacheWriteTokens,
+          total: totalInputTokens + totalOutputTokens + totalCacheReadTokens + totalCacheWriteTokens,
+        },
+        sessionCosts,
+        modelCosts,
+        rawData: allTokenUsageData,
+      };
+    } catch (error) {
+      console.error('Error fetching cost data:', error);
+      throw new Error('Failed to fetch cost data');
+    }
+  });

--- a/packages/webapp/src/app/cost/components/CostBreakdown.tsx
+++ b/packages/webapp/src/app/cost/components/CostBreakdown.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { MessageSquare, Bot, BarChart } from 'lucide-react';
+import Link from 'next/link';
+
+interface SessionCost {
+  workerId: string;
+  initialMessage?: string;
+  sessionCost: number;
+  createdAt: number;
+}
+
+interface ModelCost {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalCost: number;
+}
+
+interface CostBreakdownProps {
+  sessionCosts: SessionCost[];
+  modelCosts: ModelCost[];
+  t: any; // Translation function
+}
+
+export default function CostBreakdown({ sessionCosts, modelCosts, t }: CostBreakdownProps) {
+  // State for active tab
+  const [activeTab, setActiveTab] = useState<'sessions' | 'models'>('sessions');
+
+  return (
+    <Card className="p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold">{t('costBreakdown')}</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          {t('costBreakdownDescription')}
+        </p>
+      </div>
+
+      {/* Tab navigation */}
+      <div className="flex space-x-2 mb-6">
+        <Button
+          variant={activeTab === 'sessions' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('sessions')}
+          className="flex items-center gap-2"
+        >
+          <MessageSquare className="h-4 w-4" />
+          {t('bySession')}
+        </Button>
+        <Button
+          variant={activeTab === 'models' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('models')}
+          className="flex items-center gap-2"
+        >
+          <Bot className="h-4 w-4" />
+          {t('byModel')}
+        </Button>
+      </div>
+
+      {/* Session costs table */}
+      {activeTab === 'sessions' && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700">
+                <th className="px-4 py-3 text-left">{t('sessionId')}</th>
+                <th className="px-4 py-3 text-left">{t('initialPrompt')}</th>
+                <th className="px-4 py-3 text-left">{t('date')}</th>
+                <th className="px-4 py-3 text-right">{t('cost')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessionCosts.length > 0 ? (
+                sessionCosts
+                  .sort((a, b) => b.sessionCost - a.sessionCost) // Sort by cost descending
+                  .map((session) => (
+                    <tr key={session.workerId} className="border-b border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900">
+                      <td className="px-4 py-3">
+                        <Link 
+                          href={`/sessions/${session.workerId}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline"
+                        >
+                          {session.workerId}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 max-w-[300px] truncate">
+                        {session.initialMessage || t('noMessage')}
+                      </td>
+                      <td className="px-4 py-3">
+                        {new Date(session.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium">
+                        ${session.sessionCost.toFixed(2)}
+                      </td>
+                    </tr>
+                  ))
+              ) : (
+                <tr>
+                  <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                    <BarChart className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                    <p>{t('noSessionData')}</p>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+            <tfoot>
+              <tr className="bg-gray-50 dark:bg-gray-800">
+                <td colSpan={3} className="px-4 py-3 font-medium">{t('total')}</td>
+                <td className="px-4 py-3 text-right font-bold">
+                  ${sessionCosts.reduce((sum, session) => sum + session.sessionCost, 0).toFixed(2)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+
+      {/* Model costs table */}
+      {activeTab === 'models' && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700">
+                <th className="px-4 py-3 text-left">{t('model')}</th>
+                <th className="px-4 py-3 text-right">{t('inputTokens')}</th>
+                <th className="px-4 py-3 text-right">{t('outputTokens')}</th>
+                <th className="px-4 py-3 text-right">{t('cacheTokens')}</th>
+                <th className="px-4 py-3 text-right">{t('cost')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {modelCosts.length > 0 ? (
+                modelCosts
+                  .sort((a, b) => b.totalCost - a.totalCost) // Sort by cost descending
+                  .map((model) => (
+                    <tr key={model.modelId} className="border-b border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900">
+                      <td className="px-4 py-3 font-medium">{model.modelId}</td>
+                      <td className="px-4 py-3 text-right">{model.inputTokens.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-right">{model.outputTokens.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-right">
+                        {(model.cacheReadTokens + model.cacheWriteTokens).toLocaleString()}
+                        <span className="text-xs text-gray-500 ml-1">
+                          (R: {model.cacheReadTokens.toLocaleString()}, W: {model.cacheWriteTokens.toLocaleString()})
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium">
+                        ${model.totalCost.toFixed(2)}
+                      </td>
+                    </tr>
+                  ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                    <Bot className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                    <p>{t('noModelData')}</p>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+            <tfoot>
+              <tr className="bg-gray-50 dark:bg-gray-800">
+                <td className="px-4 py-3 font-medium">{t('total')}</td>
+                <td className="px-4 py-3 text-right font-medium">
+                  {modelCosts.reduce((sum, model) => sum + model.inputTokens, 0).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right font-medium">
+                  {modelCosts.reduce((sum, model) => sum + model.outputTokens, 0).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right font-medium">
+                  {modelCosts
+                    .reduce(
+                      (sum, model) => sum + model.cacheReadTokens + model.cacheWriteTokens, 
+                      0
+                    )
+                    .toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right font-bold">
+                  ${modelCosts.reduce((sum, model) => sum + model.totalCost, 0).toFixed(2)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/webapp/src/app/cost/components/CostSummary.tsx
+++ b/packages/webapp/src/app/cost/components/CostSummary.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { DollarSign, MessageSquare, Zap } from 'lucide-react';
+
+interface TokenCounts {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+}
+
+interface CostSummaryProps {
+  totalCost: number;
+  tokenCounts: TokenCounts;
+  t: any; // Translation function
+}
+
+export default function CostSummary({ totalCost, tokenCounts, t }: CostSummaryProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      {/* Total Cost Card */}
+      <Card className="p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="p-3 rounded-full bg-green-100 dark:bg-green-900">
+            <DollarSign className="h-6 w-6 text-green-600 dark:text-green-300" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{t('totalCost')}</p>
+            <h3 className="text-2xl font-bold">${totalCost.toFixed(2)}</h3>
+          </div>
+        </div>
+      </Card>
+
+      {/* Total Tokens Card */}
+      <Card className="p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="p-3 rounded-full bg-blue-100 dark:bg-blue-900">
+            <MessageSquare className="h-6 w-6 text-blue-600 dark:text-blue-300" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{t('totalTokens')}</p>
+            <h3 className="text-2xl font-bold">{tokenCounts.total.toLocaleString()}</h3>
+          </div>
+        </div>
+      </Card>
+
+      {/* Input/Output Tokens Card */}
+      <Card className="p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="p-3 rounded-full bg-purple-100 dark:bg-purple-900">
+            <Zap className="h-6 w-6 text-purple-600 dark:text-purple-300" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{t('inputOutputTokens')}</p>
+            <div className="flex gap-3">
+              <span className="text-sm">
+                <span className="font-medium">{t('input')}:</span> {tokenCounts.input.toLocaleString()}
+              </span>
+              <span className="text-sm">
+                <span className="font-medium">{t('output')}:</span> {tokenCounts.output.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex gap-3 mt-1">
+              <span className="text-sm">
+                <span className="font-medium">{t('cacheRead')}:</span> {tokenCounts.cacheRead.toLocaleString()}
+              </span>
+              <span className="text-sm">
+                <span className="font-medium">{t('cacheWrite')}:</span> {tokenCounts.cacheWrite.toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* Token Usage Breakdown */}
+      <Card className="p-6 border border-gray-200 dark:border-gray-700 shadow-sm md:col-span-3">
+        <h3 className="text-lg font-semibold mb-4">{t('tokenUsageBreakdown')}</h3>
+        <div className="relative pt-1">
+          <div className="flex mb-2 items-center justify-between">
+            <div>
+              <span className="text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full bg-green-200 text-green-800">
+                {t('input')}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-xs font-semibold inline-block">
+                {((tokenCounts.input / tokenCounts.total) * 100).toFixed(1)}%
+              </span>
+            </div>
+          </div>
+          <div className="overflow-hidden h-2 mb-4 text-xs flex rounded bg-gray-200">
+            <div
+              style={{ width: `${(tokenCounts.input / tokenCounts.total) * 100}%` }}
+              className="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-green-500"
+            ></div>
+          </div>
+          
+          <div className="flex mb-2 items-center justify-between">
+            <div>
+              <span className="text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full bg-blue-200 text-blue-800">
+                {t('output')}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-xs font-semibold inline-block">
+                {((tokenCounts.output / tokenCounts.total) * 100).toFixed(1)}%
+              </span>
+            </div>
+          </div>
+          <div className="overflow-hidden h-2 mb-4 text-xs flex rounded bg-gray-200">
+            <div
+              style={{ width: `${(tokenCounts.output / tokenCounts.total) * 100}%` }}
+              className="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-blue-500"
+            ></div>
+          </div>
+          
+          <div className="flex mb-2 items-center justify-between">
+            <div>
+              <span className="text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full bg-purple-200 text-purple-800">
+                {t('cacheRead')}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-xs font-semibold inline-block">
+                {((tokenCounts.cacheRead / tokenCounts.total) * 100).toFixed(1)}%
+              </span>
+            </div>
+          </div>
+          <div className="overflow-hidden h-2 mb-4 text-xs flex rounded bg-gray-200">
+            <div
+              style={{ width: `${(tokenCounts.cacheRead / tokenCounts.total) * 100}%` }}
+              className="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-purple-500"
+            ></div>
+          </div>
+          
+          <div className="flex mb-2 items-center justify-between">
+            <div>
+              <span className="text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full bg-yellow-200 text-yellow-800">
+                {t('cacheWrite')}
+              </span>
+            </div>
+            <div className="text-right">
+              <span className="text-xs font-semibold inline-block">
+                {((tokenCounts.cacheWrite / tokenCounts.total) * 100).toFixed(1)}%
+              </span>
+            </div>
+          </div>
+          <div className="overflow-hidden h-2 mb-4 text-xs flex rounded bg-gray-200">
+            <div
+              style={{ width: `${(tokenCounts.cacheWrite / tokenCounts.total) * 100}%` }}
+              className="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-yellow-500"
+            ></div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/packages/webapp/src/app/cost/page.tsx
+++ b/packages/webapp/src/app/cost/page.tsx
@@ -1,0 +1,47 @@
+import Header from '@/components/Header';
+import { getTranslations } from 'next-intl/server';
+import { fetchCostDataAction } from './actions';
+import CostSummary from './components/CostSummary';
+import CostBreakdown from './components/CostBreakdown';
+import { RefreshOnFocus } from '@/components/RefreshOnFocus';
+
+export default async function CostAnalysisPage() {
+  // Get translations
+  const t = await getTranslations('cost');
+  
+  // Calculate date range for current month
+  const now = new Date();
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const startDate = startOfMonth.getTime();
+  
+  // Fetch cost data for the current month
+  const costData = await fetchCostDataAction.call({ startDate });
+  
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
+      <Header />
+      <RefreshOnFocus />
+      
+      <main className="flex-grow container max-w-6xl mx-auto px-4 py-6">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold mb-2">{t('title')}</h1>
+          <p className="text-gray-600 dark:text-gray-300">{t('description')}</p>
+        </div>
+        
+        {/* Cost Summary Component */}
+        <CostSummary
+          totalCost={costData.totalCost}
+          tokenCounts={costData.tokenCounts}
+          t={t}
+        />
+        
+        {/* Cost Breakdown Components */}
+        <CostBreakdown
+          sessionCosts={costData.sessionCosts}
+          modelCosts={costData.modelCosts}
+          t={t}
+        />
+      </main>
+    </div>
+  );
+}

--- a/packages/webapp/src/app/cost/schemas.ts
+++ b/packages/webapp/src/app/cost/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+// Schema for cost data fetching
+export const fetchCostDataSchema = z.object({
+  // Optional start date for filtering (timestamp)
+  startDate: z.number().optional(),
+  // Optional end date for filtering (timestamp)
+  endDate: z.number().optional(),
+});
+
+// Schema for model cost breakdown
+export const modelCostSchema = z.object({
+  modelId: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheReadTokens: z.number(),
+  cacheWriteTokens: z.number(),
+  totalCost: z.number(),
+});
+
+// Schema for session cost data
+export const sessionCostSchema = z.object({
+  workerId: z.string(),
+  initialMessage: z.string().optional(),
+  sessionCost: z.number(),
+  createdAt: z.number(),
+});

--- a/packages/webapp/src/components/Header.tsx
+++ b/packages/webapp/src/components/Header.tsx
@@ -81,6 +81,25 @@ export default function Header() {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
+                  <Link href="/cost" className="w-full cursor-default flex items-center" prefetch={false}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="mr-2 h-4 w-4"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" />
+                      <path d="M12 18V6" />
+                    </svg>
+                    <span>{t('costAnalysis')}</span>
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
                   <Link href="/api/auth/sign-out" className="w-full cursor-default flex items-center" prefetch={false}>
                     <LogOut className="mr-2 h-4 w-4" />
                     <span>{t('signOut')}</span>

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -8,7 +8,8 @@
     "menu": "Menu",
     "language": "Language",
     "promptSettings": "Prompt Settings",
-    "apiKeys": "API Keys"
+    "apiKeys": "API Keys",
+    "costAnalysis": "Cost Analysis"
   },
   "sessions": {
     "title": "Sessions",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -8,7 +8,8 @@
     "menu": "メニュー",
     "language": "言語",
     "promptSettings": "プロンプト設定",
-    "apiKeys": "APIキー"
+    "apiKeys": "APIキー",
+    "costAnalysis": "コスト分析"
   },
   "sessions": {
     "title": "セッション一覧",


### PR DESCRIPTION
## Description

This PR adds a new cost analysis page to the webapp that shows users the monthly total LLM cost and token usage.

### Features

- Monthly total LLM cost display
- Token usage breakdown by type (input, output, cache read, cache write)
- Cost breakdown by session
- Cost breakdown by model

### Implementation

- Added a new  page with server components
- Created server action to fetch cost data from DynamoDB
- Implemented UI components for cost visualization
- Added translation support for English and Japanese
- Added menu link in the header

Closes #197