### PR TITLE
Add test for creating new files with empty oldString in fileEditor tool

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "echo \"No tests yet\"",
+    "test": "vitest run",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -82,7 +82,7 @@ function getUserDisplayName(user: User): string {
 }
 `;
   const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
-  
+
   // Ensure file doesn't exist before test
   expect(existsSync(filePath)).toBe(false);
 
@@ -96,7 +96,7 @@ function getUserDisplayName(user: User): string {
   // THEN
   expect(result).toBe('successfully created the file.');
   expect(existsSync(filePath)).toBe(true);
-  
+
   const fileContent = readFileSync(filePath, 'utf-8');
   expect(fileContent).toEqual(newContent);
 });

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, test } from 'vitest';
 import { fileEditTool } from './';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
@@ -65,4 +65,38 @@ function displayVehicleInfo(vehicle: Vehicle) {
     }
 }
 `);
+});
+
+test('create new file with empty oldString', async () => {
+  // GIVEN
+  const tool = fileEditTool.handler;
+  const newContent = `
+interface User {
+    id: number;
+    name: string;
+    email: string;
+}
+
+function getUserDisplayName(user: User): string {
+    return \`\${user.name} <\${user.email}>\`;
+}
+`;
+  const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
+  
+  // Ensure file doesn't exist before test
+  expect(existsSync(filePath)).toBe(false);
+
+  // WHEN
+  const result = await tool({
+    filePath,
+    oldString: '',
+    newString: newContent,
+  });
+
+  // THEN
+  expect(result).toBe('successfully created the file.');
+  expect(existsSync(filePath)).toBe(true);
+  
+  const fileContent = readFileSync(filePath, 'utf-8');
+  expect(fileContent).toEqual(newContent);
 });

--- a/packages/agent-core/vitest.config.ts
+++ b/packages/agent-core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Description

This PR adds a test case for the existing functionality in the fileEditor tool that creates a new file when oldString is empty. The implementation was already correctly handling this case, but there was no test coverage for it.

## Changes
- Added a test case for creating new files with empty oldString
- Updated package.json to use vitest for testing
- Added vitest.config.ts to properly configure the testing environment

## Testing
- Verified that all tests pass