### PR TITLE
Add handler for pull_request_review events

### DIFF
--- a/packages/github-actions/src/handlers/pr-review.ts
+++ b/packages/github-actions/src/handlers/pr-review.ts
@@ -5,6 +5,7 @@ import { ActionContext } from '../lib/context';
 import { WebhookPayload } from '@actions/github/lib/interfaces';
 import { getIssueComments, getIssueDescription, submitIssueComment } from '../lib/comments';
 import { sendMessageToSession, startRemoteSweSession } from '../lib/remote-swe-api';
+import { isCollaborator } from '../lib/permission';
 
 export async function handlePrReviewEvent(context: ActionContext, payload: WebhookPayload): Promise<void> {
   const review = payload.review;
@@ -19,6 +20,21 @@ export async function handlePrReviewEvent(context: ActionContext, payload: Webho
   // Skip if review body is empty
   if (!reviewBody.trim()) {
     core.info('Review body is empty, exiting');
+    return;
+  }
+
+  // Check if reviewer is a collaborator
+  const reviewer = review.user?.login;
+  if (!reviewer) {
+    core.info('Review author not found, exiting');
+    return;
+  }
+
+  const repositoryName = `${github.context.repo.owner}/${github.context.repo.repo}`;
+  const hasPermission = await isCollaborator(reviewer, repositoryName);
+
+  if (!hasPermission) {
+    core.info(`Review author ${reviewer} does not have collaborator permissions, exiting`);
     return;
   }
 
@@ -44,7 +60,6 @@ export async function handlePrReviewEvent(context: ActionContext, payload: Webho
   }
 
   // Prepare the message with review content
-  const reviewer = review.user?.login || 'Unknown';
   const reviewState = review.state || 'Unknown';
   const message = `A new review has been submitted on PR #${prNumber} by ${reviewer} with status: ${reviewState}\n\n${reviewBody}\n\nThe above message was received from a GitHub pull request review. Please address the review comments.`;
 

--- a/packages/github-actions/src/handlers/pr-review.ts
+++ b/packages/github-actions/src/handlers/pr-review.ts
@@ -51,12 +51,12 @@ export async function handlePrReviewEvent(context: ActionContext, payload: Webho
   const sessionContext = {
     repository: github.context.repo,
     pullRequestUrl: payload.pull_request?.html_url,
-    reviewId: review.id
+    reviewId: review.id,
   };
 
   // Send the review to the existing session
   core.info(`Found existing workerId: ${workerId}, sending review to existing session`);
   await sendMessageToSession(workerId, message, sessionContext, context);
-  
+
   core.info('Review message sent to worker successfully');
 }

--- a/packages/github-actions/src/handlers/pr-review.ts
+++ b/packages/github-actions/src/handlers/pr-review.ts
@@ -1,0 +1,62 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { extractWorkerIdFromText } from '@remote-swe-agents/agent-core/lib';
+import { ActionContext } from '../lib/context';
+import { WebhookPayload } from '@actions/github/lib/interfaces';
+import { getIssueComments, getIssueDescription, submitIssueComment } from '../lib/comments';
+import { sendMessageToSession, startRemoteSweSession } from '../lib/remote-swe-api';
+
+export async function handlePrReviewEvent(context: ActionContext, payload: WebhookPayload): Promise<void> {
+  const review = payload.review;
+  if (!review) {
+    core.info('No review found in payload, exiting');
+    return;
+  }
+
+  const reviewBody = (review.body as string) || '';
+  core.info(`Review body: ${reviewBody}`);
+
+  // Skip if review body is empty
+  if (!reviewBody.trim()) {
+    core.info('Review body is empty, exiting');
+    return;
+  }
+
+  // Get PR number
+  const prNumber = payload.pull_request?.number;
+  if (!prNumber) {
+    core.info('No PR number found, exiting');
+    return;
+  }
+
+  // Get PR description to look for session ID
+  const prDescription = await getIssueDescription(prNumber);
+  if (!prDescription) {
+    core.info('No PR description found, exiting');
+    return;
+  }
+
+  // Extract worker ID from PR description
+  const workerId = extractWorkerIdFromText(prDescription);
+  if (!workerId) {
+    core.info('No worker ID found in PR description, exiting');
+    return;
+  }
+
+  // Prepare the message with review content
+  const reviewer = review.user?.login || 'Unknown';
+  const reviewState = review.state || 'Unknown';
+  const message = `A new review has been submitted on PR #${prNumber} by ${reviewer} with status: ${reviewState}\n\n${reviewBody}\n\nThe above message was received from a GitHub pull request review. Please address the review comments.`;
+
+  const sessionContext = {
+    repository: github.context.repo,
+    pullRequestUrl: payload.pull_request?.html_url,
+    reviewId: review.id
+  };
+
+  // Send the review to the existing session
+  core.info(`Found existing workerId: ${workerId}, sending review to existing session`);
+  await sendMessageToSession(workerId, message, sessionContext, context);
+  
+  core.info('Review message sent to worker successfully');
+}

--- a/packages/github-actions/src/index.ts
+++ b/packages/github-actions/src/index.ts
@@ -4,6 +4,7 @@ import { handleIssueAssignmentEvent } from './handlers/issue-assignment';
 import { handlePrAssignmentEvent } from './handlers/pr-assignment';
 import { ActionContext } from './lib/context';
 import { handleCommentEvent } from './handlers/comment';
+import { handlePrReviewEvent } from './handlers/pr-review';
 
 function getContext(): ActionContext {
   return {
@@ -28,6 +29,8 @@ async function run() {
       await handleCommentEvent(context, payload);
     } else if (eventName === 'pull_request_review_comment') {
       await handleCommentEvent(context, payload);
+    } else if (eventName === 'pull_request_review') {
+      await handlePrReviewEvent(context, payload);
     } else if (eventName === 'issues' && payload.action === 'assigned') {
       await handleIssueAssignmentEvent(context, payload);
     } else if (eventName === 'pull_request' && payload.action === 'assigned') {


### PR DESCRIPTION
## Description
This PR adds support for handling `pull_request_review` events in the GitHub Actions component. When a pull request review is received, the handler will:

1. Search for session ID in the PR description
2. If a session ID is found, send the review message to the worker
3. Include relevant context about the review (reviewer, review state, etc.)

## Implementation
- Created a new handler in `packages/github-actions/src/handlers/pr-review.ts`
- Updated `index.ts` to listen and route `pull_request_review` events to this handler
- Implemented logic to extract the session ID from PR description
- Added message formatting similar to other event handlers

## Testing
The implementation follows the same patterns as other event handlers in the repository, and should work as expected once deployed.

Closes #217

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:api-1749992136716 -->