### PR TITLE
Add WebUI URL to Slack messages at the end of agent loop

### DIFF
--- a/packages/agent-core/src/lib/messages.ts
+++ b/packages/agent-core/src/lib/messages.ts
@@ -8,6 +8,7 @@ import { ddb, TableName } from './aws/ddb';
 import { writeBytesToKey, getBytesFromKey } from './aws/s3';
 import { sendWebappEvent } from './events';
 import { sendMessageToSlack } from './slack';
+import { getWebappSessionUrl } from './webapp-origin';
 import { MessageItem } from '../schema';
 
 // Maximum input token count before applying middle-out strategy
@@ -305,9 +306,20 @@ const postProcessMessageContent = async (content: string) => {
   return flattenedArray;
 };
 
-export const sendSystemMessage = async (workerId: string, message: string) => {
-  await Promise.all([
-    sendWebappEvent(workerId, { type: 'message', role: 'assistant', message }),
-    sendMessageToSlack(message),
-  ]);
+export const sendSystemMessage = async (workerId: string, message: string, appendWebappUrl: boolean = false) => {
+  // Always send original message to webapp
+  await sendWebappEvent(workerId, { type: 'message', role: 'assistant', message });
+  
+  // For Slack, optionally append webapp URL
+  if (appendWebappUrl) {
+    const sessionUrl = await getWebappSessionUrl(workerId);
+    if (sessionUrl) {
+      const slackMessage = `${message} ([webapp](${sessionUrl}))`;
+      await sendMessageToSlack(slackMessage);
+    } else {
+      await sendMessageToSlack(message);
+    }
+  } else {
+    await sendMessageToSlack(message);
+  }
 };

--- a/packages/agent-core/src/lib/messages.ts
+++ b/packages/agent-core/src/lib/messages.ts
@@ -309,7 +309,7 @@ const postProcessMessageContent = async (content: string) => {
 export const sendSystemMessage = async (workerId: string, message: string, appendWebappUrl: boolean = false) => {
   // Always send original message to webapp
   await sendWebappEvent(workerId, { type: 'message', role: 'assistant', message });
-  
+
   // For Slack, optionally append webapp URL
   if (appendWebappUrl) {
     const sessionUrl = await getWebappSessionUrl(workerId);

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -434,7 +434,8 @@ Users will primarily request software engineering assistance including bug fixes
       const responseText = finalMessage.content?.at(-1)?.text ?? finalMessage.content?.at(0)?.text ?? '';
       // remove <thinking> </thinking> part with multiline support
       const responseTextWithoutThinking = responseText.replace(/<thinking>[\s\S]*?<\/thinking>/g, '');
-      await sendSystemMessage(workerId, `${mention}${responseTextWithoutThinking}`);
+      // Pass true to appendWebappUrl parameter to add the webapp URL to the Slack message at the end of agent loop
+      await sendSystemMessage(workerId, `${mention}${responseTextWithoutThinking}`, true);
       break;
     }
   }


### PR DESCRIPTION
## Description

This PR adds the WebUI URL link to Slack messages when the agent finishes its turn. This makes it easier for users to access the WebUI session from anywhere in a long Slack thread without having to scroll back to the beginning.

## Implementation

- Added an optional `appendWebappUrl` parameter to `sendSystemMessage` function with default value of `false`
- When `appendWebappUrl` is `true`, the function appends a markdown link to the webapp session URL at the end of the Slack message: `([webapp](URL))`
- Modified the agent loop to use this parameter only at the end of the agent turn

## Changes

- Modified `packages/agent-core/src/lib/messages.ts` to add the optional parameter and webapp URL handling
- Modified `packages/worker/src/agent/index.ts` to pass `true` for the parameter at the end of the agent loop

## Related Issues

Fixes #270

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1751622968753739 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/1751622968753739