### PR TITLE
Update ultrathink prompt directive

### DIFF
--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -131,7 +131,7 @@ IMPORTANT:
 - DO NOT make up any urls by yourself because it is unreliable. Instead, use search engines such as https://www.google.com/search?q=QUERY or https://www.bing.com/search?q=QUERY
 - Some pages can be inaccessible due to permission issues or bot protection. If you encountered these, just returns a message "I cannot access to the page due to REASON...". DO NOT make up any information guessing from the URL.
 - When you are asked to check URLs of GitHub domain (github.com), you should use GitHub CLI with ${commandExecutionTool.name} tool to check the information, because it is often more efficient.
-- The keyword 'ultrathink' in user messages is used for thinking budget adjustment and should be ignored semantically.
+- When you see the keyword 'ultrathink' in user messages, you should use your thinking budget to its maximum capacity and perform deep analysis before responding.
 
 ## Respecting Conventions
 When modifying files, first understand existing code conventions. Match coding style, utilize established libraries, and follow existing patterns.


### PR DESCRIPTION
## Changes made

This PR modifies the behavior of the `ultrathink` keyword in the agent prompt. Previously, this keyword was instructed to be ignored semantically. With this change, when the keyword appears in user messages, the agent will:

- Use its thinking budget to maximum capacity
- Perform deep analysis before responding

This change will enable users to request more thorough analysis on complex topics when needed.

## Testing

This change only affects the agent's prompt and behavior with a specific keyword and doesn't require additional unit tests.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1752725684662 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1752725684662