### PR TITLE
Show extended thinking content in the webapp

### DIFF
--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -9,6 +9,7 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     message: z.string(),
     timestamp: z.number(),
     thinkingBudget: z.number().optional(),
+    reasoningText: z.string().optional(),
   }),
   z.object({
     type: z.literal('toolUse'),
@@ -18,6 +19,7 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     input: z.string(),
     timestamp: z.number(),
     thinkingBudget: z.number().optional(),
+    reasoningText: z.string().optional(),
   }),
   z.object({
     type: z.literal('toolResult'),

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Copy } from 'lucide-react';
+import React, { useState } from 'react';
+import { Copy, ThoughtBubble } from 'lucide-react';
 import { useTranslations, useLocale } from 'next-intl';
 import { toast } from 'sonner';
 import { MessageView } from './MessageList';
@@ -17,6 +17,7 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
   const t = useTranslations('sessions');
   const locale = useLocale();
   const localeForDate = locale === 'ja' ? 'ja-JP' : 'en-US';
+  const [showReasoning, setShowReasoning] = useState(false);
 
   const copyMessageToClipboard = (content: string) => {
     navigator.clipboard
@@ -57,6 +58,23 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
                   <MarkdownRenderer content={message.content} />
                 )}
                 {message.imageKeys && message.imageKeys.length > 0 && <ImageViewer imageKeys={message.imageKeys} />}
