### PR TITLE
(worker): generate a title for each session when starting a conversation

### DIFF
--- a/packages/agent-core/src/lib/sessions.ts
+++ b/packages/agent-core/src/lib/sessions.ts
@@ -2,6 +2,7 @@ import { GetCommand, QueryCommand, QueryCommandInput, UpdateCommand, paginateQue
 import { ddb, TableName } from './aws';
 import { AgentStatus, SessionItem } from '../schema';
 import { getConversationHistory } from './messages';
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 
 /**
  * Get session information from DynamoDB
@@ -112,6 +113,76 @@ export const updateSessionVisibility = async (workerId: string, isHidden: boolea
       UpdateExpression: 'SET isHidden = :isHidden',
       ExpressionAttributeValues: {
         ':isHidden': isHidden,
+      },
+    })
+  );
+};
+
+/**
+ * Generate a session title using Bedrock Claude Haiku model
+ * @param message The message content to generate title from
+ * @returns A generated title (10 characters or less)
+ */
+export const generateSessionTitle = async (message: string): Promise<string> => {
+  try {
+    const client = new BedrockRuntimeClient({ region: 'us-west-2' });
+    
+    const prompt = `
+    Based on the following message, create a concise title that is 10 characters or less.
+    The title should be brief but descriptive of the message content or intent.
+    Only return the title itself without any explanation or additional text.
+    
+    Message: "${message}"
+    
+    Title:
+    `;
+    
+    const command = new InvokeModelCommand({
+      modelId: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+      contentType: 'application/json',
+      body: JSON.stringify({
+        prompt,
+        max_tokens_to_sample: 20,
+        temperature: 0.7,
+      }),
+    });
+    
+    const response = await client.send(command);
+    const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+    let title = responseBody.completion.trim();
+    
+    // Remove any quotes if the model included them
+    title = title.replace(/^["']|["']$/g, '');
+    
+    // Ensure title is 10 characters or less
+    if (title.length > 10) {
+      title = title.substring(0, 10);
+    }
+    
+    return title;
+  } catch (error) {
+    console.error('Error generating session title:', error);
+    // Return a default title if generation fails
+    return 'New Chat';
+  }
+};
+
+/**
+ * Update title for a session
+ * @param workerId Worker ID of the session to update
+ * @param title The title to set for the session
+ */
+export const updateSessionTitle = async (workerId: string, title: string): Promise<void> => {
+  await ddb.send(
+    new UpdateCommand({
+      TableName,
+      Key: {
+        PK: 'sessions',
+        SK: workerId,
+      },
+      UpdateExpression: 'SET title = :title',
+      ExpressionAttributeValues: {
+        ':title': title,
       },
     })
   );

--- a/packages/agent-core/src/schema/session.ts
+++ b/packages/agent-core/src/schema/session.ts
@@ -24,6 +24,7 @@ export const sessionItemSchema = z.object({
   isHidden: z.boolean().optional(),
   slackChannelId: z.string().optional(),
   slackThreadTs: z.string().optional(),
+  title: z.string().optional(),
 });
 
 export type SessionItem = z.infer<typeof sessionItemSchema>;


### PR DESCRIPTION
## Overview
This PR adds functionality to automatically generate a title for each session when a conversation starts. The title is generated using the Bedrock Claude Haiku model based on the first user message and stored in the DynamoDB session item.

## Implementation
- Added a `title` field to the `SessionItem` schema
- Implemented `generateSessionTitle` function using Bedrock Claude Haiku model to create a title (10 characters or less) from the user's first message
- Added `updateSessionTitle` function to update the title in DynamoDB
- Integrated title generation in `onMessageReceived` function after the agent completes its first turn

## Testing
Tested that the code builds successfully. The title generation occurs when:
1. Agent completes its first turn
2. The session does not already have a title
3. There is at least one user message in the conversation history

Fixes #185

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1754712114541 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1754712114541