### PR TITLE
Add copy button to assistant messages

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useLayoutEffect, useRef } from 'react';
-import { Bot, User, Loader2, Clock, Info, Settings, Code, Terminal, ChevronRight, ChevronDown } from 'lucide-react';
+import { Bot, User, Loader2, Clock, Info, Settings, Code, Terminal, ChevronRight, ChevronDown, Copy } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -235,7 +235,13 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
     );
   };
 
-  const MessageItem = ({ message, showTimestamp = true }: { message: MessageView; showTimestamp?: boolean }) => (
+  const MessageItem = ({ message, showTimestamp = true }: { message: MessageView; showTimestamp?: boolean }) => {
+    const copyMessageToClipboard = (content: string) => {
+      navigator.clipboard.writeText(content)
+        .catch(err => console.error('Could not copy text: ', err));
+    };
+
+    return (
     <div className="flex items-start gap-1 py-1">
       <div
         className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 mt-1 md:block hidden"
@@ -256,12 +262,26 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
           <div
             className={`text-gray-900 dark:text-white pb-2 break-all${message.role == 'user' ? ' whitespace-pre-wrap' : ''}`}
           >
-            <MarkdownRenderer content={message.content} />
+            <div className="flex items-start">
+              <div className="flex-1">
+                <MarkdownRenderer content={message.content} />
+              </div>
+              {message.type === 'message' && message.role === 'assistant' && (
+                <button 
+                  onClick={() => copyMessageToClipboard(message.content)}
+                  className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0"
+                  title="Copy message"
+                >
+                  <Copy className="w-4 h-4" />
+                </button>
+              )}
+            </div>
           </div>
         )}
       </div>
     </div>
   );
