### PR TITLE
Add DynamoDB Local setup for local development

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,14 @@
+# DynamoDB Local configuration
+DYNAMODB_ENDPOINT=http://localhost:8000
+TABLE_NAME=RemoteSWEAgentsTable-local
+AWS_REGION=ap-northeast-1
+
+# AWS credentials for local development (can be any values for DynamoDB local)
+AWS_ACCESS_KEY_ID=local
+AWS_SECRET_ACCESS_KEY=local
+
+# Worker configuration
+WORKER_ID=local-worker
+
+# OpenAI API configuration
+OPENAI_API_KEY=your_openai_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env.local

--- a/README_LOCAL_SETUP.md
+++ b/README_LOCAL_SETUP.md
@@ -1,0 +1,129 @@
+# ローカル開発環境セットアップガイド
+
+このガイドでは、Remote SWE Agentsをローカル環境で開発およびテストするための手順を説明します。特にDynamoDB Localを使用して、AWSアカウントに依存せずに完全なローカル開発環境を設定する方法を紹介します。
+
+## 前提条件
+
+- Node.js (v18以上)
+- Docker および Docker Compose
+- Git
+- OpenAI API キー（ローカルでのエージェント実行に必要）
+
+## セットアップ手順
+
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/aws-samples/remote-swe-agents.git
+cd remote-swe-agents
+```
+
+### 2. 依存関係のインストール
+
+```bash
+npm ci
+```
+
+### 3. 環境変数の設定
+
+`.env.local.example`ファイルを`.env.local`としてコピーし、必要な環境変数を設定します：
+
+```bash
+cp .env.local.example .env.local
+```
+
+`.env.local`を編集して、少なくとも以下の値を設定してください：
+
+```
+# DynamoDB Local設定はデフォルト値のままで問題ありません
+DYNAMODB_ENDPOINT=http://localhost:8000
+TABLE_NAME=RemoteSWEAgentsTable-local
+AWS_REGION=ap-northeast-1
+
+# ローカル開発用のAWS認証情報（DynamoDB Localでは任意の値で構いません）
+AWS_ACCESS_KEY_ID=local
+AWS_SECRET_ACCESS_KEY=local
+
+# Workerの設定
+WORKER_ID=local-worker
+
+# OpenAI API設定（実際のAPIキーを設定してください）
+OPENAI_API_KEY=your_openai_api_key
+```
+
+### 4. DynamoDB LocalとWorkerの起動
+
+提供されているスクリプトを使用して、DynamoDB Localの起動とテーブルの作成、そしてworkerの起動を一度に行うことができます：
+
+```bash
+./scripts/start-local.sh
+```
+
+このスクリプトは以下の処理を行います：
+
+1. `.env.local`から環境変数を読み込む
+2. Docker Composeを使用してDynamoDB LocalとDynamoDB Adminを起動
+3. DynamoDB Localにテーブルを作成
+4. agent-coreモジュールをビルド
+5. ローカルworkerを起動
+
+### 5. 個別のコンポーネント起動（オプション）
+
+個別にコンポーネントを起動したい場合は、以下のコマンドを実行してください：
+
+#### DynamoDB LocalとDynamoDB Adminの起動
+
+```bash
+docker-compose up -d dynamodb-local dynamodb-admin
+```
+
+DynamoDB Adminは`http://localhost:8001`でアクセスできます。
+
+#### テーブルの作成
+
+```bash
+node scripts/setup-dynamodb-local.js
+```
+
+#### agent-coreのビルド
+
+```bash
+npm run build -w @remote-swe-agents/agent-core
+```
+
+#### workerの起動
+
+```bash
+cd packages/worker && npm run start:local
+```
+
+## 使用方法
+
+ローカルworkerが起動すると、コマンドラインインターフェースを通じてエージェントと対話できます。プロンプトに従ってメッセージを入力してください。
+
+## DynamoDBデータの確認
+
+DynamoDB Adminインターフェース（`http://localhost:8001`）を使用して、テーブル内のデータを確認および操作できます。
+
+## トラブルシューティング
+
+### DynamoDB Localに接続できない
+
+- Docker Composeが正常に実行されているか確認してください
+- `docker ps`コマンドで`dynamodb-local`コンテナが実行中か確認
+- ポート8000が他のアプリケーションで使用されていないか確認
+
+### テーブル作成エラー
+
+- DynamoDB Localが起動しているか確認
+- 環境変数`DYNAMODB_ENDPOINT`が正しく設定されているか確認
+
+### Workerが起動しない
+
+- agent-coreモジュールが正しくビルドされているか確認
+- 環境変数が正しく設定されているか確認（特に`TABLE_NAME`と`OPENAI_API_KEY`）
+
+## リソース
+
+- [DynamoDB Local公式ドキュメント](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
+- [Remote SWE Agentsドキュメント](https://github.com/aws-samples/remote-swe-agents)

--- a/README_LOCAL_SETUP_EN.md
+++ b/README_LOCAL_SETUP_EN.md
@@ -1,0 +1,129 @@
+# Local Development Environment Setup Guide
+
+This guide explains how to set up and test Remote SWE Agents in a local development environment. Specifically, it introduces how to set up a complete local development environment using DynamoDB Local without depending on an AWS account.
+
+## Prerequisites
+
+- Node.js (v18 or later)
+- Docker and Docker Compose
+- Git
+- OpenAI API key (required for running the agent locally)
+
+## Setup Steps
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/aws-samples/remote-swe-agents.git
+cd remote-swe-agents
+```
+
+### 2. Install Dependencies
+
+```bash
+npm ci
+```
+
+### 3. Configure Environment Variables
+
+Copy the `.env.local.example` file as `.env.local` and set the necessary environment variables:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Edit `.env.local` and set at least the following values:
+
+```
+# Default DynamoDB Local settings should work fine
+DYNAMODB_ENDPOINT=http://localhost:8000
+TABLE_NAME=RemoteSWEAgentsTable-local
+AWS_REGION=ap-northeast-1
+
+# AWS credentials for local development (any values are fine for DynamoDB Local)
+AWS_ACCESS_KEY_ID=local
+AWS_SECRET_ACCESS_KEY=local
+
+# Worker configuration
+WORKER_ID=local-worker
+
+# OpenAI API configuration (set your actual API key)
+OPENAI_API_KEY=your_openai_api_key
+```
+
+### 4. Start DynamoDB Local and the Worker
+
+You can use the provided script to start DynamoDB Local, create tables, and start the worker at once:
+
+```bash
+./scripts/start-local.sh
+```
+
+This script performs the following:
+
+1. Loads environment variables from `.env.local`
+2. Starts DynamoDB Local and DynamoDB Admin using Docker Compose
+3. Creates tables in DynamoDB Local
+4. Builds the agent-core module
+5. Starts the local worker
+
+### 5. Start Individual Components (Optional)
+
+If you want to start components individually, run the following commands:
+
+#### Start DynamoDB Local and DynamoDB Admin
+
+```bash
+docker-compose up -d dynamodb-local dynamodb-admin
+```
+
+DynamoDB Admin is accessible at `http://localhost:8001`.
+
+#### Create Tables
+
+```bash
+node scripts/setup-dynamodb-local.js
+```
+
+#### Build agent-core
+
+```bash
+npm run build -w @remote-swe-agents/agent-core
+```
+
+#### Start the Worker
+
+```bash
+cd packages/worker && npm run start:local
+```
+
+## Usage
+
+Once the local worker is started, you can interact with the agent through the command-line interface. Follow the prompts to enter messages.
+
+## Checking DynamoDB Data
+
+You can use the DynamoDB Admin interface (`http://localhost:8001`) to view and manipulate data in the tables.
+
+## Troubleshooting
+
+### Cannot Connect to DynamoDB Local
+
+- Check if Docker Compose is running properly
+- Use the `docker ps` command to verify the `dynamodb-local` container is running
+- Check if port 8000 is being used by another application
+
+### Table Creation Error
+
+- Verify DynamoDB Local is running
+- Check if the `DYNAMODB_ENDPOINT` environment variable is set correctly
+
+### Worker Won't Start
+
+- Verify the agent-core module is built correctly
+- Check if environment variables are set correctly (especially `TABLE_NAME` and `OPENAI_API_KEY`)
+
+## Resources
+
+- [DynamoDB Local Official Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
+- [Remote SWE Agents Documentation](https://github.com/aws-samples/remote-swe-agents)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
+    working_dir: /home/dynamodblocal
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/shell/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  dynamodb-admin:
+    image: aaronshaf/dynamodb-admin:latest
+    container_name: dynamodb-admin
+    ports:
+      - "8001:8001"
+    environment:
+      - DYNAMO_ENDPOINT=http://dynamodb-local:8000
+      - AWS_REGION=ap-northeast-1
+    depends_on:
+      dynamodb-local:
+        condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "npm run test --workspaces",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,mts}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,mts}\"",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "start:local": "./scripts/start-local.sh"
   },
   "devDependencies": {
     "prettier": "^3.5.1",

--- a/packages/agent-core/src/lib/aws/ddb.ts
+++ b/packages/agent-core/src/lib/aws/ddb.ts
@@ -2,5 +2,17 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
 export const TableName = process.env.TABLE_NAME!;
-const client = new DynamoDBClient();
+
+// Allow configuration of DynamoDB endpoint via environment variable
+// This enables using DynamoDB Local for development
+const clientConfig: {
+  endpoint?: string;
+} = {};
+
+if (process.env.DYNAMODB_ENDPOINT) {
+  clientConfig.endpoint = process.env.DYNAMODB_ENDPOINT;
+  console.log(`Using custom DynamoDB endpoint: ${process.env.DYNAMODB_ENDPOINT}`);
+}
+
+const client = new DynamoDBClient(clientConfig);
 export const ddb = DynamoDBDocumentClient.from(client);

--- a/scripts/setup-dynamodb-local.js
+++ b/scripts/setup-dynamodb-local.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * This script sets up the necessary DynamoDB local table for development.
+ * Run this script after starting DynamoDB Local with docker-compose.
+ */
+
+const { DynamoDBClient, CreateTableCommand, ListTablesCommand } = require('@aws-sdk/client-dynamodb');
+
+// Configuration
+const ENDPOINT = process.env.DYNAMODB_ENDPOINT || 'http://localhost:8000';
+const TABLE_NAME = process.env.TABLE_NAME || 'RemoteSWEAgentsTable-local';
+const REGION = process.env.AWS_REGION || 'ap-northeast-1';
+
+// Initialize DynamoDB Client
+const client = new DynamoDBClient({
+  endpoint: ENDPOINT,
+  region: REGION,
+});
+
+// Table definition based on the actual schema used in the app
+const tableParams = {
+  TableName: TABLE_NAME,
+  AttributeDefinitions: [
+    {
+      AttributeName: 'pk',
+      AttributeType: 'S',
+    },
+    {
+      AttributeName: 'sk',
+      AttributeType: 'S',
+    },
+    {
+      AttributeName: 'gsi1pk',
+      AttributeType: 'S',
+    },
+    {
+      AttributeName: 'gsi1sk',
+      AttributeType: 'S',
+    },
+  ],
+  KeySchema: [
+    {
+      AttributeName: 'pk',
+      KeyType: 'HASH',
+    },
+    {
+      AttributeName: 'sk',
+      KeyType: 'RANGE',
+    },
+  ],
+  GlobalSecondaryIndexes: [
+    {
+      IndexName: 'gsi1',
+      KeySchema: [
+        {
+          AttributeName: 'gsi1pk',
+          KeyType: 'HASH',
+        },
+        {
+          AttributeName: 'gsi1sk',
+          KeyType: 'RANGE',
+        },
+      ],
+      Projection: {
+        ProjectionType: 'ALL',
+      },
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 5,
+        WriteCapacityUnits: 5,
+      },
+    },
+  ],
+  BillingMode: 'PROVISIONED',
+  ProvisionedThroughput: {
+    ReadCapacityUnits: 5,
+    WriteCapacityUnits: 5,
+  },
+};
+
+async function checkTableExists(tableName) {
+  try {
+    const { TableNames } = await client.send(new ListTablesCommand({}));
+    return TableNames.includes(tableName);
+  } catch (error) {
+    console.error('Error checking if table exists:', error);
+    return false;
+  }
+}
+
+async function createTable() {
+  try {
+    // Check if table already exists
+    const tableExists = await checkTableExists(TABLE_NAME);
+    
+    if (tableExists) {
+      console.log(`Table '${TABLE_NAME}' already exists.`);
+      return;
+    }
+
+    // Create table
+    const response = await client.send(new CreateTableCommand(tableParams));
+    console.log(`Table '${TABLE_NAME}' created successfully:`, response);
+  } catch (error) {
+    console.error('Error creating table:', error);
+  }
+}
+
+// Main execution
+console.log(`Setting up DynamoDB local table '${TABLE_NAME}' at ${ENDPOINT}...`);
+createTable()
+  .then(() => console.log('Setup complete.'))
+  .catch((err) => console.error('Setup failed:', err));

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Load environment variables from .env.local if exists
+if [ -f .env.local ]; then
+  export $(grep -v '^#' .env.local | xargs)
+  echo "Loaded environment variables from .env.local"
+else
+  echo "Warning: .env.local file not found. Using default values."
+  export DYNAMODB_ENDPOINT=http://localhost:8000
+  export TABLE_NAME=RemoteSWEAgentsTable-local
+  export AWS_REGION=ap-northeast-1
+  export AWS_ACCESS_KEY_ID=local
+  export AWS_SECRET_ACCESS_KEY=local
+  export WORKER_ID=local-worker
+fi
+
+# Check if DynamoDB Local is running
+if curl -s http://localhost:8000 > /dev/null; then
+  echo "DynamoDB Local is running"
+else
+  echo "Starting DynamoDB Local using Docker Compose..."
+  docker-compose up -d dynamodb-local dynamodb-admin
+  
+  # Wait for DynamoDB Local to start
+  echo "Waiting for DynamoDB Local to start..."
+  until curl -s http://localhost:8000 > /dev/null; do
+    echo "."
+    sleep 1
+  done
+  echo "DynamoDB Local is running"
+fi
+
+# Run setup script to create the table
+echo "Setting up DynamoDB Local table..."
+node scripts/setup-dynamodb-local.js
+
+# Build and start the worker
+echo "Building agent-core..."
+npm run build -w @remote-swe-agents/agent-core
+
+echo "Starting local worker..."
+cd packages/worker && npm run start:local


### PR DESCRIPTION
## Overview
This PR adds support for running the worker code with DynamoDB Local, allowing for a completely local development environment without requiring an AWS account.

## Changes
- Add `docker-compose.yml` file to set up DynamoDB Local and DynamoDB Admin
- Update the DynamoDB client configuration to allow custom endpoint through environment variables
- Add setup scripts for creating tables and starting the local environment
- Add comprehensive documentation in both English and Japanese
- Include an environment variables template (.env.local.example)

## Testing
1. Clone the repository
2. Run `cp .env.local.example .env.local` and set the required environment variables
3. Run `npm run start:local` to start DynamoDB Local and the worker

## Benefits
- Simplifies local development and testing
- Eliminates the need for an actual AWS account during development
- Provides a consistent development environment for all contributors

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1751508648419 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1751508648419