### PR TITLE
Add support for Claude Opus 4.1 model

### DIFF
--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -22,7 +22,16 @@ const ULTRA_THINKING_KEYWORD = 'ultrathink';
 
 const defaultOutputTokenCount = 8192;
 
-const modelTypeSchema = z.enum(['sonnet3.5v1', 'sonnet3.5', 'sonnet3.7', 'haiku3.5', 'nova-pro', 'opus4', 'opus4.1', 'sonnet4']);
+const modelTypeSchema = z.enum([
+  'sonnet3.5v1',
+  'sonnet3.5',
+  'sonnet3.7',
+  'haiku3.5',
+  'nova-pro',
+  'opus4',
+  'opus4.1',
+  'sonnet4',
+]);
 type ModelType = z.infer<typeof modelTypeSchema>;
 
 const modelConfigSchema = z.object({

--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -22,7 +22,7 @@ const ULTRA_THINKING_KEYWORD = 'ultrathink';
 
 const defaultOutputTokenCount = 8192;
 
-const modelTypeSchema = z.enum(['sonnet3.5v1', 'sonnet3.5', 'sonnet3.7', 'haiku3.5', 'nova-pro', 'opus4', 'sonnet4']);
+const modelTypeSchema = z.enum(['sonnet3.5v1', 'sonnet3.5', 'sonnet3.7', 'haiku3.5', 'nova-pro', 'opus4', 'opus4.1', 'sonnet4']);
 type ModelType = z.infer<typeof modelTypeSchema>;
 
 const modelConfigSchema = z.object({
@@ -63,6 +63,13 @@ const modelConfigs: Record<ModelType, Partial<z.infer<typeof modelConfigSchema>>
     toolChoiceSupport: ['auto'],
   },
   opus4: {
+    maxOutputTokens: 32_000,
+    maxInputTokens: 200_000,
+    cacheSupport: ['system', 'message', 'tool'],
+    reasoningSupport: true,
+    toolChoiceSupport: ['any', 'auto', 'tool'],
+  },
+  'opus4.1': {
     maxOutputTokens: 32_000,
     maxInputTokens: 200_000,
     cacheSupport: ['system', 'message', 'tool'],
@@ -292,6 +299,9 @@ const chooseModelAndRegion = (modelType: ModelType) => {
       break;
     case 'opus4':
       modelId = 'anthropic.claude-opus-4-20250514-v1:0';
+      break;
+    case 'opus4.1':
+      modelId = 'anthropic.claude-opus-4-1-20250805-v1:0';
       break;
     case 'sonnet4':
       modelId = 'anthropic.claude-sonnet-4-20250514-v1:0';


### PR DESCRIPTION
## Description

This PR adds support for the Claude Opus 4.1 model (model ID: `us.anthropic.claude-opus-4-1-20250805-v1:0`).

## Changes

- Added `'opus4.1'` to the model type enum in `modelTypeSchema`
- Added configuration for Opus 4.1 in `modelConfigs` based on existing Opus 4 settings
- Added case for Opus 4.1 in `chooseModelAndRegion` function with the specified model ID

## Testing

No changes to default behavior. The model can now be selected as an available option when choosing models.

## Notes

The configuration for Opus 4.1 is based on the existing Opus 4 configuration, as specified in the requirements.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1754626803463 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1754626803463