### PR TITLE
Add WebApp link to initial Slack message

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -127,23 +127,6 @@ export class MainStack extends cdk.Stack {
       modelOverride: props.workerModelOverride,
     });
 
-    new SlackBolt(this, 'SlackBolt', {
-      botTokenParameter: botToken,
-      signingSecretParameter: signingSecret,
-      launchTemplateId: worker.launchTemplate.launchTemplateId!,
-      subnetIdListForWorkers: vpc.publicSubnets.map((s) => s.subnetId).join(','),
-      workerBus: worker.bus,
-      storage,
-      adminUserIdList: props.slack.adminUserIdList,
-      workerLogGroupName: worker.logGroup.logGroupName,
-      workerAmiIdParameter,
-    });
-
-    new EC2GarbageCollector(this, 'EC2GarbageCollector', {
-      expirationInDays: 1,
-      imageRecipeName: worker.imageBuilder.imageRecipeName,
-    });
-
     const auth = new Auth(this, 'Auth', {
       hostedZone,
       sharedCertificate: props.sharedCertificate,
@@ -167,6 +150,24 @@ export class MainStack extends cdk.Stack {
       workerBus: worker.bus,
       asyncJob,
       workerAmiIdParameter,
+    });
+
+    new SlackBolt(this, 'SlackBolt', {
+      botTokenParameter: botToken,
+      signingSecretParameter: signingSecret,
+      launchTemplateId: worker.launchTemplate.launchTemplateId!,
+      subnetIdListForWorkers: vpc.publicSubnets.map((s) => s.subnetId).join(','),
+      workerBus: worker.bus,
+      storage,
+      adminUserIdList: props.slack.adminUserIdList,
+      workerLogGroupName: worker.logGroup.logGroupName,
+      workerAmiIdParameter,
+      webappOriginSourceParameter: webapp.originSourceParameter,
+    });
+
+    new EC2GarbageCollector(this, 'EC2GarbageCollector', {
+      expirationInDays: 1,
+      imageRecipeName: worker.imageBuilder.imageRecipeName,
     });
 
     new cdk.CfnOutput(this, 'FrontendDomainName', {

--- a/cdk/lib/constructs/slack-bolt/index.ts
+++ b/cdk/lib/constructs/slack-bolt/index.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, Duration, IgnoreMode, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnOutput, Duration, IgnoreMode, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { CfnStage, HttpApi } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
@@ -53,10 +53,11 @@ export class SlackBolt extends Construct {
     props.storage.bucket.grantReadWrite(asyncHandler);
     props.workerBus.api.grantPublish(asyncHandler);
 
+    // Reference the same parameter name pattern as in webapp.ts
     const originSourceParameter = StringParameter.fromStringParameterName(
       this,
       'OriginSourceParameter',
-      'remote-swe-agents-webapp-originSourceParameter'
+      `/remote-swe-agents/${Stack.of(this).stackName}/webapp/origin-source`
     );
 
     const handler = new DockerImageFunction(this, 'Handler', {

--- a/cdk/lib/constructs/slack-bolt/index.ts
+++ b/cdk/lib/constructs/slack-bolt/index.ts
@@ -71,7 +71,9 @@ export class SlackBolt extends Construct {
         TABLE_NAME: props.storage.table.tableName,
         BUCKET_NAME: props.storage.bucket.bucketName,
         LOG_GROUP_NAME: props.workerLogGroupName,
-        ...(webappOriginSourceParameter ? { APP_ORIGIN_SOURCE_PARAMETER: webappOriginSourceParameter.parameterName } : {}),
+        ...(webappOriginSourceParameter
+          ? { APP_ORIGIN_SOURCE_PARAMETER: webappOriginSourceParameter.parameterName }
+          : {}),
         ...(props.adminUserIdList ? { ADMIN_USER_ID_LIST: props.adminUserIdList } : {}),
       },
       architecture: Architecture.ARM_64,

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -152,14 +152,14 @@ export class Webapp extends Construct {
           service: 'ssm',
           action: 'putParameter',
           parameters: {
-            Name: originSourceParameter.parameterName,
+            Name: this.originSourceParameter.parameterName,
             Value: service.url,
             Overwrite: true,
           },
-          physicalResourceId: PhysicalResourceId.of(originSourceParameter.parameterName),
+          physicalResourceId: PhysicalResourceId.of(this.originSourceParameter.parameterName),
         },
         policy: AwsCustomResourcePolicy.fromSdkCalls({
-          resources: [originSourceParameter.parameterArn],
+          resources: [this.originSourceParameter.parameterArn],
         }),
       });
     }

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -45,6 +45,7 @@ export interface WebappProps {
 
 export class Webapp extends Construct {
   public readonly baseUrl: string;
+  public readonly originSourceParameter?: IStringParameter;
 
   constructor(scope: Construct, id: string, props: WebappProps) {
     super(scope, id);
@@ -136,13 +137,12 @@ export class Webapp extends Construct {
         [`${this.baseUrl}/api/auth/sign-out-callback`, `http://localhost:3011/api/auth/sign-out-callback`]
       );
 
-      // Create parameter with a standardized name that can be referenced by other constructs
-      const originSourceParameter = new StringParameter(this, 'OriginSourceParameter', {
-        parameterName: `/remote-swe-agents/${Stack.of(this).stackName}/webapp/origin-source`,
+      // Create parameter and expose it publicly for other constructs to use
+      this.originSourceParameter = new StringParameter(this, 'OriginSourceParameter', {
         stringValue: 'dummy',
       });
-      originSourceParameter.grantRead(handler);
-      handler.addEnvironment('APP_ORIGIN_SOURCE_PARAMETER', originSourceParameter.parameterName);
+      this.originSourceParameter.grantRead(handler);
+      handler.addEnvironment('APP_ORIGIN_SOURCE_PARAMETER', this.originSourceParameter.parameterName);
 
       // We need to pass APP_ORIGIN environment variable for callback URL,
       // but we cannot know CloudFront domain before deploying Lambda function.

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -136,7 +136,9 @@ export class Webapp extends Construct {
         [`${this.baseUrl}/api/auth/sign-out-callback`, `http://localhost:3011/api/auth/sign-out-callback`]
       );
 
+      // Create parameter with a standardized name that can be referenced by other constructs
       const originSourceParameter = new StringParameter(this, 'OriginSourceParameter', {
+        parameterName: `/remote-swe-agents/${Stack.of(this).stackName}/webapp/origin-source`,
         stringValue: 'dummy',
       });
       originSourceParameter.grantRead(handler);

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -66,10 +66,6 @@ exports[`Snapshot test: MainStack 1`] = `
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SlackBoltOriginSourceParameterParameterAAC4F693": {
-      "Default": "remote-swe-agents-webapp-originSourceParameter",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
     "SsmParameterValueawsservicecanonicalubuntuserver2404stablecurrentamd64hvmebsgp3amiidC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
@@ -2339,7 +2335,9 @@ exports.handler = async function (event, context) {
         },
         "Environment": {
           "Variables": {
-            "APP_ORIGIN_SOURCE_PARAMETER": "remote-swe-agents-webapp-originSourceParameter",
+            "APP_ORIGIN_SOURCE_PARAMETER": {
+              "Ref": "WebappOriginSourceParameterD87E143B",
+            },
             "ASYNC_LAMBDA_NAME": {
               "Ref": "SlackBoltAsyncHandler9A0D467E",
             },
@@ -2424,7 +2422,17 @@ exports.handler = async function (event, context) {
                 "ssm:GetParameters",
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/remote-swe-agents-webapp-originSourceParameter",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:us-east-1:123456789012:parameter/",
+                    {
+                      "Ref": "WebappOriginSourceParameterD87E143B",
+                    },
+                  ],
+                ],
+              },
             },
             {
               "Action": "lambda:InvokeFunction",

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -66,6 +66,10 @@ exports[`Snapshot test: MainStack 1`] = `
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SlackBoltOriginSourceParameterParameterAAC4F693": {
+      "Default": "remote-swe-agents-webapp-originSourceParameter",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "SsmParameterValueawsservicecanonicalubuntuserver2404stablecurrentamd64hvmebsgp3amiidC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
@@ -2335,6 +2339,7 @@ exports.handler = async function (event, context) {
         },
         "Environment": {
           "Variables": {
+            "APP_ORIGIN_SOURCE_PARAMETER": "remote-swe-agents-webapp-originSourceParameter",
             "ASYNC_LAMBDA_NAME": {
               "Ref": "SlackBoltAsyncHandler9A0D467E",
             },
@@ -2411,6 +2416,16 @@ exports.handler = async function (event, context) {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+                "ssm:GetParameters",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/remote-swe-agents-webapp-originSourceParameter",
+            },
             {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",

--- a/packages/agent-core/src/lib/aws/ssm.ts
+++ b/packages/agent-core/src/lib/aws/ssm.ts
@@ -1,3 +1,22 @@
-import { SSMClient } from '@aws-sdk/client-ssm';
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 
 export const ssm = new SSMClient({});
+
+/**
+ * Get a parameter from SSM Parameter Store
+ * @param parameterName The name of the parameter
+ * @returns The parameter value
+ */
+export const getParameter = async (parameterName: string): Promise<string | undefined> => {
+  try {
+    const response = await ssm.send(
+      new GetParameterCommand({
+        Name: parameterName,
+      })
+    );
+    return response.Parameter?.Value;
+  } catch (error) {
+    console.error(`Error getting parameter ${parameterName}:`, error);
+    return undefined;
+  }
+};

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -142,7 +142,7 @@ export async function handleMessage(
                         },
                       ],
                     },
-                    webappUrl && {
+                    ...(webappUrl ? [{
                       type: 'rich_text_section',
                       elements: [
                         {
@@ -158,7 +158,7 @@ export async function handleMessage(
                           },
                         },
                       ],
-                    },
+                    }] : []),
                     {
                       type: 'rich_text_section',
                       elements: [
@@ -188,7 +188,7 @@ export async function handleMessage(
                         },
                       ],
                     },
-                  ].filter(Boolean),
+                  ],
                 },
               ],
             },

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -69,7 +69,7 @@ export async function handleMessage(
   // Get webapp domain from SSM parameter
   const originSourceParameterName = process.env.APP_ORIGIN_SOURCE_PARAMETER;
   let webappUrl: string | undefined = undefined;
-  
+
   if (originSourceParameterName) {
     try {
       webappUrl = await getParameter(originSourceParameterName);
@@ -127,13 +127,17 @@ export async function handleMessage(
               },
             } as SectionBlock,
             // Conditionally add webapp link if available
-            ...(webappUrl ? [{
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: `• View this session in WebApp: <${webappUrl}/sessions/${workerId}|*Open in Web UI*>`,
-              },
-            } as SectionBlock] : []),
+            ...(webappUrl
+              ? [
+                  {
+                    type: 'section',
+                    text: {
+                      type: 'mrkdwn',
+                      text: `• View this session in WebApp: <${webappUrl}/sessions/${workerId}|*Open in Web UI*>`,
+                    },
+                  } as SectionBlock,
+                ]
+              : []),
             {
               type: 'section',
               text: {

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -117,80 +117,34 @@ export async function handleMessage(
                 text: `Hi <@${userId}>, please wait for your agent to launch.\n\n*Useful Tips:*`,
               },
             },
+            // Use separate sections instead of rich_text to avoid type issues
             {
-              type: 'rich_text',
-              elements: [
-                {
-                  type: 'rich_text_list',
-                  style: 'bullet',
-                  indent: 0,
-                  elements: [
-                    {
-                      type: 'rich_text_section',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: 'You can view ',
-                        },
-                        {
-                          type: 'link',
-                          url: cloudwatchUrl,
-                          text: 'the execution log here',
-                          style: {
-                            bold: true,
-                          },
-                        },
-                      ],
-                    },
-                    ...(webappUrl ? [{
-                      type: 'rich_text_section',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: 'View this session in WebApp: ',
-                        },
-                        {
-                          type: 'link',
-                          url: `${webappUrl}/sessions/${workerId}`,
-                          text: 'Open in Web UI',
-                          style: {
-                            bold: true,
-                          },
-                        },
-                      ],
-                    }] : []),
-                    {
-                      type: 'rich_text_section',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: 'Send ',
-                        },
-                        {
-                          type: 'text',
-                          text: 'dump_history',
-                          style: {
-                            code: true,
-                          },
-                        },
-                        {
-                          type: 'text',
-                          text: ' to get conversation history and token consumption stats.',
-                        },
-                      ],
-                    },
-                    {
-                      type: 'rich_text_section',
-                      elements: [
-                        {
-                          type: 'text',
-                          text: 'You can always interrupt and ask them to stop what they are doing.',
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `• You can view <${cloudwatchUrl}|*the execution log here*>`,
+              },
+            },
+            ...(webappUrl ? [{
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `• View this session in WebApp: <${webappUrl}/sessions/${workerId}|*Open in Web UI*>`,
+              },
+            }] : []),
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: '• Send `dump_history` to get conversation history and token consumption stats.',
+              },
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: '• You can always interrupt and ask them to stop what they are doing.',
+              },
             },
           ],
         })

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -1,5 +1,6 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { WebClient } from '@slack/web-api';
+import { Block, KnownBlock, SectionBlock } from '@slack/types';
 import { saveConversationHistory } from '../util/history';
 import { s3, BucketName, getParameter } from '@remote-swe-agents/agent-core/aws';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -116,7 +117,7 @@ export async function handleMessage(
                 type: 'mrkdwn',
                 text: `Hi <@${userId}>, please wait for your agent to launch.\n\n*Useful Tips:*`,
               },
