### PR TITLE
feat: add WORKER_MODEL_OVERRIDE environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,17 +345,25 @@ All the new agents can now use MCP servers as their tools.
 
 ### Overriding the Foundation Model
 
-By default the Remote SWE uses Claude Sonnet 3.7 as the foundation model. You can override this configuration by the below steps:
+By default the Remote SWE uses Claude Sonnet 3.7 as the foundation model. You can override this configuration in one of two ways:
 
-1. Edit [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts) to set the environment variable `MODEL_OVERRIDE` for the worker service. The available values are: `sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, and sonnet4`
+1. **Using environment variable (recommended)**:
+   ```bash
+   WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
+   ```
+
+2. **Directly editing the code**:
+   Edit [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts) to set the environment variable `MODEL_OVERRIDE` for the worker service.
    ```diff
    Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
    + Environment=MODEL_OVERRIDE=nova-pro
 
    [Install]
    ```
-2. Run cdk deploy
-3. New workers now use the override model.
+
+The available model values are: `sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, and sonnet4`
+
+After deploying, new workers will use the override model.
 
 Note that this feature is highly experimental and we generally recommend to use the default model for optimized experience.
 

--- a/README.md
+++ b/README.md
@@ -345,21 +345,11 @@ All the new agents can now use MCP servers as their tools.
 
 ### Overriding the Foundation Model
 
-By default the Remote SWE uses Claude Sonnet 3.7 as the foundation model. You can override this configuration in one of two ways:
+By default the Remote SWE uses Claude Sonnet 3.7 as the foundation model. You can override this configuration using an environment variable:
 
-1. **Using environment variable (recommended)**:
-   ```bash
-   WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
-   ```
-
-2. **Directly editing the code**:
-   Edit [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts) to set the environment variable `MODEL_OVERRIDE` for the worker service.
-   ```diff
-   Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
-   + Environment=MODEL_OVERRIDE=nova-pro
-
-   [Install]
-   ```
+```bash
+WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
+```
 
 The available model values are: `sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, and sonnet4`
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -339,21 +339,11 @@ npx cdk deploy --all
 
 ### 基盤モデルのオーバーライド
 
-デフォルトでは、Remote SWEは基盤モデルとしてClaude Sonnet 3.7を使用しています。この設定を上書きするには、次の2つの方法があります：
+デフォルトでは、Remote SWEは基盤モデルとしてClaude Sonnet 3.7を使用しています。この設定は環境変数を使用して上書きできます：
 
-1. **環境変数の使用（推奨）**:
-   ```bash
-   WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
-   ```
-
-2. **コードを直接編集する方法**:
-   [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts)を編集してワーカーサービスの環境変数`MODEL_OVERRIDE`を設定します。
-   ```diff
-   Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
-   + Environment=MODEL_OVERRIDE=nova-pro
-
-   [Install]
-   ```
+```bash
+WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
+```
 
 利用可能なモデル値は次のとおりです：`sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, sonnet4`
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -339,17 +339,25 @@ npx cdk deploy --all
 
 ### 基盤モデルのオーバーライド
 
-デフォルトでは、Remote SWEは基盤モデルとしてClaude Sonnet 3.7を使用しています。以下の手順でこの設定をオーバーライドできます：
+デフォルトでは、Remote SWEは基盤モデルとしてClaude Sonnet 3.7を使用しています。この設定を上書きするには、次の2つの方法があります：
 
-1. [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts)を編集してワーカーサービスの環境変数`MODEL_OVERRIDE`を設定します。利用可能な値は：`sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro`です。
+1. **環境変数の使用（推奨）**:
+   ```bash
+   WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
+   ```
+
+2. **コードを直接編集する方法**:
+   [cdk/lib/constructs/worker/index.ts](./cdk/lib/constructs/worker/index.ts)を編集してワーカーサービスの環境変数`MODEL_OVERRIDE`を設定します。
    ```diff
    Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
    + Environment=MODEL_OVERRIDE=nova-pro
 
    [Install]
    ```
