### PR TITLE
Add automatic git push before PR creation

### DIFF
--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -104,6 +104,13 @@ const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
 
   // Get current branch name
   const branchName = await execute('git rev-parse --abbrev-ref HEAD', gitDirectoryPath);
+  
+  // Push the current branch to origin before creating PR
+  try {
+    await execute(`git push -u origin ${branchName}`, gitDirectoryPath);
+  } catch (error) {
+    throw new Error(`Failed to push branch to origin: ${(error as Error).message}`);
+  }
 
   // Add issue reference if issueId is provided
   let finalDescription = description;
@@ -143,8 +150,7 @@ export const createPRTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   toolSpec: async () => ({
     name,
     description:
-      `Create a new pull request of your branch to the upstream. This tool tracks PRs created in the session and prevents duplicate PRs unless forced. When your PR is linked to an issue, always provide the issue id as well. 
-IMPORTANT: Please make sure to push the current branch before using this tool.
+      `Create a new pull request of your branch to the upstream. This tool tracks PRs created in the session and prevents duplicate PRs unless forced. When your PR is linked to an issue, always provide the issue id as well.
     `.trim(),
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),

--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -150,7 +150,7 @@ export const createPRTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   toolSpec: async () => ({
     name,
     description:
-      `Create a new pull request of your branch to the upstream. This tool tracks PRs created in the session and prevents duplicate PRs unless forced. When your PR is linked to an issue, always provide the issue id as well.
+      `Create a new pull request of your branch to the upstream. This tool automatically pushes your current branch to the remote repository before creating the PR. Make sure to commit your changes before running this tool. This tool tracks PRs created in the session and prevents duplicate PRs unless forced. When your PR is linked to an issue, always provide the issue id as well.
     `.trim(),
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),

--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -104,7 +104,7 @@ const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
 
   // Get current branch name
   const branchName = await execute('git rev-parse --abbrev-ref HEAD', gitDirectoryPath);
-  
+
   // Push the current branch to origin before creating PR
   try {
     await execute(`git push -u origin ${branchName}`, gitDirectoryPath);


### PR DESCRIPTION
## Changes
- Modified the createPullRequest tool to automatically run `git push -u origin <branchName>` before creating a pull request
- Removed the "IMPORTANT: Please make sure to push the current branch before using this tool" note from the tool description as it's no longer necessary

## Background
This change eliminates the need for the user to manually push their branch before creating a PR. The tool now automatically handles this step, making the PR creation process more seamless.

The added code gets the current branch name and pushes it to the remote repository before proceeding with PR creation. If the push operation fails, it throws an appropriate error message.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1749963080946 -->