### PR TITLE
feat: Add support for existing VPC deployment

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -74,6 +74,7 @@ const props: MainStackProps = {
       }
     : {}),
   ...(additionalAwsManagedPolicies ? { additionalAwsManagedPolicies } : {}),
+  ...(process.env.VPC_ID ? { existingVpcId: process.env.VPC_ID } : {}),
   initialWebappUserEmail: process.env.INITIAL_WEBAPP_USER_EMAIL,
 };
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -74,7 +74,7 @@ const props: MainStackProps = {
       }
     : {}),
   ...(additionalAwsManagedPolicies ? { additionalAwsManagedPolicies } : {}),
-  ...(process.env.VPC_ID ? { existingVpcId: process.env.VPC_ID } : {}),
+  ...(process.env.VPC_ID ? { vpcId: process.env.VPC_ID } : {}),
   initialWebappUserEmail: process.env.INITIAL_WEBAPP_USER_EMAIL,
 };
 

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -20,7 +20,7 @@ export interface MainStackProps extends cdk.StackProps {
   readonly domainName?: string;
   readonly sharedCertificate?: ICertificate;
   readonly cloudFrontWebAclArn?: string;
-  readonly existingVpcId?: string;
+  readonly vpcId?: string;
 
   readonly slack: {
     botTokenParameterName: string;
@@ -79,8 +79,8 @@ export class MainStack extends cdk.Stack {
     });
 
     // 既存VPCが指定されていればそれを使用し、そうでなければ新規作成
-    const vpc = props.existingVpcId
-      ? Vpc.fromLookup(this, 'ImportedVpc', { vpcId: props.existingVpcId })
+    const vpc = props.vpcId
+      ? Vpc.fromLookup(this, 'VpcV2', { vpcId: props.vpcId })
       : new Vpc(this, 'VpcV2', {
           subnetConfiguration: [
             {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -20,6 +20,7 @@ export interface MainStackProps extends cdk.StackProps {
   readonly domainName?: string;
   readonly sharedCertificate?: ICertificate;
   readonly cloudFrontWebAclArn?: string;
+  readonly existingVpcId?: string;
 
   readonly slack: {
     botTokenParameterName: string;
@@ -77,19 +78,22 @@ export class MainStack extends cdk.Stack {
       objectOwnership: ObjectOwnership.OBJECT_WRITER,
     });
 
-    const vpc = new Vpc(this, 'VpcV2', {
-      subnetConfiguration: [
-        {
-          // We use public subnets for worker EC2 instances. Here are the reasons:
-          //   1. to remove NAT Gateway cost
-          //   2. to avoid IP-address-based throttling/filtering from external services
-          // All the instances are securely protected by security groups without any inbound rules.
-          subnetType: SubnetType.PUBLIC,
-          name: 'Public',
-          cidrMask: 20,
-        },
-      ],
-    });
+    // 既存VPCが指定されていればそれを使用し、そうでなければ新規作成
+    const vpc = props.existingVpcId
+      ? Vpc.fromLookup(this, 'ImportedVpc', { vpcId: props.existingVpcId })
+      : new Vpc(this, 'VpcV2', {
+          subnetConfiguration: [
+            {
+              // We use public subnets for worker EC2 instances. Here are the reasons:
+              //   1. to remove NAT Gateway cost
+              //   2. to avoid IP-address-based throttling/filtering from external services
+              // All the instances are securely protected by security groups without any inbound rules.
+              subnetType: SubnetType.PUBLIC,
+              name: 'Public',
+              cidrMask: 20,
+            },
+          ],
+        });
 
     const storage = new Storage(this, 'Storage', { accessLogBucket });
 


### PR DESCRIPTION
## 概要
このPRでは、既存のVPC IDを環境変数として指定することで、新しいVPCを作成せずにデプロイできる機能を追加しました。

## 変更内容
- `MainStackProps` インターフェースに `vpcId` オプションを追加
- VPC作成ロジックを条件分岐式に更新し、既存VPC IDが指定されている場合はそれを使用するように変更
- 環境変数 `VPC_ID` から設定を読み込む機能を追加

## 使用方法
環境変数 `VPC_ID` を設定してCDKをデプロイすることで、既存のVPCを使用できます：

```bash
VPC_ID=vpc-12345abcdef npx cdk deploy
```

この設定がない場合は、従来通り新しいVPCが作成されます。

## テスト済み項目
- 環境変数なしでデプロイした場合、従来通り新しいVPCが作成されることを確認
- 環境変数 `VPC_ID` を設定してデプロイした場合、指定したVPCが使用されることを確認