### PR TITLE
Hide 'Initial Message' label on mobile screens

### DIFF
--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -68,7 +68,10 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
           <ImagePreviewList />
 
           <div className="flex items-center justify-end mb-2">
-            <label htmlFor="message" className="hidden md:block mr-auto text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="message"
+              className="hidden md:block mr-auto text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               {t('initialMessage')}
             </label>
             <div className="flex gap-2">

--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -68,7 +68,7 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
           <ImagePreviewList />
 
           <div className="flex items-center justify-between mb-2">
-            <label htmlFor="message" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label htmlFor="message" className="hidden md:block text-sm font-medium text-gray-700 dark:text-gray-300">
               {t('initialMessage')}
             </label>
             <div className="flex gap-2">

--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -67,8 +67,8 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
         <div className="text-left">
           <ImagePreviewList />
 
-          <div className="flex items-center justify-between mb-2">
-            <label htmlFor="message" className="hidden md:block text-sm font-medium text-gray-700 dark:text-gray-300">
+          <div className="flex items-center justify-end mb-2">
+            <label htmlFor="message" className="hidden md:block mr-auto text-sm font-medium text-gray-700 dark:text-gray-300">
               {t('initialMessage')}
             </label>
             <div className="flex gap-2">


### PR DESCRIPTION
## Description

This PR modifies the new session page to hide the "Initial Message" label on mobile devices while keeping it visible on larger screens (768px and above). This helps improve the mobile UI experience by reducing clutter on smaller screens.

## Changes

- Added Tailwind CSS classes `hidden md:block` to the label element in `NewSessionForm.tsx`
  - `hidden`: Hidden by default on mobile screens 
  - `md:block`: Displayed as block element on medium screens (768px+)

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1750383145838 -->