### PR TITLE
fix: error when global preferences is not set

### DIFF
--- a/packages/agent-core/src/schema/preferences.ts
+++ b/packages/agent-core/src/schema/preferences.ts
@@ -5,7 +5,7 @@ export const globalPreferencesSchema = z.object({
   PK: z.literal('global-config'),
   SK: z.literal('general'),
   modelOverride: modelTypeSchema.default('sonnet3.7'),
-  updatedAt: z.number(),
+  updatedAt: z.number().default(0),
 });
 
 export const updateGlobalPreferenceSchema = globalPreferencesSchema


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

An error was thrown here
https://github.com/aws-samples/remote-swe-agents/blob/bf3aa3e800b8f610c3c92d84cec4100dcb9d95d3/packages/agent-core/src/lib/preferences.ts#L46-L53
because updatedAt is not set.

This PR makes updateAt an optional field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
