### PR TITLE
(agent-core): Set target branch when using createPullRequest tool

### DIFF
--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -15,10 +15,10 @@ const inputSchema = z.object({
   issueId: z.number().optional().describe('Optional issue ID to link with the PR'),
   force: z.boolean().default(false).describe('Ignore duplicate validation and create PR anyway'),
   gitDirectoryPath: z.string().describe('The absolute path to the git local repository'),
-  targetBranch: z
+  baseBranch: z
     .string()
     .optional()
-    .describe('The target branch for the PR. If not provided, the default branch will be used.'),
+    .describe('The base branch for the PR. If not provided, the default branch will be used.'),
 });
 
 interface PRRecord {
@@ -92,7 +92,7 @@ const addIssueReference = (description: string, issueId: number): string => {
 };
 
 const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
-  const { title, description, issueId, force, gitDirectoryPath, targetBranch } = input;
+  const { title, description, issueId, force, gitDirectoryPath, baseBranch } = input;
   const workerId = process.env.WORKER_ID!;
 
   // Check for existing PR unless force is true
@@ -139,10 +139,10 @@ const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
   writeFileSync(tempFile, finalDescription);
 
   try {
-    // Create pull request using gh CLI with optional target branch
-    const targetBranchOption = targetBranch ? ` --base "${targetBranch}"` : '';
+    // Create pull request using gh CLI with optional base branch
+    const baseBranchOption = baseBranch ? ` --base "${baseBranch}"` : '';
     const prUrl = await execute(
-      `gh pr create --title "${title}" --body-file "${tempFile}"${targetBranchOption}`,
+      `gh pr create --title "${title}" --body-file "${tempFile}"${baseBranchOption}`,
       gitDirectoryPath
     );
 

--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -15,7 +15,10 @@ const inputSchema = z.object({
   issueId: z.number().optional().describe('Optional issue ID to link with the PR'),
   force: z.boolean().default(false).describe('Ignore duplicate validation and create PR anyway'),
   gitDirectoryPath: z.string().describe('The absolute path to the git local repository'),
-  targetBranch: z.string().optional().describe('The target branch for the PR. If not provided, the default branch will be used.'),
+  targetBranch: z
+    .string()
+    .optional()
+    .describe('The target branch for the PR. If not provided, the default branch will be used.'),
 });
 
 interface PRRecord {
@@ -138,7 +141,10 @@ const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
   try {
     // Create pull request using gh CLI with optional target branch
     const targetBranchOption = targetBranch ? ` --base "${targetBranch}"` : '';
-    const prUrl = await execute(`gh pr create --title "${title}" --body-file "${tempFile}"${targetBranchOption}`, gitDirectoryPath);
+    const prUrl = await execute(
+      `gh pr create --title "${title}" --body-file "${tempFile}"${targetBranchOption}`,
+      gitDirectoryPath
+    );
 
     // Store PR record in DynamoDB
     await storePRRecord(workerId, prUrl, branchName);

--- a/packages/agent-core/src/tools/create-pr/index.ts
+++ b/packages/agent-core/src/tools/create-pr/index.ts
@@ -15,6 +15,7 @@ const inputSchema = z.object({
   issueId: z.number().optional().describe('Optional issue ID to link with the PR'),
   force: z.boolean().default(false).describe('Ignore duplicate validation and create PR anyway'),
   gitDirectoryPath: z.string().describe('The absolute path to the git local repository'),
+  targetBranch: z.string().optional().describe('The target branch for the PR. If not provided, the default branch will be used.'),
 });
 
 interface PRRecord {
@@ -88,7 +89,7 @@ const addIssueReference = (description: string, issueId: number): string => {
 };
 
 const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
-  const { title, description, issueId, force, gitDirectoryPath } = input;
+  const { title, description, issueId, force, gitDirectoryPath, targetBranch } = input;
   const workerId = process.env.WORKER_ID!;
 
   // Check for existing PR unless force is true
@@ -135,8 +136,9 @@ const createPullRequest = async (input: z.infer<typeof inputSchema>) => {
   writeFileSync(tempFile, finalDescription);
 
   try {
-    // Create pull request using gh CLI
-    const prUrl = await execute(`gh pr create --title "${title}" --body-file "${tempFile}"`, gitDirectoryPath);
+    // Create pull request using gh CLI with optional target branch
+    const targetBranchOption = targetBranch ? ` --base "${targetBranch}"` : '';
+    const prUrl = await execute(`gh pr create --title "${title}" --body-file "${tempFile}"${targetBranchOption}`, gitDirectoryPath);
 
     // Store PR record in DynamoDB
     await storePRRecord(workerId, prUrl, branchName);


### PR DESCRIPTION
## Description

This PR implements the functionality to set target branch when using the `createPullRequest` tool, as described in issue #264.

## Changes

- Added `targetBranch` optional parameter to the `inputSchema` object
- Modified the PR creation command to include the `--base` option when `targetBranch` is provided
- The tool will continue to use the repository's default branch if no target branch is specified

## Related Issue

Closes #264

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1751595254698659 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/1751595254698659