### PR TITLE
docs: Add foundation model override documentation to English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,20 @@ As our agent can work as an MCP client, you can easily integrate it with various
 
 All the new agents can now use MCP servers as their tools.
 
+### Foundation Model Override
+
+By default, Remote SWE uses Claude Sonnet 3.7 as the foundation model. You can override this setting using an environment variable:
+
+```bash
+WORKER_MODEL_OVERRIDE=nova-pro npx cdk deploy
+```
+
+Available model values are: `sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, opus4.1, sonnet4`
+
+After deployment, new workers will use the overridden model.
+
+This feature is highly experimental, and it's recommended to use the default model for the optimal experience.
+
 ## How it works
 
 This system utilizes a Slack Bolt application to manage user interactions and implement a scalable worker system. Here's the main workflow:


### PR DESCRIPTION
## 概要 / Overview

このPRは英語版のREADME.mdに基盤モデルのオーバーライド機能に関するドキュメントを追加します。この情報は日本語版のREADME_ja.mdにはすでに存在していましたが、英語版には記載されていませんでした。

This PR adds documentation about foundation model override functionality to the English README.md. This information already existed in the Japanese README_ja.md but was missing from the English version.

## 変更内容 / Changes

- 英語版README.mdに「Foundation Model Override」セクションを追加
- 使用可能なモデルの一覧を記載（sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, opus4.1, sonnet4）
- モデルオーバーライドの使用方法と注意点を説明

- Add "Foundation Model Override" section to English README.md
- List available models (sonnet3.5v1, sonnet3.5, sonnet3.7, haiku3.5, nova-pro, opus4, opus4.1, sonnet4)
- Explain how to use model override and cautions

## スクリーンショット / Screenshots

なし / None

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1759410562057729 -->

---

**Open in Web UI**: https://d2rxkhmmx7fxxi.cloudfront.net/sessions/1759410562057729