### PR TITLE
feat(agent-core): replace asChild boolean with an explicit session role enum

### DIFF
--- a/packages/agent-core/src/lib/sessions.ts
+++ b/packages/agent-core/src/lib/sessions.ts
@@ -5,6 +5,7 @@ import {
   UpdateCommand,
   DeleteCommand,
   BatchWriteCommand,
+  TransactWriteCommand,
   paginateQuery,
 } from '@aws-sdk/lib-dynamodb';
 import { z } from 'zod';
@@ -12,6 +13,7 @@ import { ddb, TableName } from './aws';
 import { AgentStatus, SessionItem, sessionItemSchema } from '../schema';
 import { deleteAllEventTriggers } from './event-triggers';
 import { deleteUnreadByWorkerId } from './unread';
+import { sendWebappEvent } from './events';
 
 /**
  * Get session information from DynamoDB
@@ -289,4 +291,74 @@ export const updateSession = async (workerId: string, params: UpdateSessionParam
       ExpressionAttributeValues: expressionAttributeValues,
     })
   );
+};
+
+/**
+ * Move one or more sessions under a new parent (atomically via TransactWrite).
+ * Used by the `createNewSession` tool's `role=successor` path to re-parent
+ * the current session and its children under the newly-created successor.
+ *
+ * Safety:
+ * - Cycle detection: walks the new parent's ancestor chain to ensure no child
+ *   being moved is already an ancestor.
+ * - Self-parent guard: rejects `newParentId` appearing in `childWorkerIds`.
+ * - Bounded at 100 items (DDB TransactWrite limit).
+ *
+ * @param newParentId Worker ID of the session that will become the new parent
+ * @param childWorkerIds Worker IDs to re-parent under newParentId
+ */
+export const reparentSessions = async (newParentId: string, childWorkerIds: string[]): Promise<void> => {
+  if (childWorkerIds.length === 0) return;
+
+  if (childWorkerIds.length > 100) {
+    throw new Error(
+      `Cannot reparent more than 100 sessions in a single transaction (got ${childWorkerIds.length}); TransactWrite supports at most 100 items.`
+    );
+  }
+
+  const childIdSet = new Set(childWorkerIds);
+  if (childIdSet.has(newParentId)) {
+    throw new Error(`Cannot set session ${newParentId} as its own parent`);
+  }
+
+  // Walk the new parent's ancestor chain. If any session being re-parented is
+  // already an ancestor of the new parent, the move would create a cycle.
+  const visited = new Set<string>([newParentId]);
+  let cursor = (await getSession(newParentId))?.parentSessionId;
+  while (cursor && !visited.has(cursor)) {
+    if (childIdSet.has(cursor)) {
+      throw new Error(`Reparenting would create a cycle: ${cursor} is an ancestor of ${newParentId}`);
+    }
+    visited.add(cursor);
+    cursor = (await getSession(cursor))?.parentSessionId;
+  }
+
+  const now = Date.now();
+  await ddb.send(
+    new TransactWriteCommand({
+      TransactItems: childWorkerIds.map((childId) => ({
+        Update: {
+          TableName,
+          Key: { PK: 'sessions', SK: childId },
+          ConditionExpression: 'attribute_exists(SK)',
+          UpdateExpression: 'SET #parentSessionId = :parentSessionId, #updatedAt = :updatedAt',
+          ExpressionAttributeNames: { '#parentSessionId': 'parentSessionId', '#updatedAt': 'updatedAt' },
+          ExpressionAttributeValues: { ':parentSessionId': newParentId, ':updatedAt': now },
+        },
+      })),
+    })
+  );
+
+  // Notify webapp of hierarchy change so the sidebar can update in real time.
+  for (const childId of childWorkerIds) {
+    try {
+      await sendWebappEvent(childId, {
+        type: 'sessionReparented',
+        newParentSessionId: newParentId,
+        oldParentSessionId: null,
+      });
+    } catch {
+      // Non-critical: webapp event failure does not affect the reparent
+    }
+  }
 };

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -91,4 +91,11 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     timestamp: z.number(),
     workerId: z.string(),
   }),
