### PR TITLE
Add thinking budget indicator to webapp

### DIFF
--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -103,9 +103,9 @@ export const bedrockConverse = async (
       modelType,
       maxTokensExceededCount
     );
-    
+
     const command = new ConverseCommand(processedInput);
-    
+
     // If we detected ultrathink and have a budget, send it to webapp
     if (thinkingBudget) {
       try {
@@ -157,7 +157,11 @@ const shouldUltraThink = (input: ConverseCommandInput): boolean => {
   return messageText.includes(ULTRA_THINKING_KEYWORD);
 };
 
-const preProcessInput = (input: ConverseCommandInput, modelType: ModelType, maxTokensExceededCount: number): { input: ConverseCommandInput; thinkingBudget?: number } => {
+const preProcessInput = (
+  input: ConverseCommandInput,
+  modelType: ModelType,
+  maxTokensExceededCount: number
+): { input: ConverseCommandInput; thinkingBudget?: number } => {
   const modelConfig = modelConfigSchema.parse(modelConfigs[modelType]);
   // we cannot use JSON.parse(JSON.stringify(input)) here because input sometimes contains Buffer object for image.
   input = structuredClone(input);
@@ -189,7 +193,7 @@ const preProcessInput = (input: ConverseCommandInput, modelType: ModelType, maxT
   }
 
   let thinkingBudget: number | undefined = undefined;
-  
+
   if (enableReasoning) {
     // Detect if we need to adjust the thinking budget based on keywords
     const enableUltraThink = shouldUltraThink(input);

--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -188,6 +188,21 @@ const preProcessInput = (input: ConverseCommandInput, modelType: ModelType, maxT
       },
     };
 
+    // Send thinking budget event to webapp if workerId is available
+    const workerId = input.conversationId;
+    if (workerId && typeof workerId === 'string') {
+      try {
+        // Import here to avoid circular dependency
+        const { sendWebappEvent } = require('./events');
+        sendWebappEvent(workerId, {
+          type: 'thinkingBudget',
+          budget,
+        });
+      } catch (e) {
+        console.error('Failed to send thinking budget event:', e);
+      }
+    }
+
     // Adjust output tokens as well
     input.inferenceConfig = {
       ...input.inferenceConfig,

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -37,4 +37,10 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     timestamp: z.number(),
     workerId: z.string(),
   }),
+  z.object({
+    type: z.literal('thinkingBudget'),
+    budget: z.number(),
+    timestamp: z.number(),
+    workerId: z.string(),
+  }),
 ]);

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -46,6 +46,7 @@ export default function SessionPageClient({
   const [instanceStatus, setInstanceStatus] = useState<InstanceStatus | undefined>(initialInstanceStatus);
   const [agentStatus, setAgentStatus] = useState<AgentStatus | undefined>(initialAgentStatus);
   const [todoList, setTodoList] = useState<TodoListType | null>(initialTodoList);
+  const [thinkingBudget, setThinkingBudget] = useState<number | null>(null);
 
   // Update state when props change (e.g., on refresh)
   useEffect(() => {
@@ -153,6 +154,9 @@ export default function SessionPageClient({
             break;
           case 'agentStatusUpdate':
             setAgentStatus(event.status);
+            break;
+          case 'thinkingBudget':
+            setThinkingBudget(event.budget);
             break;
           case 'toolResult':
             setMessages((prev) => {
@@ -299,6 +303,14 @@ export default function SessionPageClient({
                     className={`inline-block w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full flex-shrink-0 ${getSessionStatus().color}`}
                   />
                   <span className="text-xs sm:text-sm font-medium truncate">{getSessionStatus().text}</span>
+                </div>
+              )}
+              {thinkingBudget && (
+                <div className="flex items-center gap-1 sm:gap-2 ml-2">
+                  <div className="px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded text-xs font-medium">
+                    <span className="hidden sm:inline">{t('thinkingBudget')}: </span>
+                    <span>{thinkingBudget.toLocaleString()} tokens</span>
+                  </div>
                 </div>
               )}
               {todoList && (

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -82,6 +82,7 @@
     "interruptToolTip": "Interrupt (or press Escape)",
     "initiatedByOtherUsers": "Initiated by other users",
     "attachImage": "Attach image",
+    "thinkingBudget": "Thinking Budget",
     "shareSession": "Take Over Session",
     "shareSessionDescription": "Post this text to Slack with an app mention to send messages to the session and receive notifications.",
     "copyToClipboard": "Copy to Clipboard",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -82,6 +82,7 @@
     "interruptToolTip": "Escapeキーで中断",
     "initiatedByOtherUsers": "他のユーザーが開始",
     "attachImage": "画像を添付",
+    "thinkingBudget": "思考予算",
     "shareSession": "セッションを引き継ぎ",
     "shareSessionDescription": "このテキストをアプリへのメンション付きでSlackに投稿すると、セッションにSlackからメッセージを送ったり通知を受信したりできます。",
     "copyToClipboard": "クリップボードにコピー",


### PR DESCRIPTION
This PR implements the thinking budget indicator feature requested in #288.

## Changes
1. Added a new `thinkingBudget` event type to the webapp event schema
2. Modified the worker code to send the thinking budget event when ultrathink is detected
3. Updated SessionPageClient.tsx to handle the event and display the thinking budget indicator
4. Added translations for the thinking budget text in both English and Japanese

## Implementation Details
- When ultrathink is detected, the converse.ts file sends a `thinkingBudget` event with the budget value
- The webapp displays the thinking budget as a purple badge in the header area
- The indicator shows the number of tokens allocated for thinking

This indicator helps users understand when the ultra think feature is active and how many tokens are allocated for the thinking process.

Closes #288

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:api-1752654240377 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/api-1752654240377