### PR TITLE
feat: implement force stop agent work functionality using Escape key

### DIFF
--- a/packages/agent-core/src/lib/events.ts
+++ b/packages/agent-core/src/lib/events.ts
@@ -55,6 +55,9 @@ export const workerEventSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('onMessageReceived'),
   }),
+  z.object({
+    type: z.literal('forceStop'),
+  }),
 ]);
 
 export async function sendWorkerEvent(workerId: string, event: z.infer<typeof workerEventSchema>) {

--- a/packages/webapp/src/app/sessions/[workerId]/actions.ts
+++ b/packages/webapp/src/app/sessions/[workerId]/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { fetchTodoListSchema, sendMessageToAgentSchema, updateAgentStatusSchema } from './schemas';
+import { fetchTodoListSchema, sendMessageToAgentSchema, updateAgentStatusSchema, sendEventSchema } from './schemas';
 import { authActionClient } from '@/lib/safe-action';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
@@ -58,4 +58,11 @@ export const updateAgentStatus = authActionClient
   .schema(updateAgentStatusSchema)
   .action(async ({ parsedInput: { workerId, status } }) => {
     await updateSessionAgentStatus(workerId, status);
+  });
+
+export const sendEventToAgent = authActionClient
+  .schema(sendEventSchema)
+  .action(async ({ parsedInput: { workerId, event } }) => {
+    await sendWorkerEvent(workerId, event);
+    return { success: true };
   });

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import Header from '@/components/Header';
 import { ArrowLeft, ListChecks, Check, Plus, Loader2 } from 'lucide-react';
 import { useScrollPosition } from '@/hooks/use-scroll-position';
 import Link from 'next/link';
 import { useAction } from 'next-safe-action/hooks';
-import { updateAgentStatus } from '../actions';
+import { updateAgentStatus, sendEventToAgent } from '../actions';
 import { useEventBus } from '@/hooks/use-event-bus';
 import MessageForm from './MessageForm';
 import MessageList, { MessageView } from './MessageList';
@@ -46,6 +46,36 @@ export default function SessionPageClient({
   const [todoList, setTodoList] = useState<TodoListType | null>(initialTodoList);
   const [showTodoModal, setShowTodoModal] = useState(false);
   const { isBottom } = useScrollPosition();
+  
+  // Setup event handler for Escape key press to force stop agent work
+  const { execute: sendEvent } = useAction(sendEventToAgent, {
+    onSuccess: () => {
+      toast.success(t('forceStopSuccess'));
+      setAgentStatus('pending');
+    },
+    onError: (error) => {
+      toast.error(`${t('forceStopError')}: ${error.serverError || error}`);
+    },
+  });
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape' && agentStatus === 'working') {
+      if (confirm(t('confirmForceStop') || 'Are you sure you want to stop the agent work?')) {
+        sendEvent({
+          workerId,
+          event: { type: 'forceStop' },
+        });
+      }
+    }
+  }, [workerId, agentStatus, t, sendEvent]);
+  
+  // Add and remove event listener for Escape key
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   const getUnifiedStatus = () => {
     if (agentStatus === 'completed') {

--- a/packages/webapp/src/app/sessions/[workerId]/schemas.ts
+++ b/packages/webapp/src/app/sessions/[workerId]/schemas.ts
@@ -15,3 +15,10 @@ export const updateAgentStatusSchema = z.object({
   workerId: z.string(),
   status: agentStatusSchema,
 });
+
+export const sendEventSchema = z.object({
+  workerId: z.string(),
+  event: z.object({
+    type: z.literal('forceStop'),
+  }),
+});

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -110,6 +110,11 @@ const main = async () => {
       if (type == 'onMessageReceived') {
         tracker.cancelCurrentSessions();
         tracker.startOnMessageReceived();
+      } else if (type == 'forceStop') {
+        tracker.cancelCurrentSessions();
+        // Update agent status to pending after force stop
+        await updateInstanceStatus(workerId, 'running');
+        await sendSystemMessage(workerId, 'Agent work was force stopped by user.');
       }
     },
     error: (err) => console.error('error', err),

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,0 +1,79 @@
+# Force Stop Agent Work - Test Plan
+
+## Overview
+This test plan verifies the functionality that allows users to stop agent work immediately when pressing the Escape key on the session page.
+
+## Prerequisites
+- Access to a deployed environment of the remote-swe-agents application
+- A session with a running agent (agent status is "working")
+
+## Test Cases
+
+### 1. Force Stop via Escape Key
+**Objective:** Verify that pressing the Escape key triggers the force stop functionality.
+
+**Steps:**
+1. Navigate to a session page with an active agent (status: "working")
+2. Press the Escape key
+3. Observe the confirmation dialog
+4. Click "OK" to confirm
+
+**Expected Results:**
+- A confirmation dialog appears asking to confirm stopping the agent
+- After confirming, a success toast message is displayed
+- Agent status changes from "working" to "pending"
+- Any ongoing agent work stops immediately
+- A system message appears: "Agent work was force stopped by user."
+
+### 2. Cancel Force Stop Action
+**Objective:** Verify that the force stop action can be canceled.
+
+**Steps:**
+1. Navigate to a session page with an active agent (status: "working")
+2. Press the Escape key
+3. When the confirmation dialog appears, click "Cancel"
+
+**Expected Results:**
+- The confirmation dialog disappears
+- No events are sent to the agent
+- Agent continues working without interruption
+
+### 3. Escape Key with Inactive Agent
+**Objective:** Verify that the Escape key has no effect when agent is not working.
+
+**Steps:**
+1. Navigate to a session page where the agent status is "pending" or "completed"
+2. Press the Escape key
+
+**Expected Results:**
+- No confirmation dialog appears
+- No change in agent status or behavior
+
+### 4. Network Error Handling
+**Objective:** Verify error handling when the force stop request fails.
+
+**Steps:**
+1. Simulate a network error condition
+2. Navigate to a session page with an active agent
+3. Press the Escape key and confirm the dialog
+
+**Expected Results:**
+- An error toast message appears indicating the failure
+- The agent continues working
+
+### 5. Multiple Escape Key Presses
+**Objective:** Verify system behavior when Escape key is pressed multiple times.
+
+**Steps:**
+1. Navigate to a session page with an active agent
+2. Press the Escape key and confirm the dialog
+3. After agent status changes to "pending", press the Escape key again
+
+**Expected Results:**
+- First press: Force stop is triggered and completes successfully
+- Second press: No confirmation dialog appears (as agent is no longer working)
+
+## Non-Functional Requirements
+- Performance: The force stop action should be processed within 2 seconds
+- Usability: The confirmation dialog should be clear about the action being taken
+- Reliability: The force stop functionality should work consistently across different browsers


### PR DESCRIPTION
This PR implements the feature to force stop agent work when pressing the Escape key on the session page.

## Changes
- Added a new `forceStop` event type to the workerEventSchema in agent-core
- Implemented force stop event handling in worker/main.ts to cancel current sessions and update agent status
- Added Escape key handling in SessionPageClient.tsx to capture key press, show confirmation dialog, and send the forceStop event
- Added a new server action to send the forceStop event to the worker
- Created a test plan to verify the functionality works as expected

## Testing
The implementation includes:
1. Capturing Escape key press on the session page
2. Confirming with the user before stopping the agent
3. Sending a forceStop event to the worker
4. Handling the force stop event in the worker by canceling current sessions
5. Updating the agent status to pending after force stop
6. Displaying appropriate toast messages for success/error cases

Closes #220

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:api-1749997310066 -->