+  z.object({
+    type: z.literal('sessionReparented'),
+    workerId: z.string(),
+    newParentSessionId: z.string(),
+    oldParentSessionId: z.string().nullable(),
+    timestamp: z.number(),
+  }),
 ]);

--- a/packages/agent-core/src/schema/session.ts
+++ b/packages/agent-core/src/schema/session.ts
@@ -32,6 +32,11 @@ export const sessionItemSchema = z.object({
   runtimeType: runtimeTypeSchema.optional(),
   parentSessionId: z.string().optional(),
   creatorSessionId: z.string().optional(),
+  // Worker ID of the successor session this session was handed over to (webapp
+  // handover feature). Written exactly once with a conditional update — its
+  // presence is the idempotency guard that prevents concurrent/repeated
+  // handovers from creating multiple successors.
+  handedOverTo: z.string().optional(),
   agentName: z.string().optional(),
 });
 

--- a/packages/agent-core/src/tools/create-session/index.test.ts
+++ b/packages/agent-core/src/tools/create-session/index.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockGetChildSessions = vi.fn();
+const mockReparentSessions = vi.fn();
+const mockCreateSession = vi.fn();
+const mockGetWebappSessionUrl = vi.fn();
+
+vi.mock('../../lib/sessions', () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  getChildSessions: (...args: any[]) => mockGetChildSessions(...args),
+  reparentSessions: (...args: any[]) => mockReparentSessions(...args),
+}));
+
+vi.mock('../../lib/create-session', () => ({
+  createSession: (...args: any[]) => mockCreateSession(...args),
+}));
+
+vi.mock('../../lib/webapp-origin', () => ({
+  getWebappSessionUrl: (...args: any[]) => mockGetWebappSessionUrl(...args),
+}));
+
+import { createNewSessionTool } from './index';
+import type { GlobalPreferences } from '../../schema';
+
+const context = {
+  workerId: 'session-parent-123',
+  toolUseId: 'tool-use-1',
+  globalPreferences: {} as GlobalPreferences,
+};
+
+describe('createNewSessionTool handler', () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+    mockCreateSession.mockReset();
+    mockGetWebappSessionUrl.mockReset();
+    mockGetChildSessions.mockReset();
+    mockReparentSessions.mockReset();
+    mockGetChildSessions.mockResolvedValue([]);
+    mockReparentSessions.mockResolvedValue(undefined);
+    mockGetWebappSessionUrl.mockResolvedValue(undefined);
+    mockCreateSession.mockResolvedValue('session-child-456');
+  });
+
+  test('role=child creates session with current session as parent', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+    });
+
+    const result = await createNewSessionTool.handler({ message: 'sub-task', role: 'child' }, context);
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    const params = mockCreateSession.mock.calls[0][0];
+    expect(params.parentSessionId).toBe('session-parent-123');
+    expect(params.creatorSessionId).toBeUndefined();
+    expect(result).toContain('session-child-456');
+    expect(result).toContain('Parent Session: session-parent-123');
+  });
+
+  test('role=independent creates session without parent', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+    });
+
+    const result = await createNewSessionTool.handler({ message: 'new topic', role: 'independent' }, context);
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    const params = mockCreateSession.mock.calls[0][0];
+    expect(params.parentSessionId).toBeUndefined();
+    expect(params.creatorSessionId).toBe('session-parent-123');
+    expect(result).toContain('New session created successfully');
+    expect(result).not.toContain('Parent Session');
+  });
+
+  test('role=successor performs handover: creates fresh parent and re-parents sessions', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+    });
+    mockGetChildSessions.mockResolvedValue([{ workerId: 'child-A' }, { workerId: 'child-B' }]);
+    mockCreateSession.mockResolvedValue('session-newparent-789');
+
+    const result = await createNewSessionTool.handler({ message: 'take over', role: 'successor' }, context);
+
+    const params = mockCreateSession.mock.calls[0][0];
+    expect(params.parentSessionId).toBeUndefined();
+    expect(params.creatorSessionId).toBe('session-parent-123');
+
+    expect(mockReparentSessions).toHaveBeenCalledWith('session-newparent-789', [
+      'session-parent-123',
+      'child-A',
+      'child-B',
+    ]);
+    expect(result).toContain('Parent handover complete');
+    expect(result).toContain('session-newparent-789');
+  });
+
+  test('role is required (schema validation rejects missing role)', () => {
+    const parseResult = createNewSessionTool.schema.safeParse({ message: 'test' });
+    expect(parseResult.success).toBe(false);
+  });
+
+  test('role rejects invalid values', () => {
+    const parseResult = createNewSessionTool.schema.safeParse({ message: 'test', role: 'unknown' });
+    expect(parseResult.success).toBe(false);
+  });
+
+  test('role=successor with 0 child sessions re-parents only self', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+    });
+    mockGetChildSessions.mockResolvedValue([]);
+    mockCreateSession.mockResolvedValue('session-newparent-789');
+
+    const result = await createNewSessionTool.handler({ message: 'take over', role: 'successor' }, context);
+
+    expect(mockReparentSessions).toHaveBeenCalledWith('session-newparent-789', ['session-parent-123']);
+    expect(result).toContain('Re-parented 1 session(s)');
+    expect(result).toContain('0 existing child session(s)');
+  });
+
+  test('role=successor from a child session places successor under the same parent via createSession', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+      parentSessionId: 'session-grandparent-000',
+    });
+    mockGetChildSessions.mockResolvedValue([{ workerId: 'child-A' }]);
+    mockCreateSession.mockResolvedValue('session-successor-999');
+
+    const result = await createNewSessionTool.handler({ message: 'take over', role: 'successor' }, context);
+
+    expect(mockReparentSessions).toHaveBeenCalledTimes(1);
+    expect(mockReparentSessions).toHaveBeenCalledWith('session-successor-999', ['session-parent-123', 'child-A']);
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ parentSessionId: 'session-grandparent-000' })
+    );
+    expect(result).toContain('Parent handover complete');
+    expect(result).toContain('session-successor-999');
+  });
+
+  test('role=successor from a top-level session does not pass parentSessionId to createSession', async () => {
+    mockGetSession.mockResolvedValue({
+      PK: 'sessions',
+      SK: 'session-parent-123',
+      workerId: 'session-parent-123',
+      initiator: 'webapp#user-1',
+    });
+    mockGetChildSessions.mockResolvedValue([]);
+    mockCreateSession.mockResolvedValue('session-newparent-789');
+
+    await createNewSessionTool.handler({ message: 'take over', role: 'successor' }, context);
+
+    expect(mockReparentSessions).toHaveBeenCalledTimes(1);
+    expect(mockReparentSessions).toHaveBeenCalledWith('session-newparent-789', ['session-parent-123']);
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ parentSessionId: undefined }));
+  });
+});

