### PR TITLE
Disable markdown rendering for user messages except for URLs

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { MessageView } from './MessageList';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { ToolUseRenderer } from './ToolUseRenderer';
+import { UrlRenderer } from './UrlRenderer';
 
 type MessageItemProps = {
   message: MessageView;
@@ -47,11 +48,15 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
           />
         ) : (
           <div
-            className={`text-gray-900 dark:text-white pb-2 break-all${message.role == 'user' ? ' whitespace-pre-wrap' : ''}`}
+            className="text-gray-900 dark:text-white pb-2 break-all"
           >
             <div className="flex items-start">
               <div className="flex-1">
-                <MarkdownRenderer content={message.content} />
+                {message.role === 'user' ? (
+                  <UrlRenderer content={message.content} />
+                ) : (
+                  <MarkdownRenderer content={message.content} />
+                )}
               </div>
               {message.type === 'message' && message.role === 'assistant' && (
                 <button

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -47,9 +47,7 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
             messageId={message.id}
           />
         ) : (
-          <div
-            className="text-gray-900 dark:text-white pb-2 break-all"
-          >
+          <div className="text-gray-900 dark:text-white pb-2 break-all">
             <div className="flex items-start">
               <div className="flex-1">
                 {message.role === 'user' ? (

--- a/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
@@ -5,19 +5,19 @@ type UrlRendererProps = {
 };
 
 export const UrlRenderer = ({ content }: UrlRendererProps) => {
-  // URLを検出するための正規表現
+  // Regular expression to detect URLs
   const urlRegex = /(https?:\/\/[^\s]+)/g;
 
-  // テキストをURLと非URLのパーツに分割
+  // Split text into URL and non-URL parts
   const parts = content.split(urlRegex);
   const matches = content.match(urlRegex) || [];
 
-  // マッチングした部分とマッチングしなかった部分を交互に配置
+  // Arrange matched and unmatched parts alternately
   const elements: React.ReactNode[] = [];
 
   parts.forEach((part, i) => {
     if (part.match(urlRegex)) {
-      // URLの場合はリンクとして表示
+      // Display as a link if it's a URL
       elements.push(
         <a
           key={i}
@@ -30,7 +30,7 @@ export const UrlRenderer = ({ content }: UrlRendererProps) => {
         </a>
       );
     } else {
-      // 通常のテキストの場合
+      // For regular text content
       const lines = part.split('\n');
       elements.push(
         <React.Fragment key={i}>

--- a/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
@@ -7,14 +7,14 @@ type UrlRendererProps = {
 export const UrlRenderer = ({ content }: UrlRendererProps) => {
   // URLを検出するための正規表現
   const urlRegex = /(https?:\/\/[^\s]+)/g;
-  
+
   // テキストをURLと非URLのパーツに分割
   const parts = content.split(urlRegex);
   const matches = content.match(urlRegex) || [];
-  
+
   // マッチングした部分とマッチングしなかった部分を交互に配置
   const elements: React.ReactNode[] = [];
-  
+
   parts.forEach((part, i) => {
     if (part.match(urlRegex)) {
       // URLの場合はリンクとして表示

--- a/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/UrlRenderer.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+type UrlRendererProps = {
+  content: string;
+};
+
+export const UrlRenderer = ({ content }: UrlRendererProps) => {
+  // URLを検出するための正規表現
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  
+  // テキストをURLと非URLのパーツに分割
+  const parts = content.split(urlRegex);
+  const matches = content.match(urlRegex) || [];
+  
+  // マッチングした部分とマッチングしなかった部分を交互に配置
+  const elements: React.ReactNode[] = [];
+  
+  parts.forEach((part, i) => {
+    if (part.match(urlRegex)) {
+      // URLの場合はリンクとして表示
+      elements.push(
+        <a
+          key={i}
+          href={part}
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {part}
+        </a>
+      );
+    } else {
+      // 通常のテキストの場合
+      const lines = part.split('\n');
+      elements.push(
+        <React.Fragment key={i}>
+          {lines.map((line, j) => (
+            <React.Fragment key={`${i}-${j}`}>
+              {j > 0 && <br />}
+              {line}
+            </React.Fragment>
+          ))}
+        </React.Fragment>
+      );
+    }
+  });
+
+  return <div className="whitespace-pre-wrap">{elements}</div>;
+};


### PR DESCRIPTION
## Description
This PR modifies the `MessageItem.tsx` component to disable Markdown rendering for user messages while still making URLs clickable.

## Implemented Changes
- Created a new `UrlRenderer.tsx` component that detects URLs in text and makes them clickable
- Updated `MessageItem.tsx` to use the appropriate renderer based on message role:
  - For user messages: Use the new `UrlRenderer` that only converts URLs to links
  - For assistant messages: Continue using the existing `MarkdownRenderer`

## Testing
- Verified that user messages no longer render Markdown formatting
- Verified that URLs in user messages still appear as clickable links
- Confirmed that assistant messages still render with full Markdown support