### PR TITLE
fix fluent-bit log in cloudwatch is duplicated on instance reboot

### DIFF
--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -367,17 +367,20 @@ EOF
     userData.addCommands(`
 # Configure Fluent Bit for CloudWatch Logs
 mkdir -p /etc/fluent-bit
+mkdir -p /var/lib/fluent-bit
 
 cat << EOF > /etc/fluent-bit/fluent-bit.conf
 [SERVICE]
     Flush        5
     Daemon       Off
     Log_Level    info
+    storage.path /var/lib/fluent-bit/
 
 [INPUT]
-    Name         systemd
-    Tag          myapp
-    Systemd_Filter    _SYSTEMD_UNIT=myapp.service
+    Name           systemd
+    Tag            myapp
+    Systemd_Filter _SYSTEMD_UNIT=myapp.service
+    DB             /var/lib/fluent-bit/systemd.db
 
 [FILTER]
     Name         modify

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -4592,6 +4592,8 @@ phases:
 
               mkdir -p /etc/fluent-bit
 
+              mkdir -p /var/lib/fluent-bit
+
 
               cat << EOF > /etc/fluent-bit/fluent-bit.conf
 
@@ -4603,14 +4605,18 @@ phases:
 
               \\    Log_Level    info
 
+              \\    storage.path /var/lib/fluent-bit/
+
 
               [INPUT]
 
-              \\    Name         systemd
+              \\    Name           systemd
 
-              \\    Tag          myapp
+              \\    Tag            myapp
 
-              \\    Systemd_Filter    _SYSTEMD_UNIT=myapp.service
+              \\    Systemd_Filter _SYSTEMD_UNIT=myapp.service
+
+              \\    DB             /var/lib/fluent-bit/systemd.db
 
 
               [FILTER]
@@ -5305,6 +5311,8 @@ phases:
 
               mkdir -p /etc/fluent-bit
 
+              mkdir -p /var/lib/fluent-bit
+
 
               cat << EOF > /etc/fluent-bit/fluent-bit.conf
 
@@ -5316,14 +5324,18 @@ phases:
 
               \\    Log_Level    info
 
+              \\    storage.path /var/lib/fluent-bit/
+
 
               [INPUT]
 
-              \\    Name         systemd
+              \\    Name           systemd
 
-              \\    Tag          myapp
+              \\    Tag            myapp
 
-              \\    Systemd_Filter    _SYSTEMD_UNIT=myapp.service
+              \\    Systemd_Filter _SYSTEMD_UNIT=myapp.service
+
+              \\    DB             /var/lib/fluent-bit/systemd.db
 
 
               [FILTER]
@@ -5718,17 +5730,20 @@ EOF
 
 # Configure Fluent Bit for CloudWatch Logs
 mkdir -p /etc/fluent-bit
+mkdir -p /var/lib/fluent-bit
 
 cat << EOF > /etc/fluent-bit/fluent-bit.conf
 [SERVICE]
     Flush        5
     Daemon       Off
     Log_Level    info
+    storage.path /var/lib/fluent-bit/
 
 [INPUT]
-    Name         systemd
-    Tag          myapp
-    Systemd_Filter    _SYSTEMD_UNIT=myapp.service
+    Name           systemd
+    Tag            myapp
+    Systemd_Filter _SYSTEMD_UNIT=myapp.service
+    DB             /var/lib/fluent-bit/systemd.db
 
 [FILTER]
     Name         modify


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We now store the cursor position in file system so that it is not reset on every reboot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
