### PR TITLE
fix: navigate to new session page more smoothly

### DIFF
--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -28,8 +28,7 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
     handleSubmitWithAction,
   } = useHookFormAction(createNewWorker, zodResolver(createNewWorkerSchema), {
     actionProps: {
-      onSuccess: (args) => {
-      },
+      onSuccess: (args) => {},
       onError: ({ error }) => {
         toast.error(typeof error === 'string' ? error : 'Failed to create session');
       },
@@ -128,11 +127,7 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
                 className="w-full"
                 size="lg"
               >
-                {isPending
-                  ? t('creatingSession')
-                  : isUploading
-                    ? t('waitingForImageUpload')
-                    : t('createSessionButton')}
+                {isPending ? t('creatingSession') : isUploading ? t('waitingForImageUpload') : t('createSessionButton')}
               </Button>
             </TooltipTrigger>
             <TooltipContent>

--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hooks';
-import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Image as ImageIcon, FileText } from 'lucide-react';
 import { createNewWorker } from './actions';
@@ -19,21 +18,17 @@ interface NewSessionFormProps {
 }
 
 export default function NewSessionForm({ templates }: NewSessionFormProps) {
-  const router = useRouter();
   const t = useTranslations('new_session');
   const sessionsT = useTranslations('sessions');
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false);
 
   const {
     form: { register, formState, reset, setValue, watch },
-    action: { isExecuting },
+    action: { isPending },
     handleSubmitWithAction,
   } = useHookFormAction(createNewWorker, zodResolver(createNewWorkerSchema), {
     actionProps: {
       onSuccess: (args) => {
-        if (args.data) {
-          router.push(`/sessions/${args.data.workerId}`);
-        }
       },
       onError: ({ error }) => {
         toast.error(typeof error === 'string' ? error : 'Failed to create session');
@@ -78,7 +73,7 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
               <Button
                 type="button"
                 onClick={() => setIsTemplateModalOpen(true)}
-                disabled={isExecuting}
+                disabled={isPending}
                 size="sm"
                 variant="outline"
                 className="flex gap-2 items-center"
@@ -89,7 +84,7 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
               <Button
                 type="button"
                 onClick={handleImageSelect}
-                disabled={isExecuting}
+                disabled={isPending}
                 size="sm"
                 variant="outline"
                 className="flex gap-2 items-center"
@@ -106,13 +101,13 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
             placeholder={t('placeholder')}
             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
             rows={4}
-            disabled={isExecuting}
+            disabled={isPending}
             onPaste={handlePaste}
             onKeyDown={(e) => {
               if (
                 e.key === 'Enter' &&
                 (e.ctrlKey || e.altKey || e.metaKey) &&
-                !isExecuting &&
+                !isPending &&
                 formState.isValid &&
                 !isUploading
               ) {
@@ -129,11 +124,11 @@ export default function NewSessionForm({ templates }: NewSessionFormProps) {
             <TooltipTrigger asChild>
               <Button
                 type="submit"
-                disabled={isExecuting || !formState.isValid || isUploading}
+                disabled={isPending || !formState.isValid || isUploading}
                 className="w-full"
                 size="lg"
               >
-                {isExecuting
+                {isPending
                   ? t('creatingSession')
                   : isUploading
                     ? t('waitingForImageUpload')

--- a/packages/webapp/src/app/sessions/new/actions.ts
+++ b/packages/webapp/src/app/sessions/new/actions.ts
@@ -7,6 +7,7 @@ import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
 import { getOrCreateWorkerInstance, renderUserMessage } from '@remote-swe-agents/agent-core/lib';
 import { sendWorkerEvent } from '@remote-swe-agents/agent-core/lib';
 import { MessageItem, SessionItem } from '@remote-swe-agents/agent-core/schema';
+import { redirect } from 'next/navigation';
 
 export const createNewWorker = authActionClient
   .inputSchema(createNewWorkerSchema)
@@ -78,5 +79,5 @@ export const createNewWorker = authActionClient
     // Send worker event to notify message received
     await sendWorkerEvent(workerId, { type: 'onMessageReceived' });
 
-    return { workerId };
+    redirect(`/sessions/${workerId}`)
   });

--- a/packages/webapp/src/app/sessions/new/actions.ts
+++ b/packages/webapp/src/app/sessions/new/actions.ts
@@ -79,5 +79,5 @@ export const createNewWorker = authActionClient
     // Send worker event to notify message received
     await sendWorkerEvent(workerId, { type: 'onMessageReceived' });
 
-    redirect(`/sessions/${workerId}`)
+    redirect(`/sessions/${workerId}`);
   });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, there was some lag between pushing `create new session` button and navigating to /sessions/:sessionId page.
This PR removes it and enhances the UX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
