### PR TITLE
Update API authentication to use x-api-key header

### DIFF
--- a/packages/webapp/src/app/api/auth/api-key.ts
+++ b/packages/webapp/src/app/api/auth/api-key.ts
@@ -7,17 +7,11 @@ import { NextRequest, NextResponse } from 'next/server';
  * @returns Response or undefined if validation passes
  */
 export async function validateApiKeyMiddleware(request: NextRequest): Promise<NextResponse | undefined> {
-  // Extract API key from authorization header
-  const authHeader = request.headers.get('authorization');
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Missing API key' }, { status: 401 });
-  }
-
-  const apiKey = authHeader.split(' ')[1];
+  // Extract API key from x-api-key header
+  const apiKey = request.headers.get('x-api-key');
 
   if (!apiKey) {
-    return NextResponse.json({ error: 'Invalid API key format' }, { status: 401 });
+    return NextResponse.json({ error: 'Missing API key' }, { status: 401 });
   }
 
   const isValid = await validateApiKey(apiKey);

--- a/packages/webapp/src/app/settings/api-keys/page.tsx
+++ b/packages/webapp/src/app/settings/api-keys/page.tsx
@@ -34,7 +34,7 @@ export default async function ApiKeysPage() {
                     <h3 className="text-lg font-medium mb-2">{documentationT('authentication')}</h3>
                     <p className="text-gray-600 dark:text-gray-300 mb-2">{documentationT('authDesc')}</p>
                     <pre className="p-4 bg-gray-100 dark:bg-gray-800 rounded-md overflow-x-auto">
-                      <code>Authorization: Bearer YOUR_API_KEY</code>
+                      <code>x-api-key: YOUR_API_KEY</code>
                     </pre>
                   </div>
 
@@ -82,7 +82,7 @@ export default async function ApiKeysPage() {
                       <code>{`curl -X POST \\
   ${AppOrigin}/api/sessions/ \\
   -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "x-api-key: YOUR_API_KEY" \\
   -d '{"message": "Create a React component for a user profile page"}'`}</code>
                     </pre>
 
@@ -91,7 +91,7 @@ export default async function ApiKeysPage() {
                       <code>{`curl -X POST \\
   ${AppOrigin}/api/sessions/api-1234567890 \\
   -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "x-api-key: YOUR_API_KEY" \\
   -d '{"message": "Add dark mode support to the component"}'`}</code>
                     </pre>
                   </div>


### PR DESCRIPTION
This PR updates the API authentication to use the x-api-key header instead of the Authorization: Bearer header. The middleware has been simplified to directly use the value from the x-api-key header, removing the need to parse the Bearer prefix. Documentation has also been updated to reflect this change.