### PR TITLE
fix: slack empty mention and workflow replies

### DIFF
--- a/packages/slack-bolt-app/src/handlers/message.ts
+++ b/packages/slack-bolt-app/src/handlers/message.ts
@@ -106,7 +106,7 @@ export async function handleMessage(
               type: 'section',
               text: {
                 type: 'mrkdwn',
-                text: `Hi <@${userId}>, please wait for your agent to launch.\n\n*Useful Tips:*`,
+                text: `${userId ? `Hi <@${userId}>, p` : 'P'}lease wait for your agent to launch.\n\n*Useful Tips:*`,
               },
             },
             {

--- a/packages/slack-bolt-app/src/util/history.ts
+++ b/packages/slack-bolt-app/src/util/history.ts
@@ -11,9 +11,7 @@ export const saveConversationHistory = async (
   imageS3Keys: string[] = []
 ) => {
   const content = [];
-  if (message) {
-    content.push({ text: renderUserMessage({ message }) });
-  }
+  content.push({ text: renderUserMessage({ message }) });
   imageS3Keys.forEach((key) => {
     content.push({
       image: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the below issues:

1. When the slack app is mentioned with an empty message, it throws Bedrock validation error.
2. When Slack workflow mentiones the app, the reply contains an invalid mention.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
