### PR TITLE
Add check to prevent file overwrite when oldString is empty and file exists

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "echo \"No tests yet\"",
+    "test": "vitest run",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -112,7 +112,7 @@ const config = {
 };
 `;
   const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
-  
+
   // Create file before test
   writeFileSync(filePath, existingContent, 'utf-8');
   expect(existsSync(filePath)).toBe(true);
@@ -126,7 +126,7 @@ const config = {
 
   // THEN
   expect(result).toBe('The file already exists. Please provide a non-empty oldString to edit it.');
-  
+
   // File content should remain unchanged
   const fileContent = readFileSync(filePath, 'utf-8');
   expect(fileContent).toEqual(existingContent);

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -82,7 +82,7 @@ function getUserDisplayName(user: User): string {
 }
 `;
   const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
-  
+
   // Ensure file doesn't exist before test
   expect(existsSync(filePath)).toBe(false);
 
@@ -96,7 +96,7 @@ function getUserDisplayName(user: User): string {
   // THEN
   expect(result).toBe('successfully created the file.');
   expect(existsSync(filePath)).toBe(true);
-  
+
   const fileContent = readFileSync(filePath, 'utf-8');
   expect(fileContent).toEqual(newContent);
 });

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, test } from 'vitest';
 import { fileEditTool } from './';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
@@ -65,4 +65,38 @@ function displayVehicleInfo(vehicle: Vehicle) {
     }
 }
 `);
+});
+
+test('create new file with empty oldString', async () => {
+  // GIVEN
+  const tool = fileEditTool.handler;
+  const newContent = `
+interface User {
+    id: number;
+    name: string;
+    email: string;
+}
+
+function getUserDisplayName(user: User): string {
+    return \`\${user.name} <\${user.email}>\`;
+}
+`;
+  const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
+  
+  // Ensure file doesn't exist before test
+  expect(existsSync(filePath)).toBe(false);
+
+  // WHEN
+  const result = await tool({
+    filePath,
+    oldString: '',
+    newString: newContent,
+  });
+
+  // THEN
+  expect(result).toBe('successfully created the file.');
+  expect(existsSync(filePath)).toBe(true);
+  
+  const fileContent = readFileSync(filePath, 'utf-8');
+  expect(fileContent).toEqual(newContent);
 });

--- a/packages/agent-core/src/tools/editor/index.test.ts
+++ b/packages/agent-core/src/tools/editor/index.test.ts
@@ -100,3 +100,34 @@ function getUserDisplayName(user: User): string {
   const fileContent = readFileSync(filePath, 'utf-8');
   expect(fileContent).toEqual(newContent);
 });
+
+test('error when file exists and oldString is empty', async () => {
+  // GIVEN
+  const tool = fileEditTool.handler;
+  const existingContent = `
+const config = {
+    apiUrl: 'https://api.example.com',
+    timeout: 30000,
+    retries: 3
+};
+`;
+  const filePath = join(tempDirPath, `${randomBytes(6).toString('hex')}.ts`);
+  
+  // Create file before test
+  writeFileSync(filePath, existingContent, 'utf-8');
+  expect(existsSync(filePath)).toBe(true);
+
+  // WHEN
+  const result = await tool({
+    filePath,
+    oldString: '',
+    newString: 'new content that should not be written',
+  });
+
+  // THEN
+  expect(result).toBe('The file already exists. Please provide a non-empty oldString to edit it.');
+  
+  // File content should remain unchanged
+  const fileContent = readFileSync(filePath, 'utf-8');
+  expect(fileContent).toEqual(existingContent);
+});

--- a/packages/agent-core/src/tools/editor/index.ts
+++ b/packages/agent-core/src/tools/editor/index.ts
@@ -24,6 +24,11 @@ const editFile = async (input: z.infer<typeof inputSchema>) => {
     return 'successfully created the file.';
   }
 
+  // When oldString is empty and file already exists, prevent overwriting existing files
+  if (!oldString) {
+    return `The file already exists. Please provide a non-empty oldString to edit it.`;
+  }
+
   const fileContents = readFileSync(filePath, 'utf8');
 
   const isValid = isSingleOccurrence(fileContents, oldString);

--- a/packages/agent-core/vitest.config.ts
+++ b/packages/agent-core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Description

This PR adds a new feature to the fileEditor tool that prevents overwriting existing files when oldString is empty. Previously, when a file existed and oldString was empty, it would proceed to later code, potentially causing unexpected behavior. Now it returns an appropriate error message.

## Changes
- Added a check to prevent file modifications when oldString is empty but the file already exists
- Added a test case to verify this new behavior

## Testing
- Verified that all tests pass including the new test case