-2. cdk deployを実行
-3. これで新しいワーカーがオーバーライドモデルを使用します。
+
+利用可能なモデル値は次のとおりです：`sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, sonnet4`
+
+デプロイ後、新しいワーカーはオーバーライドされたモデルを使用します。
 
 この機能は非常に実験的であり、最適な体験のために通常はデフォルトモデルを使用することをお勧めします。
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -71,6 +71,7 @@ const props: MainStackProps = {
   ...(additionalPolicies ? { additionalManagedPolicies: additionalPolicies } : {}),
   ...(process.env.VPC_ID ? { vpcId: process.env.VPC_ID } : {}),
   initialWebappUserEmail: process.env.INITIAL_WEBAPP_USER_EMAIL,
+  ...(process.env.WORKER_MODEL_OVERRIDE ? { workerModelOverride: process.env.WORKER_MODEL_OVERRIDE } : {}),
 };
 
 new MainStack(app, `RemoteSweStack-${targetEnv}`, {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -43,6 +43,7 @@ export interface MainStackProps extends cdk.StackProps {
   readonly workerAmiIdParameterName: string;
   readonly additionalManagedPolicies?: string[];
   readonly initialWebappUserEmail?: string;
+  readonly workerModelOverride?: string;
 }
 
 export class MainStack extends cdk.Stack {
@@ -123,6 +124,7 @@ export class MainStack extends cdk.Stack {
       accessLogBucket,
       amiIdParameterName: workerAmiIdParameter.parameterName,
       additionalManagedPolicies: props.additionalManagedPolicies,
+      modelOverride: props.workerModelOverride,
     });
 
     new SlackBolt(this, 'SlackBolt', {

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -354,7 +354,7 @@ Environment=TABLE_NAME=${props.storageTable.tableName}
 Environment=BUCKET_NAME=${props.imageBucket.bucketName}
 Environment=BEDROCK_AWS_ACCOUNTS=${props.loadBalancing?.awsAccounts.join(',') ?? ''}
 Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
-${props.modelOverride ? `Environment=MODEL_OVERRIDE=${props.modelOverride}` : '# Environment=MODEL_OVERRIDE=nova-pro'}
+${props.modelOverride ? `Environment=MODEL_OVERRIDE=${props.modelOverride}` : ''}
 
 [Install]
 WantedBy=multi-user.target

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -31,6 +31,7 @@ export interface WorkerProps {
   accessLogBucket: IBucket;
   amiIdParameterName: string;
   additionalManagedPolicies?: string[];
+  modelOverride?: string;
 }
 
 export class Worker extends Construct {
@@ -353,7 +354,7 @@ Environment=TABLE_NAME=${props.storageTable.tableName}
 Environment=BUCKET_NAME=${props.imageBucket.bucketName}
 Environment=BEDROCK_AWS_ACCOUNTS=${props.loadBalancing?.awsAccounts.join(',') ?? ''}
 Environment=BEDROCK_AWS_ROLE_NAME=${props.loadBalancing?.roleName ?? ''}
-# Environment=MODEL_OVERRIDE=nova-pro
+${props.modelOverride ? `Environment=MODEL_OVERRIDE=${props.modelOverride}` : '# Environment=MODEL_OVERRIDE=nova-pro'}
 
 [Install]
 WantedBy=multi-user.target

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -4550,7 +4550,6 @@ phases:
 
               Environment=BEDROCK_AWS_ROLE_NAME=
 
-              # Environment=MODEL_OVERRIDE=nova-pro
 
 
               [Install]
@@ -5258,7 +5257,6 @@ phases:
 
               Environment=BEDROCK_AWS_ROLE_NAME=
 
-              # Environment=MODEL_OVERRIDE=nova-pro
 
 
               [Install]
@@ -5672,7 +5670,7 @@ Environment=BUCKET_NAME=",
                   "
 Environment=BEDROCK_AWS_ACCOUNTS=
 Environment=BEDROCK_AWS_ROLE_NAME=
-# Environment=MODEL_OVERRIDE=nova-pro
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Overview
This PR adds support for setting the worker model override via an environment variable `WORKER_MODEL_OVERRIDE` when running CDK. This allows more flexibility in specifying the model to be used by the worker without having to modify the code directly.

## Changes
- Added `workerModelOverride` property to `MainStackProps` interface in `cdk-stack.ts`
- Added `modelOverride` property to `WorkerProps` interface in `worker/index.ts`
- Added environment variable reading in `bin/cdk.ts` to set the model override from `WORKER_MODEL_OVERRIDE` environment variable
- Modified the worker service configuration to use the specified model override if provided

## Usage
To specify a model override when deploying with CDK:
```
WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
```

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1750346669329 -->