### PR TITLE
Add one-click deployment documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ You can view all the public pull requests created by the agent [here](https://gi
 
 ## Installation Steps
 
-This project supports two installation patterns depending on your needs. Choose the pattern that best fits your requirements:
+For a simple deployment with minimal configuration, you can use our one-click deployment solution: [AWS Sample One-Click Generative AI Solutions](https://aws-samples.github.io/sample-one-click-generative-ai-solutions/)
+
+This project also supports two detailed installation patterns depending on your needs. Choose the pattern that best fits your requirements:
 
 - **Pattern A (Web Interface Only)**: Quick setup for webapp access only
 - **Pattern B (Web + Slack Integration)**: Full setup with both webapp and Slack bot functionality

--- a/README_ja.md
+++ b/README_ja.md
@@ -31,7 +31,9 @@ Remote SWE エージェントによるセッション例：
 
 ## インストール手順
 
-このプロジェクトはニーズに応じて2つのインストールパターンをサポートしています。要件に最も適したパターンを選択してください：
+最小限の設定で簡単にデプロイするには、ワンクリックデプロイメントソリューションをご利用いただけます: [AWS Sample One-Click Generative AI Solutions](https://aws-samples.github.io/sample-one-click-generative-ai-solutions/)
+
+このプロジェクトはニーズに応じて2つの詳細なインストールパターンもサポートしています。要件に最も適したパターンを選択してください：
 
 - **パターンA（Webインターフェースのみ）**：webappアクセスのみのクイックセットアップ
 - **パターンB（Web + Slack統合）**：webappとSlackボット機能の両方を含む完全セットアップ


### PR DESCRIPTION
This PR adds links to the one-click deployment documentation in both README.md and README_ja.md files.

The links point to the AWS Sample One-Click Generative AI Solutions page (https://aws-samples.github.io/sample-one-click-generative-ai-solutions/) and are placed immediately after the "Installation Steps" heading, making it easy for users to find this simplified deployment option.

The text is concise (2 lines) and maintains consistency between both the English and Japanese versions of the README.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1753103134247 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1753103134247