+  }
 
   const MessageGroup = ({ group }: { group: MessageGroup }) => {
     const firstMessage = group.messages[0];

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -22,6 +22,7 @@ import { useTheme } from 'next-themes';
 import { useTranslations, useLocale } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { useScrollPosition } from '@/hooks/use-scroll-position';
+import { toast } from 'sonner';
 
 export type MessageView = {
   id: string;
@@ -249,7 +250,15 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
 
   const MessageItem = ({ message, showTimestamp = true }: { message: MessageView; showTimestamp?: boolean }) => {
     const copyMessageToClipboard = (content: string) => {
-      navigator.clipboard.writeText(content).catch((err) => console.error('Could not copy text: ', err));
+      navigator.clipboard
+        .writeText(content)
+        .then(() => {
+          toast.success(t('copySuccess'));
+        })
+        .catch((err) => {
+          console.error('Could not copy text: ', err);
+          toast.error(t('copyFailed'));
+        });
     };
 
     return (
@@ -280,7 +289,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
                 {message.type === 'message' && message.role === 'assistant' && (
                   <button
                     onClick={() => copyMessageToClipboard(message.content)}
-                    className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0"
+                    className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0 hidden md:block"
                     title={t('copyMessage')}
                   >
                     <Copy className="w-4 h-4" />

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -281,7 +281,7 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
                   <button
                     onClick={() => copyMessageToClipboard(message.content)}
                     className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0"
-                    title="Copy message"
+                    title={t('copyMessage')}
                   >
                     <Copy className="w-4 h-4" />
                   </button>

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -1,7 +1,19 @@
 'use client';
 
 import React, { useLayoutEffect, useRef } from 'react';
-import { Bot, User, Loader2, Clock, Info, Settings, Code, Terminal, ChevronRight, ChevronDown, Copy } from 'lucide-react';
+import {
+  Bot,
+  User,
+  Loader2,
+  Clock,
+  Info,
+  Settings,
+  Code,
+  Terminal,
+  ChevronRight,
+  ChevronDown,
+  Copy,
+} from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -237,51 +249,50 @@ export default function MessageList({ messages, instanceStatus, agentStatus }: M
 
   const MessageItem = ({ message, showTimestamp = true }: { message: MessageView; showTimestamp?: boolean }) => {
     const copyMessageToClipboard = (content: string) => {
-      navigator.clipboard.writeText(content)
-        .catch(err => console.error('Could not copy text: ', err));
+      navigator.clipboard.writeText(content).catch((err) => console.error('Could not copy text: ', err));
     };
 
     return (
-    <div className="flex items-start gap-1 py-1">
-      <div
-        className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 mt-1 md:block hidden"
-        style={{ minWidth: '55px' }}
-      >
-        {showTimestamp &&
-          new Date(message.timestamp).toLocaleTimeString(localeForDate, { hour: '2-digit', minute: '2-digit' })}
-      </div>
-      <div className="flex-1">
-        {message.type === 'toolUse' ? (
-          <ToolUseRenderer
-            content={message.content}
-            input={message.detail}
-            output={message.output}
-            messageId={message.id}
-          />
-        ) : (
-          <div
-            className={`text-gray-900 dark:text-white pb-2 break-all${message.role == 'user' ? ' whitespace-pre-wrap' : ''}`}
-          >
-            <div className="flex items-start">
-              <div className="flex-1">
-                <MarkdownRenderer content={message.content} />
+      <div className="flex items-start gap-1 py-1">
+        <div
+          className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 mt-1 md:block hidden"
+          style={{ minWidth: '55px' }}
+        >
+          {showTimestamp &&
+            new Date(message.timestamp).toLocaleTimeString(localeForDate, { hour: '2-digit', minute: '2-digit' })}
+        </div>
+        <div className="flex-1">
+          {message.type === 'toolUse' ? (
+            <ToolUseRenderer
+              content={message.content}
+              input={message.detail}
+              output={message.output}
+              messageId={message.id}
+            />
+          ) : (
+            <div
+              className={`text-gray-900 dark:text-white pb-2 break-all${message.role == 'user' ? ' whitespace-pre-wrap' : ''}`}
+            >
+              <div className="flex items-start">
+                <div className="flex-1">
+                  <MarkdownRenderer content={message.content} />
+                </div>
+                {message.type === 'message' && message.role === 'assistant' && (
+                  <button
+                    onClick={() => copyMessageToClipboard(message.content)}
+                    className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0"
+                    title="Copy message"
+                  >
+                    <Copy className="w-4 h-4" />
+                  </button>
+                )}
               </div>
-              {message.type === 'message' && message.role === 'assistant' && (
-                <button 
-                  onClick={() => copyMessageToClipboard(message.content)}
-                  className="ml-2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 flex-shrink-0"
-                  title="Copy message"
-                >
-                  <Copy className="w-4 h-4" />
-                </button>
-              )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
-    </div>
-  );
-  }
+    );
+  };
 
   const MessageGroup = ({ group }: { group: MessageGroup }) => {
     const firstMessage = group.messages[0];

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -57,6 +57,7 @@
     "hideRawJson": "Hide raw JSON",
     "input": "input",
     "output": "output",
+    "copyMessage": "Copy message",
     "scrollToTop": "Scroll to top",
     "scrollToBottom": "Scroll to bottom",
     "todoList": "Todo List",

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -58,6 +58,8 @@
     "input": "input",
     "output": "output",
     "copyMessage": "Copy message",
+    "copySuccess": "Copied to clipboard",
+    "copyFailed": "Failed to copy",
     "scrollToTop": "Scroll to top",
     "scrollToBottom": "Scroll to bottom",
     "todoList": "Todo List",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -58,6 +58,8 @@
     "input": "入力",
     "output": "出力",
     "copyMessage": "メッセージをコピー",
+    "copySuccess": "クリップボードにコピーしました",
+    "copyFailed": "コピーに失敗しました",
     "scrollToTop": "一番上までスクロール",
     "scrollToBottom": "一番下までスクロール",
     "todoList": "Todoリスト",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -57,6 +57,7 @@
     "hideRawJson": "JSONを隠す",
     "input": "入力",
     "output": "出力",
+    "copyMessage": "メッセージをコピー",
     "scrollToTop": "一番上までスクロール",
     "scrollToBottom": "一番下までスクロール",
     "todoList": "Todoリスト",


### PR DESCRIPTION
This PR adds a copy button to assistant messages in the MessageList component. The button only appears for messages with type 'message' and role 'assistant' as requested, allowing users to easily copy the assistant's responses to their clipboard.

## Changes
- Added Copy icon button to assistant messages
- Button only appears for message type 'message' and role 'assistant' (not for toolUse messages)
- Added i18n support with English and Japanese translations
- Added clipboard copy functionality