--- a/packages/agent-core/src/tools/create-session/index.ts
+++ b/packages/agent-core/src/tools/create-session/index.ts
@@ -28,7 +28,7 @@ const inputSchema = z.object({
     .describe(
       'The relationship of the new session to the current one. Must be explicitly specified.\n' +
         '- "child": Sub-task of the current session. Current session becomes the parent.\n' +
-        '- "successor": Hand over coordination to a fresh parent. Current session + its children are re-parented under the new session. Use when the user asks for session handover / 引き継ぎ.\n' +
+        '- "successor": Hand over coordination to a fresh parent. Current session + its children are re-parented under the new session. Use when the user asks for a session handover.\n' +
         '- "independent": A completely separate top-level session for an unrelated topic.'
     ),
 });
@@ -106,8 +106,8 @@ The \`role\` parameter is REQUIRED. Pick the correct one:
   - You need to coordinate/aggregate results from the new session
   - The sub-task's progress should be visible in the current session's chat view
 
-- **"successor"** (handover): Use when the user asks you to hand over, 引き継ぎ, or create a fresh coordinator. This creates a new top-level parent and re-parents the current session and all its children under it. Use when:
-  - The user explicitly asks for a session handover / 引き継ぎ
+- **"successor"** (handover): Use when the user asks you to hand over or create a fresh coordinator. This creates a new top-level parent and re-parents the current session and all its children under it. Use when:
+  - The user explicitly asks for a session handover
   - Your context has grown too large and you need a fresh coordinator
   - You want to keep child sessions running under a new parent
 

--- a/packages/agent-core/src/tools/create-session/index.ts
+++ b/packages/agent-core/src/tools/create-session/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
-import { getSession } from '../../lib/sessions';
+import { getSession, getChildSessions, reparentSessions } from '../../lib/sessions';
 import { createSession } from '../../lib/create-session';
 import { getWebappSessionUrl } from '../../lib/webapp-origin';
 
@@ -23,11 +23,13 @@ const inputSchema = z.object({
     .describe(
       "ID of a custom agent to use for the new session. If omitted, the new session inherits the current session's agent configuration. Use listAgents to find available agent IDs."
     ),
-  asChild: z
-    .boolean()
-    .optional()
+  role: z
+    .enum(['child', 'successor', 'independent'])
     .describe(
-      'When true, the new session is created as a child of the CURRENT session (automatically uses the current session ID as the parent). This groups related sessions together and aggregates child messages in the parent chat view. Default: false (independent session).'
+      'The relationship of the new session to the current one. Must be explicitly specified.\n' +
+        '- "child": Sub-task of the current session. Current session becomes the parent.\n' +
+        '- "successor": Hand over coordination to a fresh parent. Current session + its children are re-parented under the new session. Use when the user asks for session handover / 引き継ぎ.\n' +
+        '- "independent": A completely separate top-level session for an unrelated topic.'
     ),
 });
 
@@ -47,8 +49,13 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
       slackMentionUserId = initiator.replace('slack#', '');
     }
 
-    const parentSessionId = input.asChild ? context.workerId : undefined;
-    const creatorSessionId = !input.asChild ? context.workerId : undefined;
+    const parentSessionId =
+      input.role === 'child'
+        ? context.workerId
+        : input.role === 'successor'
+          ? currentSession.parentSessionId
+          : undefined;
+    const creatorSessionId = input.role !== 'child' ? context.workerId : undefined;
 
     const workerId = await createSession({
       message: input.message,
@@ -61,6 +68,19 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
       slackChannelId: currentSession.slackChannelId,
       slackMentionUserId,
     });
+
+    if (input.role === 'successor') {
+      const children = await getChildSessions(context.workerId);
+      const reparentIds = [context.workerId, ...children.map((c) => c.workerId)];
+      await reparentSessions(workerId, reparentIds);
+
+      const sessionUrl = await getWebappSessionUrl(workerId);
+      const urlInfo = sessionUrl ? `\n- Web UI: ${sessionUrl}` : '';
+      const slackInfo = currentSession.slackChannelId
+        ? '\n- Slack: A new thread has been created in the same channel'
+        : '';
+      return `Parent handover complete.\n- New parent session: ${workerId}\n- Re-parented ${reparentIds.length} session(s) under it (this session + ${children.length} existing child session(s))${urlInfo}${slackInfo}`;
+    }
 
     const sessionUrl = await getWebappSessionUrl(workerId);
     const urlInfo = sessionUrl ? `\n- Web UI: ${sessionUrl}` : '';
@@ -78,39 +98,36 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
     name,
     description: `Create a new session with a separate agent to handle a divergent topic or task.
 
