### PR TITLE
Add timeoutMs option to executeCommand tool

### DIFF
--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -15,12 +15,18 @@ const inputSchema = z.object({
     .describe(
       'If true, do not wait for the process to exit; leave the process running and return control after 10 seconds.'
     ),
+  timeoutMs: z
+    .number()
+    .optional()
+    .describe(
+      'Custom timeout in milliseconds for command execution. Default is 60000ms (60 seconds).'
+    ),
 });
 
 export const DefaultWorkingDirectory = join(homedir(), `.remote-swe-workspace`);
 spawn('mkdir', ['-p', DefaultWorkingDirectory]);
 
-export const executeCommand = async (command: string, cwd?: string, timeout = 60000, longRunningProcess = false) => {
+export const executeCommand = async (command: string, cwd?: string, timeoutMs = 60000, longRunningProcess = false) => {
   const token = await authorizeGitHubCli();
   cwd = cwd ?? DefaultWorkingDirectory;
 
@@ -55,13 +61,13 @@ export const executeCommand = async (command: string, cwd?: string, timeout = 60
         if (!longRunningProcess) {
           childProcess.kill();
           resolve({
-            error: `Command execution timed out after ${Math.round(timeout / 1000)} seconds of inactivity`,
+            error: `Command execution timed out after ${Math.round(timeoutMs / 1000)} seconds of inactivity`,
             stdout: truncate(stdout, 40e3),
             stderr: truncate(stderr),
             suggestion: generateSuggestion(command, false),
           });
         }
-      }, timeout);
+      }, timeoutMs);
     };
 
     resetTimer();
@@ -129,8 +135,8 @@ export const executeCommand = async (command: string, cwd?: string, timeout = 60
   });
 };
 
-const handler = async (input: { command: string; cwd?: string; longRunningProcess?: boolean }) => {
-  const res = await executeCommand(input.command, input.cwd, 60000, input.longRunningProcess);
+const handler = async (input: { command: string; cwd?: string; longRunningProcess?: boolean; timeoutMs?: number }) => {
+  const res = await executeCommand(input.command, input.cwd, input.timeoutMs ?? 60000, input.longRunningProcess);
   return JSON.stringify(res, undefined, 1);
 };
 
@@ -145,6 +151,8 @@ export const commandExecutionTool: ToolDefinition<z.infer<typeof inputSchema>> =
     description: `Execute any shell command. If you need to run a command in a specific directory, set \`cwd\` argument (optional).
 
 If you need to run a daemon or long-running process like \`npm run dev\` or \`docker compose up\`, set \`longRunningProcess: true\`. This will start the process, wait for 10 seconds to allow it to initialize, and return control to you while keeping the process running in the background.
+
+For one-time tasks that you expect to take longer than 60 seconds to complete, set \`timeoutMs\` to a higher value (in milliseconds). For example, \`timeoutMs: 180000\` for a 3-minute timeout. Do NOT use this for daemon processes - use \`longRunningProcess: true\` instead.
 
 IMPORTANT: When your command contains special characters (like backticks, quotes, dollar signs), they need to be properly escaped to prevent shell interpretation. Common approaches:
 1. Use single quotes to prevent variable expansion and most interpretations: 'text with $HOME and \`backticks\`'

--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -136,15 +136,8 @@ export const executeCommand = async (command: string, cwd?: string, timeoutMs = 
 const handler = async (input: { command: string; cwd?: string; longRunningProcess?: boolean; timeoutMs?: number }) => {
   // Validate that timeoutMs and longRunningProcess are not used together
   if (input.timeoutMs !== undefined && input.longRunningProcess === true) {
-    return JSON.stringify(
-      {
-        error:
-          "Cannot use both 'timeoutMs' and 'longRunningProcess' options together. Use 'timeoutMs' for one-time tasks that need longer execution time, and 'longRunningProcess' for daemon processes that should continue running in the background.",
-        stdout: '',
-        stderr: '',
-      },
-      undefined,
-      1
+    throw new Error(
+      "Cannot use both 'timeoutMs' and 'longRunningProcess' options together. Use 'timeoutMs' for one-time tasks that need longer execution time, and 'longRunningProcess' for daemon processes that should continue running in the background."
     );
   }
 

--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -18,9 +18,7 @@ const inputSchema = z.object({
   timeoutMs: z
     .number()
     .optional()
-    .describe(
-      'Custom timeout in milliseconds for command execution. Default is 60000ms (60 seconds).'
-    ),
+    .describe('Custom timeout in milliseconds for command execution. Default is 60000ms (60 seconds).'),
 });
 
 export const DefaultWorkingDirectory = join(homedir(), `.remote-swe-workspace`);

--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -134,6 +134,20 @@ export const executeCommand = async (command: string, cwd?: string, timeoutMs = 
 };
 
 const handler = async (input: { command: string; cwd?: string; longRunningProcess?: boolean; timeoutMs?: number }) => {
+  // Validate that timeoutMs and longRunningProcess are not used together
+  if (input.timeoutMs !== undefined && input.longRunningProcess === true) {
+    return JSON.stringify(
+      {
+        error:
+          "Cannot use both 'timeoutMs' and 'longRunningProcess' options together. Use 'timeoutMs' for one-time tasks that need longer execution time, and 'longRunningProcess' for daemon processes that should continue running in the background.",
+        stdout: '',
+        stderr: '',
+      },
+      undefined,
+      1
+    );
+  }
+
   const res = await executeCommand(input.command, input.cwd, input.timeoutMs ?? 60000, input.longRunningProcess);
   return JSON.stringify(res, undefined, 1);
 };


### PR DESCRIPTION
## Changes

This PR adds a custom timeout option to the `executeCommand` tool, allowing the agent to change the default timeout value.

### Details

- Added a new `timeoutMs` parameter to the input schema allowing agents to set a custom timeout value
- Modified the `executeCommand` function to use this timeout parameter
- Updated the handler function to pass the custom timeout to the execution function
- Updated the tool description to provide clear guidance on when to use `timeoutMs` vs `longRunningProcess`:
  - For daemon-like processes, use `longRunningProcess: true`
  - For one-time tasks that take longer than 60 seconds to complete, use `timeoutMs` with a higher value

### Example Use Case

```javascript
// For a one-time task that may take up to 3 minutes
executeCommand({ 
  command: "npm run build", 
  timeoutMs: 180000 // 3 minutes in milliseconds
})

// For a daemon process that should continue running in the background
executeCommand({ 
  command: "npm run dev", 
  longRunningProcess: true
})
```

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1750128845386 -->