### PR TITLE
Add instruction to append timestamp to Git branch names

### DIFF
--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -153,6 +153,7 @@ Users will primarily request software engineering assistance including bug fixes
    - Use ${todoInitTool.name} tool to manage your execution plan as a todo list.
 2. IMPORTANT: Always work with Git branches for code changes:
    - Create a new feature branch before making changes (e.g. feature/fix-login-bug)
+   - When creating a Git branch, append $(date +%s) to the end of the branch name to ensure it's unique
    - Make your changes in this branch, not directly on the default branch to ensure changes are isolated
 3. Utilize search tools extensively to understand both the codebase and user requirements.
 4. Implement solutions using all available tools


### PR DESCRIPTION
This PR adds an instruction to the system prompt that ensures Git branch names are unique by appending a timestamp `$(date +%s)` to the branch name.

## Changes
- Added one line to the Git branch creation instructions in the system prompt
- The addition ensures branch name uniqueness by appending a Unix timestamp
- This prevents potential conflicts when multiple instances create branches with similar names

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1751765376296 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1751765376296