### PR TITLE
(worker): override agent's system prompt

### DIFF
--- a/packages/agent-core/src/schema/session.ts
+++ b/packages/agent-core/src/schema/session.ts
@@ -10,6 +10,13 @@ export const instanceStatusSchema = z.union([
 
 export type InstanceStatus = z.infer<typeof instanceStatusSchema>;
 
+export const systemPromptOverrideSchema = z.object({
+  prompt: z.string(),
+  mode: z.union([z.literal('append'), z.literal('overwrite')]),
+});
+
+export type SystemPromptOverride = z.infer<typeof systemPromptOverrideSchema>;
+
 export const sessionItemSchema = z.object({
   PK: z.literal('sessions'),
   SK: z.string(),
@@ -20,6 +27,7 @@ export const sessionItemSchema = z.object({
   instanceStatus: instanceStatusSchema,
   sessionCost: z.number(),
   agentStatus: agentStatusSchema,
+  systemPromptOverride: systemPromptOverrideSchema.optional(),
 });
 
 export type SessionItem = z.infer<typeof sessionItemSchema>;

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -16,6 +16,7 @@ import {
   sendSystemMessage,
   updateSessionCost,
   readCommonPrompt,
+  getSession,
 } from '@remote-swe-agents/agent-core/lib';
 import pRetry, { AbortError } from 'p-retry';
 import { bedrockConverse } from '@remote-swe-agents/agent-core/lib';
@@ -176,6 +177,27 @@ Users will primarily request software engineering assistance including bug fixes
     }
   };
   await tryAppendCommonPrompt();
+  
+  // Check for system prompt override in session
+  const tryApplySystemPromptOverride = async () => {
+    try {
+      const session = await getSession(workerId);
+      if (session?.systemPromptOverride) {
+        const { prompt, mode } = session.systemPromptOverride;
+        
+        if (mode === 'overwrite') {
+          console.log('Overwriting system prompt with override');
+          systemPrompt = prompt;
+        } else if (mode === 'append') {
+          console.log('Appending override to system prompt');
+          systemPrompt = `${systemPrompt}\n\n${prompt}`;
+        }
+      }
+    } catch (error) {
+      console.error('Error applying system prompt override:', error);
+    }
+  };
+  await tryApplySystemPromptOverride();
 
   const tryAppendRepositoryKnowledge = async () => {
     try {

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -177,14 +177,14 @@ Users will primarily request software engineering assistance including bug fixes
     }
   };
   await tryAppendCommonPrompt();
-  
+
   // Check for system prompt override in session
   const tryApplySystemPromptOverride = async () => {
     try {
       const session = await getSession(workerId);
       if (session?.systemPromptOverride) {
         const { prompt, mode } = session.systemPromptOverride;
-        
+
         if (mode === 'overwrite') {
           console.log('Overwriting system prompt with override');
           systemPrompt = prompt;


### PR DESCRIPTION
## Summary
This PR implements system prompt override functionality as requested in issue #223.

## Changes
- Added `systemPromptOverrideSchema` to the session schema to define the structure of the override option
- Updated the worker to check for a system prompt override when starting a turn
- Implemented logic to handle both "append" and "overwrite" modes

## Implementation Details
1. Added optional `systemPromptOverride` field to `sessionItemSchema` with properties:
   - `prompt`: The system prompt text to use for override
   - `mode`: Either "append" (add to existing prompt) or "overwrite" (replace existing prompt)

2. Added a new function `tryApplySystemPromptOverride` in the worker to:
   - Read the session data
   - Check if systemPromptOverride exists
   - Apply the override according to the specified mode

This implementation allows dynamic customization of system prompts on a per-session basis without modifying the base system prompt.

Closes #223

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1750042084858 -->