-## When to use:
-- When the conversation has shifted to a completely different topic that deserves its own session
-- When the user asks you to handle a separate task that is unrelated to the current session's purpose
-- When splitting work across sessions would improve organization and clarity
+## IMPORTANT — Choosing the right role:
+The \`role\` parameter is REQUIRED. Pick the correct one:
 
-## IMPORTANT - Cost awareness:
+- **"child"**: The new session is a sub-task of your current work. Use when:
+  - The task is tightly coupled to the current session's context
+  - You need to coordinate/aggregate results from the new session
+  - The sub-task's progress should be visible in the current session's chat view
+
+- **"successor"** (handover): Use when the user asks you to hand over, 引き継ぎ, or create a fresh coordinator. This creates a new top-level parent and re-parents the current session and all its children under it. Use when:
+  - The user explicitly asks for a session handover / 引き継ぎ
+  - Your context has grown too large and you need a fresh coordinator
+  - You want to keep child sessions running under a new parent
+
+- **"independent"**: A completely separate session for a genuinely unrelated topic. Use when:
+  - The task is entirely unrelated to the current session
+  - The new session needs to communicate directly with the user on a different topic
+  - The current session should not be a parent or have any structural relationship
+
+**When in doubt, prefer "child" over "independent".** Most tasks spawned from an existing session are sub-tasks, not truly independent topics.
+
+## Cost awareness:
 - Creating a new session starts a new agent runtime, which incurs additional cost
-- You SHOULD confirm with the user before creating a new session (e.g. "This seems like a separate topic. Shall I create a new session for it?")
-- User confirmation is not technically required, but strongly recommended as a best practice
+- You SHOULD confirm with the user before creating a session (e.g. "Shall I create a new session for this?")
 
 ## Behavior:
 - The new session inherits the current session's agent configuration (custom agent, runtime type, etc.)
 - If the current session is linked to Slack, a new thread will be created in the same Slack channel
 - The new session will start processing the message immediately after creation
-- You will receive the new session ID in the response
-- Use asChild=true to group related sessions together (e.g. sub-tasks of a larger task). The parent session's chat view will show messages from child sessions. Leave it false or omit for completely independent sessions.
-- When creating child sessions, provide a descriptive 'agentName' so sibling agents can identify each other (e.g. "Frontend Dev", "Backend Dev").
-- Use 'customAgentId' to assign a specific custom agent configuration to the new session (use listAgents to find IDs).
-
-## Child vs Independent Session Guidelines:
-- **Child session (asChild=true)**: Use ONLY when the task is a sub-task of your current session. The parent acts as a coordinator/relay. Choose this when:
-  - The task is tightly coupled to the parent session's context
-  - The parent needs to aggregate or coordinate the results
-  - The sub-task's progress should be visible in the parent's chat view
-- **Independent session (asChild=false or omitted)**: Use when the task can stand on its own. Choose this when:
-  - The task is unrelated or loosely related to the current session
-  - The new session needs to communicate directly with the user
-  - The parent session may become idle/sleep and shouldn't block the new session
-
-## Decision criteria:
-- Is the task tightly dependent on the parent session's context? → Child
-- Can the task complete independently without parent coordination? → Independent
-- Does the new session need direct user communication? → Independent`,
+- When creating child sessions, provide a descriptive 'agentName' so sibling agents can identify each other (e.g. "Frontend Dev", "Backend Dev")
+- Use 'customAgentId' to assign a specific custom agent configuration to the new session (use listAgents to find IDs)`,
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),
     },


### PR DESCRIPTION
## Summary
Replace the boolean `asChild` parameter of the createNewSession tool with an
explicit `role` enum (`child` | `successor` | `independent`), and add the
session-reparenting plumbing the `successor` role needs.

## Motivation
A single boolean could not express the three distinct relationships a new session
can have with the current one. An explicit enum makes intent unambiguous in the
tool schema, enables the successor/handover flow (re-parent the current session
and its children under a fresh parent), and keeps independent sessions clearly
separate.

## Changes
- packages/agent-core/src/tools/create-session/index.ts: swap `asChild` for the
  `role` enum; expand the tool description and role guidance.
- packages/agent-core/src/lib/sessions.ts: add `reparentSessions` to move a set
  of child workers under a new parent.
- packages/agent-core/src/schema/session.ts, schema/events.ts: schema fields /
  event types for the role + reparenting.
- create-session/index.test.ts: unit coverage for the role enum + reparenting.

## Testing
- agent-core unit tests: create-session/index.test.ts — 8 tests, all passing
  (tsc + prettier + vitest).

## Notes
- Self-contained. The handover-modal PR (webapp) builds on the `successor`
  flow introduced here — merge this first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
