### PR TITLE
fix: ec2 builder validation step was not working

### DIFF
--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -158,6 +158,9 @@ export class Worker extends Construct {
     userData.addCommands(
       `
 apt-get -o DPkg::Lock::Timeout=-1 update
+apt-get -o DPkg::Lock::Timeout=-1 upgrade -y
+
+# Install python3
 apt-get -o DPkg::Lock::Timeout=-1 install -y python3-pip unzip
 ln -s -f /usr/bin/pip3 /usr/bin/pip
 ln -s -f /usr/bin/python3 /usr/bin/python

--- a/cdk/lib/constructs/worker/resources/image-component-template.yml
+++ b/cdk/lib/constructs/worker/resources/image-component-template.yml
@@ -7,6 +7,7 @@ phases:
     steps:
       - name: InstallUpdates
         action: UpdateOS
+        maxAttempts: 3
       - name: InstallDependencies
         action: ExecuteBash
         inputs:
@@ -15,31 +16,31 @@ phases:
             - dummy
   - name: validate
     steps:
-      - name: HelloWorldStep
+      - name: ValidateStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1
   - name: test
     steps:
-      - name: HelloWorldStep
+      - name: TestStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -4203,6 +4203,7 @@ phases:
     steps:
       - name: InstallUpdates
         action: UpdateOS
+        maxAttempts: 3
       - name: InstallDependencies
         action: ExecuteBash
         inputs:
@@ -4210,6 +4211,11 @@ phases:
             - "#!/bin/bash
 
               apt-get -o DPkg::Lock::Timeout=-1 update
+
+              apt-get -o DPkg::Lock::Timeout=-1 upgrade -y
+
+
+              # Install python3
 
               apt-get -o DPkg::Lock::Timeout=-1 install -y python3-pip unzip
 
@@ -4669,34 +4675,34 @@ phases:
               \\      "
   - name: validate
     steps:
-      - name: HelloWorldStep
+      - name: ValidateStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1
   - name: test
     steps:
-      - name: HelloWorldStep
+      - name: TestStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1
 ",
             ],
           ],
@@ -4919,6 +4925,7 @@ phases:
     steps:
       - name: InstallUpdates
         action: UpdateOS
+        maxAttempts: 3
       - name: InstallDependencies
         action: ExecuteBash
         inputs:
@@ -4926,6 +4933,11 @@ phases:
             - "#!/bin/bash
 
               apt-get -o DPkg::Lock::Timeout=-1 update
+
+              apt-get -o DPkg::Lock::Timeout=-1 upgrade -y
+
+
+              # Install python3
 
               apt-get -o DPkg::Lock::Timeout=-1 install -y python3-pip unzip
 
@@ -5385,34 +5397,34 @@ phases:
               \\      "
   - name: validate
     steps:
-      - name: HelloWorldStep
+      - name: ValidateStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1
   - name: test
     steps:
-      - name: HelloWorldStep
+      - name: TestStep
         action: ExecuteBash
         inputs:
           commands:
-            - aws --version
-            - docker --version
-            - python --version
-            - gh --version
-            - sudo -u ubuntu bash -i -c "uv --version"
-            - sudo -u ubuntu bash -i -c "uvx --version"
-            - sudo -u ubuntu bash -i -c "node --version"
-            - sudo -u ubuntu bash -i -c "npm --version"
-            - sudo -u ubuntu bash -i -c "npx --version"
+            - aws --version || exit 1
+            - docker --version || exit 1
+            - python --version || exit 1
+            - gh --version || exit 1
+            - sudo -u ubuntu bash -i -c "uv --version" || exit 1
+            - sudo -u ubuntu bash -i -c "uvx --version" || exit 1
+            - sudo -u ubuntu bash -i -c "node --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npm --version" || exit 1
+            - sudo -u ubuntu bash -i -c "npx --version" || exit 1
 ",
             ],
           ],
@@ -5489,6 +5501,9 @@ phases:
                 [
                   "#!/bin/bash
 apt-get -o DPkg::Lock::Timeout=-1 update
+apt-get -o DPkg::Lock::Timeout=-1 upgrade -y
+
+# Install python3
 apt-get -o DPkg::Lock::Timeout=-1 install -y python3-pip unzip
 ln -s -f /usr/bin/pip3 /usr/bin/pip
 ln -s -f /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The validation step was not working properly; it unexpectedly succeed even when some of the commands are missing. Thi s PR adds `|| exit 1` for every command to exit with error when a command failed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
