### PR TITLE
Increase Handler Lambda memory from 128MB to 256MB

### DIFF
--- a/cdk/lib/constructs/slack-bolt/index.ts
+++ b/cdk/lib/constructs/slack-bolt/index.ts
@@ -61,6 +61,7 @@ export class SlackBolt extends Construct {
         platform: Platform.LINUX_ARM64,
       }),
       timeout: Duration.seconds(29),
+      memorySize: 256,
       environment: {
         SIGNING_SECRET: signingSecretParameter.stringValue,
         BOT_TOKEN: botTokenParameter.stringValue,


### PR DESCRIPTION
## Changes

- Added `memorySize: 256` configuration to the Handler Lambda function in SlackBolt construct
- This increases the memory allocation from the default 128MB to 256MB

## Background

The Handler Lambda (`SlackBoltHandler90CA9E6C-5TQWPd1lQnHq`) was running with the default 128MB memory allocation. This change explicitly sets the memory to 256MB to improve performance.

## Files Modified

- `cdk/lib/constructs/slack-bolt/index.ts`: Added memorySize property to Handler Lambda configuration

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1756428869801 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1756428869801