+                
+                {message.reasoningText && (
+                  <div className="mt-2">
+                    <button
+                      onClick={() => setShowReasoning(!showReasoning)}
+                      className="flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 mb-1"
+                    >
+                      <ThoughtBubble className="w-3.5 h-3.5 mr-1" />
+                      {showReasoning ? t('hideThinking') || 'Hide thinking' : t('showThinking') || 'Show thinking'}
+                    </button>
+                    {showReasoning && (
+                      <div className="mt-1 p-2 rounded-md bg-gray-100 dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700">
+                        <MarkdownRenderer content={message.reasoningText} />
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
               {message.type === 'message' && message.role === 'assistant' && (
                 <button

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -58,7 +58,7 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
                   <MarkdownRenderer content={message.content} />
                 )}
                 {message.imageKeys && message.imageKeys.length > 0 && <ImageViewer imageKeys={message.imageKeys} />}
-                
+
                 {message.reasoningText && (
                   <div className="mt-2">
                     <button

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Copy, Brain } from 'lucide-react';
+import { Copy, ChevronDown, ChevronUp, ChevronRight } from 'lucide-react';
 import { useTranslations, useLocale } from 'next-intl';
 import { toast } from 'sonner';
 import { MessageView } from './MessageList';
@@ -52,20 +52,16 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
           <div className="text-gray-900 dark:text-white pb-2 break-all">
             <div className="flex items-start">
               <div className="flex-1">
-                {message.role === 'user' ? (
-                  <UrlRenderer content={message.content} />
-                ) : (
-                  <MarkdownRenderer content={message.content} />
-                )}
-                {message.imageKeys && message.imageKeys.length > 0 && <ImageViewer imageKeys={message.imageKeys} />}
-
                 {message.reasoningText && (
-                  <div className="mt-2">
+                  <div className="mb-3">
                     <button
                       onClick={() => setShowReasoning(!showReasoning)}
                       className="flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 mb-1"
                     >
-                      <Brain className="w-3.5 h-3.5 mr-1" />
+                      {showReasoning ? 
+                        <ChevronDown className="w-3.5 h-3.5 mr-1" /> : 
+                        <ChevronRight className="w-3.5 h-3.5 mr-1" />
+                      }
                       {showReasoning ? t('hideThinking') || 'Hide thinking' : t('showThinking') || 'Show thinking'}
                     </button>
                     {showReasoning && (
@@ -75,6 +71,12 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
                     )}
                   </div>
                 )}
+                {message.role === 'user' ? (
+                  <UrlRenderer content={message.content} />
+                ) : (
+                  <MarkdownRenderer content={message.content} />
+                )}
+                {message.imageKeys && message.imageKeys.length > 0 && <ImageViewer imageKeys={message.imageKeys} />}
               </div>
               {message.type === 'message' && message.role === 'assistant' && (
                 <button

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Copy, ThoughtBubble } from 'lucide-react';
+import { Copy, Brain } from 'lucide-react';
 import { useTranslations, useLocale } from 'next-intl';
 import { toast } from 'sonner';
 import { MessageView } from './MessageList';
@@ -65,7 +65,7 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
                       onClick={() => setShowReasoning(!showReasoning)}
                       className="flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 mb-1"
                     >
-                      <ThoughtBubble className="w-3.5 h-3.5 mr-1" />
+                      <Brain className="w-3.5 h-3.5 mr-1" />
                       {showReasoning ? t('hideThinking') || 'Hide thinking' : t('showThinking') || 'Show thinking'}
                     </button>
                     {showReasoning && (

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -58,10 +58,11 @@ export const MessageItem = ({ message, showTimestamp }: MessageItemProps) => {
                       onClick={() => setShowReasoning(!showReasoning)}
                       className="flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 mb-1"
                     >
-                      {showReasoning ? 
-                        <ChevronDown className="w-3.5 h-3.5 mr-1" /> : 
+                      {showReasoning ? (
+                        <ChevronDown className="w-3.5 h-3.5 mr-1" />
+                      ) : (
                         <ChevronRight className="w-3.5 h-3.5 mr-1" />
-                      }
+                      )}
                       {showReasoning ? t('hideThinking') || 'Hide thinking' : t('showThinking') || 'Show thinking'}
                     </button>
                     {showReasoning && (

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -18,6 +18,7 @@ export type MessageView = {
   type: 'message' | 'toolResult' | 'toolUse';
   imageKeys?: string[];
   thinkingBudget?: number;
+  reasoningText?: string;
 };
 
 type MessageGroup = {

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -144,6 +144,7 @@ export default function SessionPageClient({
                     timestamp: new Date(event.timestamp),
                     type: 'message',
                     thinkingBudget: event.thinkingBudget,
+                    reasoningText: event.reasoningText,
                   },
                 ]);
               }
@@ -185,6 +186,7 @@ export default function SessionPageClient({
                     timestamp: new Date(event.timestamp),
                     type: 'message',
                     thinkingBudget: event.thinkingBudget,
+                    reasoningText: event.reasoningText,
                   },
                 ]);
               }

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -58,11 +58,11 @@ export default async function SessionPage({ params }: SessionPageProps) {
 
               // Extract reasoning content if available
               let reasoningText: string | undefined;
-              const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+              const reasoningBlocks = message.content?.filter((block) => block.reasoningContent) ?? [];
               if (reasoningBlocks.length > 0) {
                 reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
               }
-              
+
               messages.push({
                 id: `${item.SK}-${i}-${toolUseId}`,
                 role: 'assistant',
@@ -76,14 +76,14 @@ export default async function SessionPage({ params }: SessionPageProps) {
             } else {
               // Handle sendMessageToUser and sendMessageToUserIfNecessary as before
               const messageText = formatMessage(input?.message ?? '');
-              
+
               // Extract reasoning content if available
               let reasoningText: string | undefined;
-              const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+              const reasoningBlocks = message.content?.filter((block) => block.reasoningContent) ?? [];
               if (reasoningBlocks.length > 0) {
                 reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
               }
-              
+
               if (messageText) {
                 messages.push({
                   id: `${item.SK}-${i}-${toolUseId}`,
@@ -161,14 +161,14 @@ export default async function SessionPage({ params }: SessionPageProps) {
       case 'assistant': {
         const text = (message.content?.map((c) => c.text).filter((c) => c) ?? []).join('\n');
         const formatted = formatMessage(text);
-        
+
         // Extract reasoning content if available
         let reasoningText: string | undefined;
-        const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+        const reasoningBlocks = message.content?.filter((block) => block.reasoningContent) ?? [];
         if (reasoningBlocks.length > 0) {
           reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
         }
-        
+
         if (formatted) {
           messages.push({
             id: `${item.SK}-${i}`,

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -56,6 +56,13 @@ export default async function SessionPage({ params }: SessionPageProps) {
               const messageText = formatMessage(input?.message ?? '');
               const key = getAttachedImageKey(workerId, toolUseId, input.imagePath);
 
+              // Extract reasoning content if available
+              let reasoningText: string | undefined;
+              const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+              if (reasoningBlocks.length > 0) {
+                reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
+              }
+              
               messages.push({
                 id: `${item.SK}-${i}-${toolUseId}`,
                 role: 'assistant',
@@ -64,10 +71,19 @@ export default async function SessionPage({ params }: SessionPageProps) {
                 type: 'message',
                 imageKeys: [key],
                 thinkingBudget: item.thinkingBudget,
+                reasoningText,
               });
             } else {
               // Handle sendMessageToUser and sendMessageToUserIfNecessary as before
               const messageText = formatMessage(input?.message ?? '');
+              
+              // Extract reasoning content if available
+              let reasoningText: string | undefined;
+              const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+              if (reasoningBlocks.length > 0) {
+                reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
+              }
+              
               if (messageText) {
                 messages.push({
                   id: `${item.SK}-${i}-${toolUseId}`,
@@ -76,6 +92,7 @@ export default async function SessionPage({ params }: SessionPageProps) {
                   timestamp: new Date(parseInt(item.SK)),
                   type: 'message',
                   thinkingBudget: item.thinkingBudget,
+                  reasoningText,
                 });
               }
             }
@@ -144,6 +161,14 @@ export default async function SessionPage({ params }: SessionPageProps) {
       case 'assistant': {
         const text = (message.content?.map((c) => c.text).filter((c) => c) ?? []).join('\n');
         const formatted = formatMessage(text);
+        
+        // Extract reasoning content if available
+        let reasoningText: string | undefined;
+        const reasoningBlocks = message.content?.filter(block => block.reasoningContent) ?? [];
+        if (reasoningBlocks.length > 0) {
+          reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
+        }
+        
         if (formatted) {
           messages.push({
             id: `${item.SK}-${i}`,
@@ -152,6 +177,7 @@ export default async function SessionPage({ params }: SessionPageProps) {
             timestamp: new Date(parseInt(item.SK)),
             type: 'message',
             thinkingBudget: item.thinkingBudget,
+            reasoningText,
           });
         }
         break;

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -63,6 +63,8 @@
     "copyMessage": "Copy message",
     "copySuccess": "Copied to clipboard",
     "copyFailed": "Failed to copy",
+    "showThinking": "Show thinking",
+    "hideThinking": "Hide thinking",
     "scrollToTop": "Scroll to top",
     "scrollToBottom": "Scroll to bottom",
     "todoList": "Todo List",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -63,6 +63,8 @@
     "copyMessage": "メッセージをコピー",
     "copySuccess": "クリップボードにコピーしました",
     "copyFailed": "コピーに失敗しました",
+    "showThinking": "思考内容を表示",
+    "hideThinking": "思考内容を非表示",
     "scrollToTop": "一番上までスクロール",
     "scrollToBottom": "一番下までスクロール",
     "todoList": "Todoリスト",

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -479,25 +479,6 @@ Users will primarily request software engineering assistance including bug fixes
       const responseText = finalMessage.content?.at(-1)?.text ?? finalMessage.content?.at(0)?.text ?? '';
       // remove <thinking> </thinking> part with multiline support
       const responseTextWithoutThinking = responseText.replace(/<thinking>[\s\S]*?<\/thinking>/g, '');
-
-      // Extract reasoning content if available
-      const reasoningBlocks = finalMessage.content?.filter((block) => block.reasoningContent) ?? [];
-      let reasoningText: string | undefined;
-      if (reasoningBlocks.length > 0) {
-        reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
-      }
-
-      // Send message event to webapp with reasoning text
-      if (responseTextWithoutThinking.trim() !== '') {
-        await sendWebappEvent(workerId, {
-          type: 'message',
-          role: 'assistant',
-          message: responseTextWithoutThinking,
-          thinkingBudget: detectedBudget,
-          reasoningText,
-        });
-      }
-
       // Pass true to appendWebappUrl parameter to add the webapp URL to the Slack message at the end of agent loop
       await sendSystemMessage(workerId, `${mention}${responseTextWithoutThinking}`, true);
       break;

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -356,7 +356,7 @@ Users will primarily request software engineering assistance including bug fixes
           throw new Error('toolUse is null');
         }
         // Extract reasoning content if available
-        const reasoningBlocks = toolUseMessage.content?.filter(block => block.reasoningContent) ?? [];
+        const reasoningBlocks = toolUseMessage.content?.filter((block) => block.reasoningContent) ?? [];
         let reasoningText: string | undefined;
         if (reasoningBlocks.length > 0) {
           reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
@@ -479,14 +479,14 @@ Users will primarily request software engineering assistance including bug fixes
       const responseText = finalMessage.content?.at(-1)?.text ?? finalMessage.content?.at(0)?.text ?? '';
       // remove <thinking> </thinking> part with multiline support
       const responseTextWithoutThinking = responseText.replace(/<thinking>[\s\S]*?<\/thinking>/g, '');
-      
+
       // Extract reasoning content if available
-      const reasoningBlocks = finalMessage.content?.filter(block => block.reasoningContent) ?? [];
+      const reasoningBlocks = finalMessage.content?.filter((block) => block.reasoningContent) ?? [];
       let reasoningText: string | undefined;
       if (reasoningBlocks.length > 0) {
         reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
       }
-      
+
       // Send message event to webapp with reasoning text
       if (responseTextWithoutThinking.trim() !== '') {
         await sendWebappEvent(workerId, {
@@ -497,7 +497,7 @@ Users will primarily request software engineering assistance including bug fixes
           reasoningText,
         });
       }
-      
+
       // Pass true to appendWebappUrl parameter to add the webapp URL to the Slack message at the end of agent loop
       await sendSystemMessage(workerId, `${mention}${responseTextWithoutThinking}`, true);
       break;


### PR DESCRIPTION
This PR implements the display of reasoning/thinking content in the webapp as requested in issue #286.

## Changes
- Added `reasoningText` field to `MessageView` type to store thinking content
- Updated `webappEventSchema` to include optional `reasoningText` property in message and toolUse events
- Modified `MessageItem.tsx` to display a "Show thinking" button when reasoning content is available
- Implemented a collapsible UI for displaying reasoning content
- Added translation strings for "Show thinking" and "Hide thinking" buttons in English and Japanese
- Updated worker to extract and pass reasoning content to the webapp in events
- Modified `page.tsx` to extract reasoning content from DynamoDB records

## Implementation Details
- Reasoning content is displayed in a collapsible section under the message
- Reasoning content is initially hidden and can be toggled with a button
- When displayed, reasoning is shown in a styled box distinct from the main message

Fixes #286

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:api-1752723824146 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/api-1752723824146