### PR TITLE
Add workerId metadata to GitHub PR and issue comments

### DIFF
--- a/packages/agent-core/src/tools/github-comments/index.ts
+++ b/packages/agent-core/src/tools/github-comments/index.ts
@@ -32,6 +32,12 @@ const getOctokitClient = async () => {
   });
 };
 
+// Utility function to append workerId metadata to comment body
+const appendWorkerIdMetadata = (body: string): string => {
+  const workerId = process.env.WORKER_ID!;
+  return `${body}\n\n<!-- DO NOT EDIT: System generated metadata -->\n<!-- WORKER_ID:${workerId} -->`;
+};
+
 // Type for review comment with replies
 type ReviewCommentWithReplies = Awaited<ReturnType<Octokit['pulls']['listReviewComments']>>['data'][0] & {
   replies: ReviewCommentWithReplies[];
@@ -133,13 +139,16 @@ const replyPRCommentHandler = async (input: z.infer<typeof replyPRCommentSchema>
 
   const octokit = await getOctokitClient();
 
+  // Append workerId metadata to comment body
+  const finalBody = appendWorkerIdMetadata(body);
+
   // Use Octokit to reply to a comment
   await octokit.pulls.createReplyForReviewComment({
     owner,
     repo,
     pull_number: pullRequestId,
     comment_id: commentId,
-    body,
+    body: finalBody,
   });
 
   return `Successfully replied to comment ${commentId}`;
@@ -150,12 +159,15 @@ const addIssueCommentHandler = async (input: z.infer<typeof addIssueCommentSchem
 
   const octokit = await getOctokitClient();
 
+  // Append workerId metadata to comment body
+  const finalBody = appendWorkerIdMetadata(body);
+
   // Use Octokit to add a comment to an issue
   await octokit.issues.createComment({
     owner,
     repo,
     issue_number: issueNumber,
-    body,
+    body: finalBody,
   });
 
   return `Successfully added comment to issue #${issueNumber}`;

--- a/packages/agent-core/src/tools/github-comments/index.ts
+++ b/packages/agent-core/src/tools/github-comments/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
 import { Octokit } from '@octokit/rest';
 import { authorizeGitHubCli } from '../command-execution/github';
+import { WorkerId } from '../../env';
 
 const getPRCommentsSchema = z.object({
   owner: z.string().describe('GitHub repository owner'),
@@ -34,7 +35,7 @@ const getOctokitClient = async () => {
 
 // Utility function to append workerId metadata to comment body
 const appendWorkerIdMetadata = (body: string): string => {
-  const workerId = process.env.WORKER_ID!;
+  const workerId = WorkerId;
   return `${body}\n\n<!-- DO NOT EDIT: System generated metadata -->\n<!-- WORKER_ID:${workerId} -->`;
 };
 


### PR DESCRIPTION
## Summary
This PR adds workerId metadata to GitHub PR comments and issue comments, similar to how it's already implemented in the create-pr tool.

## Changes
- Created a utility function `appendWorkerIdMetadata` that appends the workerId as an HTML comment to the message body
- Modified `replyPRCommentHandler` to use the utility function and add workerId metadata to PR comments
- Modified `addIssueCommentHandler` to use the utility function and add workerId metadata to issue comments

## Testing
The changes follow the same pattern as in the create-pr tool implementation, ensuring consistency in the codebase.

## References
The implementation follows the pattern established in `packages/agent-core/src/tools/create-pr/index.ts`, where comments include a hidden HTML comment with the workerId metadata.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1749967852138 -->