### PR TITLE
Add noindex meta tag to prevent search engine indexing

### DIFF
--- a/packages/webapp/src/app/layout.tsx
+++ b/packages/webapp/src/app/layout.tsx
@@ -17,6 +17,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     <html lang={locale} suppressHydrationWarning>
       <head>
         <title>{title}</title>
+        <meta name="robots" content="noindex, nofollow" />
       </head>
       <body>
         <NextIntlClientProvider locale={locale} messages={messages}>


### PR DESCRIPTION
## Description

This PR adds a meta tag with `robots` content set to `noindex, nofollow` in the webapp's root layout file. This prevents search engines from indexing and following links on the web application.

## Changes

- Added `<meta name="robots" content="noindex, nofollow" />` to the head section in `packages/webapp/src/app/layout.tsx`

## Testing

- Verify that the meta tag is properly added to the HTML head when the application is rendered.
- This change will instruct search engines not to index the content of the web application.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1749993508304 -->