### PR TITLE
Allow adjusting thinking budget from user

### DIFF
--- a/packages/agent-core/src/lib/__tests__/converse.test.ts
+++ b/packages/agent-core/src/lib/__tests__/converse.test.ts
@@ -1,0 +1,188 @@
+import { ConverseCommandInput } from '@aws-sdk/client-bedrock-runtime';
+
+// Import and mock the module to isolate the detectThinkingBudget function for testing
+jest.mock('@aws-sdk/client-bedrock-runtime');
+jest.mock('@aws-sdk/client-sts');
+jest.mock('../aws', () => ({
+  ddb: {
+    send: jest.fn(),
+  },
+  TableName: undefined,
+}));
+
+// Import the actual module under test
+const originalModule = jest.requireActual('../converse');
+
+// Create a test suite for the detectThinkingBudget function
+describe('detectThinkingBudget', () => {
+  // We need to access the private function for testing
+  const detectThinkingBudget: (input: ConverseCommandInput) => number = (originalModule as any).detectThinkingBudget;
+  const DEFAULT_THINKING_BUDGET = 1024;
+  const EXTENDED_THINKING_BUDGET = 4096;
+
+  // Test case: should return default budget when there are no messages
+  test('should return default budget when there are no messages', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(DEFAULT_THINKING_BUDGET);
+  });
+
+  // Test case: should return default budget for regular message
+  test('should return default budget for regular message', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'Hello, can you help me with this question?',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(DEFAULT_THINKING_BUDGET);
+  });
+
+  // Test case: should return extended budget when message contains 'ultrathink'
+  test('should return extended budget when message contains ultrathink keyword', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'ultrathink Please analyze this complex problem',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(EXTENDED_THINKING_BUDGET);
+  });
+
+  // Test case: should return default budget when message contains 'normalthink'
+  test('should return default budget when message contains normalthink keyword', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'normalthink Please solve this simple problem',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(DEFAULT_THINKING_BUDGET);
+  });
+
+  // Test case: should handle case-insensitive keywords
+  test('should handle case-insensitive keywords', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'ULTRATHINK please analyze this',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(EXTENDED_THINKING_BUDGET);
+  });
+
+  // Test case: should only detect keywords in the most recent user message
+  test('should only detect keywords in the most recent user message', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'ultrathink please analyze this',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              text: 'I will analyze this problem.',
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'Thank you for the help',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(DEFAULT_THINKING_BUDGET);
+  });
+
+  // Test case: should handle multiple content parts
+  test('should handle multiple content parts', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'First part of the message',
+            },
+            {
+              text: 'Second part with ultrathink keyword',
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(EXTENDED_THINKING_BUDGET);
+  });
+
+  // Test case: should handle non-text content parts
+  test('should handle non-text content parts', () => {
+    const input: Partial<ConverseCommandInput> = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: 'ultrathink Please analyze this image',
+            },
+            {
+              // Non-text content (like an image)
+              image: Buffer.from('dummy image data'),
+            },
+          ],
+        },
+      ],
+    };
+    
+    const result = detectThinkingBudget(input as ConverseCommandInput);
+    expect(result).toBe(EXTENDED_THINKING_BUDGET);
+  });
+});


### PR DESCRIPTION
## Description

This PR implements a feature that allows users to adjust the thinking budget by using specific keywords in their messages. It addresses [Issue #263](https://github.com/aws-samples/remote-swe-agents/issues/263) which requested a way for users to adjust the thinking budget according to their needs.

### Implementation Details

1. **Keyword Detection**:
   - Added `detectThinkingBudget` function that scans the latest user message for specific keywords.
   - Implemented two keywords:
     - `ultrathink` - Sets an extended thinking budget (4096 tokens)
     - `normalthink` - Explicitly sets the default thinking budget (1024 tokens)

2. **Per-Turn Budget Adjustment**:
   - The thinking budget is determined on a per-turn basis based on the latest user message
   - Keywords only affect the turn where they appear, following the turn-based consistency principle

3. **Constants for Budget Values**:
   - Defined constants for both default and extended thinking budgets
   - Makes future adjustments to the budget values straightforward

### Example Usage

```
User: ultrathink Please analyze this complex problem in detail...
```

This will temporarily increase the thinking budget to 4096 tokens for this specific turn, allowing for more thorough analysis.

### Test Coverage

Added comprehensive test cases for the `detectThinkingBudget` function:
- Detection of both keywords (`ultrathink` and `normalthink`)
- Case-insensitive keyword matching
- Handling of multi-part messages
- Handling of non-text content
- Ensuring only the most recent message is analyzed

Fixes #263

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1751597039893219 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/1751597039893219