-            },
+            } as SectionBlock,
             // Add additional sections with tips
             {
               type: 'section',
@@ -124,7 +125,7 @@ export async function handleMessage(
                 type: 'mrkdwn',
                 text: `• You can view <${cloudwatchUrl}|*the execution log here*>`,
               },
-            },
+            } as SectionBlock,
             // Conditionally add webapp link if available
             ...(webappUrl ? [{
               type: 'section',
@@ -132,21 +133,21 @@ export async function handleMessage(
                 type: 'mrkdwn',
                 text: `• View this session in WebApp: <${webappUrl}/sessions/${workerId}|*Open in Web UI*>`,
               },
-            }] : []),
+            } as SectionBlock] : []),
             {
               type: 'section',
               text: {
                 type: 'mrkdwn',
                 text: '• Send `dump_history` to get conversation history and token consumption stats.',
               },
-            },
+            } as SectionBlock,
             {
               type: 'section',
               text: {
                 type: 'mrkdwn',
                 text: '• You can always interrupt and ask them to stop what they are doing.',
               },
-            },
+            } as SectionBlock,
           ],
         })
       : client.reactions.add({

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -67,7 +67,7 @@ export async function handleMessage(
 
   // Get webapp domain from SSM parameter
   const originSourceParameterName = process.env.APP_ORIGIN_SOURCE_PARAMETER;
-  let webappUrl = undefined;
+  let webappUrl: string | undefined = undefined;
   
   if (originSourceParameterName) {
     try {

--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -117,7 +117,7 @@ export async function handleMessage(
                 text: `Hi <@${userId}>, please wait for your agent to launch.\n\n*Useful Tips:*`,
               },
             },
-            // Use separate sections instead of rich_text to avoid type issues
+            // Add additional sections with tips
             {
               type: 'section',
               text: {
@@ -125,6 +125,7 @@ export async function handleMessage(
                 text: `• You can view <${cloudwatchUrl}|*the execution log here*>`,
               },
             },
+            // Conditionally add webapp link if available
             ...(webappUrl ? [{
               type: 'section',
               text: {


### PR DESCRIPTION
## Description

This PR adds a WebApp link to the initial Slack message when starting a new conversation with the agent. 

## Changes

1. Modified `cdk/lib/constructs/slack-bolt/index.ts`:
   - Added the SSM parameter for WebApp origin to Slack Lambda environment variables
   - Added permission to read the parameter

2. Enhanced `packages/agent-core/src/lib/aws/ssm.ts`:
   - Added a new function `getParameter` to retrieve SSM parameters
   
3. Updated `packages/slack-bolt-app/src/handlers/message.ts`:
   - Added code to retrieve WebApp URL from SSM parameter
   - Added WebApp session link to the initial message sent to user

## Benefits

- Improves user experience by providing easy access to the WebApp UI
- Creates better integration between the Slack and WebApp interfaces
- Users can easily switch between Slack and WebApp for the same session

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1750402178064 -->