### PR TITLE
feat(agent-core): add session handover context and context-usage self-awareness

### DIFF
--- a/packages/agent-core/src/lib/auto-handover.test.ts
+++ b/packages/agent-core/src/lib/auto-handover.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { buildContextUsageEnvironmentBlock, CONTEXT_USAGE_GUIDELINE_PERCENTAGE } from './auto-handover';
+
+describe('buildContextUsageEnvironmentBlock', () => {
+  test('returns undefined when the percentage is unknown', () => {
+    expect(buildContextUsageEnvironmentBlock(undefined)).toBeUndefined();
+    expect(buildContextUsageEnvironmentBlock(NaN)).toBeUndefined();
+    expect(buildContextUsageEnvironmentBlock(Infinity)).toBeUndefined();
+  });
+
+  test('renders rounded usage and the guideline', () => {
+    const block = buildContextUsageEnvironmentBlock(42.349);
+    expect(block).toContain('## Context Window Usage');
+    expect(block).toContain('~42%');
+    expect(block).toContain(`~${CONTEXT_USAGE_GUIDELINE_PERCENTAGE}%`);
+  });
+
+  test('is model-driven: instructs the model to hand over itself via createNewSession role=successor', () => {
+    const block = buildContextUsageEnvironmentBlock(85)!;
+    expect(block).toContain('createNewSession');
+    expect(block).toContain('successor');
+    // must NOT describe a mechanical/automatic trigger anymore
+    expect(block.toLowerCase()).not.toContain('automatic handover');
+  });
+
+  test('includes soft loop guidance (do not immediately hand over again)', () => {
+    const block = buildContextUsageEnvironmentBlock(85)!;
+    expect(block.toLowerCase()).toContain('handover');
+    expect(block).toMatch(/do not hand over immediately|prioritise making concrete progress/i);
+  });
+
+  test('clamps out-of-range values', () => {
+    expect(buildContextUsageEnvironmentBlock(150)).toContain('~100%');
+    expect(buildContextUsageEnvironmentBlock(-5)).toContain('~0%');
+  });
+
+  test('respects a custom guideline', () => {
+    expect(buildContextUsageEnvironmentBlock(50, { guideline: 70 })).toContain('~70%');
+  });
+});

--- a/packages/agent-core/src/lib/auto-handover.ts
+++ b/packages/agent-core/src/lib/auto-handover.ts
@@ -1,0 +1,64 @@
+/**
+ * Context-window self-awareness (model-driven handover).
+ *
+ * The worker measures each turn's context-window utilisation (a single
+ * normalised `contextUsagePercentage` populated by the inference backend
+ * backends — see `TurnResult`) and surfaces it back to the MODEL via a dynamic
+ * per-turn "environment" block. The model can then decide, on its own, to hand
+ * its work over to a fresh successor session (by calling the `createNewSession`
+ * tool with `role: 'successor'`) before its context fills up.
+ *
+ * There is intentionally NO orchestrator-side mechanical auto-fire: handover is
+ * a decision the agent makes, not something the runtime forces at a fixed
+ * percentage. This module therefore only builds the informational block; it
+ * performs no session creation or reparenting itself.
+ */
+
+/**
+ * Soft guideline percentage surfaced to the model as "you are getting full".
+ * It is NOT a hard trigger — the model decides when to hand over. Presented as
+ * a rule-of-thumb so the agent has time to wrap up (persist state, summarise,
+ * reach a clean stopping point) and spin up a successor before it runs into
+ * middle-out truncation or a context-overflow error.
+ *
+ * ~80% leaves roughly a fifth of the window (~40k tokens on a 200k model) as
+ * head-room to compose a handover message and let the successor start cleanly.
+ */
+export const CONTEXT_USAGE_GUIDELINE_PERCENTAGE = 80;
+
+/**
+ * Build the dynamic "environment" block that tells the MODEL its own current
+ * context-window utilisation and instructs it to hand over on its own when it
+ * is getting full.
+ *
+ * IMPORTANT: this string is meant to live in the per-turn ENVIRONMENT layer
+ * (a dynamic section regenerated every inference and NOT persisted into the
+ * conversation history), never appended to the stored user prompt. Appending
+ * it per-turn would accumulate in history and itself consume context — the
+ * opposite of what a context-management feature should do.
+ *
+ * Returns `undefined` when the percentage is unknown (e.g. the very first turn
+ * of a session, before any usage has been measured), so callers can omit the
+ * block entirely rather than show a misleading value.
+ */
+export const buildContextUsageEnvironmentBlock = (
+  contextUsagePercentage: number | undefined,
+  options: { guideline?: number } = {}
+): string | undefined => {
+  if (contextUsagePercentage === undefined || !Number.isFinite(contextUsagePercentage)) return undefined;
+  const guideline = options.guideline ?? CONTEXT_USAGE_GUIDELINE_PERCENTAGE;
+  const pct = Math.max(0, Math.min(100, contextUsagePercentage));
+
+  return [
+    '## Context Window Usage',
+    `Your conversation is currently using ~${pct.toFixed(0)}% of the available context window.`,
+    `As a rule of thumb, once usage climbs past ~${guideline}% you should hand your work over to a fresh successor session ` +
+      'rather than pushing on until the window overflows (which forces lossy truncation of earlier context). ' +
+      'To hand over, call the `createNewSession` tool with `role: "successor"` and pass a thorough handover message that ' +
+      'captures the task, everything done so far, current state, and the concrete next steps — the successor starts from ' +
+      'that message, so include enough detail for it to continue seamlessly without re-reading this conversation. ' +
+      'Before handing over, make sure important state is durably persisted (commit/push code, write notes to files, open the PR). ' +
+      'If you were yourself just started by a handover, prioritise making concrete progress first and only hand over again ' +
+      'after substantial work and genuinely high usage — do not hand over immediately.',
+  ].join('\n');
+};

--- a/packages/agent-core/src/lib/handover-context.test.ts
+++ b/packages/agent-core/src/lib/handover-context.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildHandoverMessage,
+  buildHandoverTitle,
+  collectRecentConversation,
+  collectWorkStateScanTexts,
+  extractWorkState,
+  stripPromptEnvelope,
+} from './handover-context';
+import { MessageItem } from '../schema';
+import { TodoList } from '../schema/todo';
+
+const makeItem = (partial: Partial<MessageItem> & { content: string }): MessageItem => ({
+  PK: 'message-session-1',
+  SK: '000000000000001',
+  role: 'user',
+  tokenCount: 0,
+  messageType: 'userMessage',
+  ...partial,
+});
+
+const textContent = (text: string) => JSON.stringify([{ text }]);
+
+describe('extractWorkState', () => {
+  test('detects branch from git checkout -b', () => {
+    const state = extractWorkState(['I ran git checkout -b feature/session-handover-123 and started work']);
+    expect(state.branches).toContain('feature/session-handover-123');
+  });
+
+  test('detects branch from git push origin', () => {
+    const state = extractWorkState(['git push -u origin fix/login-bug-456']);
+    expect(state.branches).toContain('fix/login-bug-456');
+  });
+
+  test('detects branch from "branch:" prose', () => {
+    const state = extractWorkState(['Pushed. branch: `feature/awesome-1755`']);
+    expect(state.branches).toContain('feature/awesome-1755');
+  });
+
+  // Uses CJK (Japanese) prose on purpose: verifies a branch name is extracted
+  // even when embedded in non-English text with no git-command context.
+  test('detects plain-text branch mentions without git command context (E2E-1)', () => {
+    const state = extractWorkState(['feature/e2e-test-branch-handover というブランチで作業中です']);
+    expect(state.branches).toContain('feature/e2e-test-branch-handover');
+  });
+
+  test('does not misdetect branch-prefix-like segments inside URLs', () => {
+    const state = extractWorkState(['see https://github.com/owner/feature/blob/main/x.md for details']);
+    expect(state.branches).toEqual([]);
+  });
+
+  test('detects PR URLs and their repository', () => {
+    const state = extractWorkState(['Opened https://github.com/aws-samples/remote-swe-agents/pull/123 for review.']);
+    expect(state.pullRequests).toEqual(['https://github.com/aws-samples/remote-swe-agents/pull/123']);
+    expect(state.repositories).toContain('https://github.com/aws-samples/remote-swe-agents');
+  });
+
+  test('detects CodeCommit repository URLs', () => {
+    const state = extractWorkState(['Cloned https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example-repo.']);
+    expect(state.repositories).toContain('https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example-repo');
+  });
+
+  test('detects commit hashes only with commit context', () => {
+    const state = extractWorkState(['Created commit abc1234def with the fix. Random hex deadbeefcafe elsewhere.']);
+    expect(state.commits).toEqual(['abc1234def']);
+  });
+
+  test('returns most recent mentions first and dedupes', () => {
+    const state = extractWorkState([
+      'git checkout -b feature/first-1',
+      'git checkout -b feature/second-2',
+      'git push -u origin feature/second-2',
+    ]);
+    expect(state.branches[0]).toBe('feature/second-2');
+    expect(state.branches.filter((b) => b === 'feature/second-2')).toHaveLength(1);
+  });
+
+  test('caps each category at 3 entries', () => {
+    const texts = [1, 2, 3, 4, 5].map((i) => `git checkout -b feature/branch-${i}`);
+    const state = extractWorkState(texts);
+    expect(state.branches).toHaveLength(3);
+    expect(state.branches[0]).toBe('feature/branch-5');
+  });
+
+  test('returns empty arrays when nothing is detected', () => {
+    const state = extractWorkState(['just chatting about the weather']);
+    expect(state.branches).toEqual([]);
+    expect(state.pullRequests).toEqual([]);
+    expect(state.repositories).toEqual([]);
+    expect(state.commits).toEqual([]);
+  });
+});
+
+describe('stripPromptEnvelope', () => {
+  test('extracts body from user_message envelope and drops the command tail', () => {
+    const raw = `<user_message>\n[from: alice (webapp)]\nfix the bug please\n</user_message>\n<command>\nUser sent you a message.\n</command>`;
+    expect(stripPromptEnvelope(raw)).toBe('fix the bug please');
+  });
+
+  test('strips agent message prefix', () => {
+    expect(stripPromptEnvelope('[Message from PM (session-1)]: do the thing')).toBe('do the thing');
+  });
+
+  test('returns plain text unchanged', () => {
+    expect(stripPromptEnvelope('hello world')).toBe('hello world');
+  });
+});
+
+describe('collectRecentConversation', () => {
+  test('keeps only user/assistant conversation and applies the envelope strip', () => {
+    const items: MessageItem[] = [
+      makeItem({ content: textContent('<user_message>\nfirst request\n</user_message>'), messageType: 'userMessage' }),
+      makeItem({ content: textContent('working on it'), role: 'assistant', messageType: 'assistant' }),
+      makeItem({
+        content: JSON.stringify([{ toolUse: { name: 'executeCommand', input: {} } }]),
+        role: 'assistant',
+        messageType: 'toolUse',
+      }),
+      makeItem({ content: textContent('[Message from PM (session-9)]: status?'), messageType: 'agentMessage' }),
+    ];
+    const conversation = collectRecentConversation(items, 10);
+    expect(conversation).toEqual([
+      { role: 'user', text: 'first request' },
+      { role: 'assistant', text: 'working on it' },
+      { role: 'user', text: 'status?' },
+    ]);
+  });
+
+  test('returns only the last N messages', () => {
+    const items = [1, 2, 3, 4, 5].map((i) => makeItem({ content: textContent(`message ${i}`) }));
+    const conversation = collectRecentConversation(items, 2);
+    expect(conversation.map((m) => m.text)).toEqual(['message 4', 'message 5']);
+  });
+
+  test('ignores unparsable content', () => {
+    const items = [makeItem({ content: 'not-json' }), makeItem({ content: textContent('valid') })];
+    expect(collectRecentConversation(items, 10)).toEqual([{ role: 'user', text: 'valid' }]);
+  });
+});
+
+describe('collectWorkStateScanTexts', () => {
+  test('includes message text, tool inputs and tool result texts', () => {
+    const items: MessageItem[] = [
+      makeItem({ content: textContent('pushed the branch') }),
+      makeItem({
+        content: JSON.stringify([
+          { toolUse: { name: 'executeCommand', input: { command: 'git checkout -b feature/x-1' } } },
+        ]),
+        role: 'assistant',
+        messageType: 'toolUse',
+      }),
+      makeItem({
+        content: JSON.stringify([{ toolResult: { toolUseId: 't1', content: [{ text: 'commit abc1234 created' }] } }]),
+        messageType: 'toolResult',
+      }),
+    ];
+    const texts = collectWorkStateScanTexts(items, 50);
+    expect(texts.some((t) => t.includes('pushed the branch'))).toBe(true);
+    expect(texts.some((t) => t.includes('git checkout -b feature/x-1'))).toBe(true);
+    expect(texts.some((t) => t.includes('commit abc1234'))).toBe(true);
+  });
+
+  test('respects the maxItems window', () => {
+    const items = [1, 2, 3].map((i) => makeItem({ content: textContent(`text ${i}`) }));
+    const texts = collectWorkStateScanTexts(items, 1);
+    expect(texts).toEqual(['text 3']);
+  });
+});
+
+describe('buildHandoverTitle', () => {
+  test('appends the handover suffix', () => {
+    expect(buildHandoverTitle('My Task')).toBe('My Task (handover)');
+  });
+
+  test('returns undefined when there is no title', () => {
+    expect(buildHandoverTitle(undefined)).toBeUndefined();
+    expect(buildHandoverTitle('')).toBeUndefined();
+  });
+
+  test('is idempotent for already-suffixed titles', () => {
+    expect(buildHandoverTitle('My Task (handover)')).toBe('My Task (handover)');
+  });
+
+  test('keeps the result within the 50 character title limit', () => {
+    const longTitle = 'x'.repeat(60);
+    const result = buildHandoverTitle(longTitle)!;
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(result.endsWith(' (handover)')).toBe(true);
+  });
+});
+
+describe('buildHandoverMessage', () => {
+  const emptyWorkState = { branches: [], pullRequests: [], repositories: [], commits: [] };
+
+  test('renders all sections when data is available', () => {
+    const todoList: TodoList = {
+      items: [
+        { id: 'task-1', description: 'implement feature', status: 'completed', createdAt: 1, updatedAt: 1 },
+        { id: 'task-2', description: 'write tests', status: 'in_progress', createdAt: 1, updatedAt: 1 },
+      ],
+      lastUpdated: 1,
+    };
+    const message = buildHandoverMessage({
+      oldSessionId: 'session-old-1',
+      todoList,
+      recentMessages: [
+        { role: 'user', text: 'please fix the bug' },
+        { role: 'assistant', text: 'on it, created branch feature/fix-1' },
+      ],
+      workState: {
+        branches: ['feature/fix-1'],
+        pullRequests: ['https://github.com/o/r/pull/1'],
+        repositories: ['https://github.com/o/r'],
+        commits: ['abc1234'],
+      },
+    });
+
+    expect(message).toContain('[System: Session Handover]');
+    expect(message).toContain('session session-old-1 which became unresponsive');
+    expect(message).toContain('## Previous Todo List');
+    expect(message).toContain('- [completed] implement feature');
+    expect(message).toContain('- [in_progress] write tests');
+    expect(message).toContain('## Last Messages (most recent context)');
+    expect(message).toContain('[user] please fix the bug');
+    expect(message).toContain('## Detected Work State (best-effort)');
+    expect(message).toContain('- Branch: feature/fix-1');
+    expect(message).toContain('- Pull Request: https://github.com/o/r/pull/1');
+    expect(message).toContain('unpushed local changes may have been lost');
+    expect(message).toContain('## Instructions');
+    expect(message).toContain('searchSessions (scope: "tree")');
+  });
+
+  test('omits todo and messages sections when empty', () => {
+    const message = buildHandoverMessage({
+      oldSessionId: 'session-old-2',
+      todoList: null,
+      recentMessages: [],
+      workState: emptyWorkState,
+    });
+    expect(message).not.toContain('## Previous Todo List');
+    expect(message).not.toContain('## Last Messages');
+    expect(message).toContain('## Detected Work State (best-effort)');
+    expect(message).toContain('## Instructions');
+  });
+
+  test('truncates long message bodies', () => {
+    const message = buildHandoverMessage({
+      oldSessionId: 'session-old-3',
+      todoList: null,
+      recentMessages: [{ role: 'assistant', text: 'x'.repeat(1000) }],
+      workState: emptyWorkState,
+      maxMessageChars: 100,
+    });
+    expect(message).toContain('… (truncated)');
+    expect(message).not.toContain('x'.repeat(101));
+  });
+});

--- a/packages/agent-core/src/lib/handover-context.ts
+++ b/packages/agent-core/src/lib/handover-context.ts
@@ -1,0 +1,250 @@
+import { MessageItem } from '../schema';
+import { TodoList } from '../schema/todo';
+
+/**
+ * Helpers for the webapp "Handover to New Session" feature.
+ *
+ * When a session becomes unresponsive, the user can hand its work over to a
+ * fresh session in one action. The new session's seed message must carry
+ * enough context (todo list, recent conversation, detected work state) for
+ * the successor to continue without manual archaeology. Everything in this
+ * module is a pure function so it can be unit-tested without AWS access.
+ */
+
+export interface DetectedWorkState {
+  /** Git branch names, most recent mention first. */
+  branches: string[];
+  /** Pull request URLs, most recent mention first. */
+  pullRequests: string[];
+  /** Repository URLs (GitHub / CodeCommit), most recent mention first. */
+  repositories: string[];
+  /** Commit hashes, most recent mention first. */
+  commits: string[];
+}
+
+export interface HandoverConversationMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+const MAX_ITEMS_PER_CATEGORY = 3;
+
+const BRANCH_PATTERNS = [
+  /git checkout -b\s+['"`]?([\w./-]+)/g,
+  /git switch -c\s+['"`]?([\w./-]+)/g,
+  /git push(?:\s+(?:-u|--set-upstream))?\s+origin\s+['"`]?([\w./-]+)/g,
+  /Switched to a new branch '([\w./-]+)'/g,
+  /branch\s*[:：]\s*`?([\w./-]{3,})`?/gi,
+  /branch\s+`([\w./-]{3,})`/gi,
+  // Plain-text mention of a branch-like token (e.g. "working on
+  // feature/foo-123"). Restricted to well-known branch prefixes and guarded
+  // by a lookbehind so path segments inside URLs / file paths
+  // (e.g. github.com/owner/feature/...) are not misdetected.
+  /(?<![\w/.])((?:feature|fix|bugfix|hotfix|chore|release|refactor)\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*)/g,
+];
+
+const PR_URL_PATTERN = /https:\/\/github\.com\/[\w-]+\/[\w.-]+\/pull\/\d+/g;
+const GITHUB_REPO_PATTERN = /https:\/\/github\.com\/([\w-]+\/[\w.-]+)/g;
+const CODECOMMIT_REPO_PATTERN = /https:\/\/git-codecommit\.[\w-]+\.amazonaws\.com\/v1\/repos\/[\w.-]+/g;
+const COMMIT_PATTERN = /\bcommit\s+([0-9a-f]{7,40})\b/gi;
+
+const stripTrailingPunctuation = (value: string) => value.replace(/[.,;:)]+$/, '');
+
+const collectMatches = (texts: string[], pattern: RegExp, transform?: (m: string) => string): string[] => {
+  const found: string[] = [];
+  for (const text of texts) {
+    // Reset lastIndex since the shared RegExp objects are sticky across calls (global flag).
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const raw = stripTrailingPunctuation(match[1] ?? match[0]);
+      if (!raw) continue;
+      found.push(transform ? transform(raw) : raw);
+    }
+  }
+  // Keep the most recent mention first, dropping duplicates.
+  const unique: string[] = [];
+  for (let i = found.length - 1; i >= 0; i--) {
+    if (!unique.includes(found[i])) {
+      unique.push(found[i]);
+    }
+  }
+  return unique.slice(0, MAX_ITEMS_PER_CATEGORY);
+};
+
+/**
+ * Best-effort extraction of the work state (branch / PR / repository /
+ * commit) from free-form conversation and tool activity texts.
+ * @param texts Texts ordered oldest → newest.
+ */
+export const extractWorkState = (texts: string[]): DetectedWorkState => {
+  const branches: string[] = [];
+  for (const pattern of BRANCH_PATTERNS) {
+    for (const branch of collectMatches(texts, pattern)) {
+      if (!branches.includes(branch)) {
+        branches.push(branch);
+      }
+    }
+  }
+
+  const pullRequests = collectMatches(texts, PR_URL_PATTERN);
+  const repositories = collectMatches(texts, GITHUB_REPO_PATTERN, (repo) => `https://github.com/${repo}`).concat(
+    collectMatches(texts, CODECOMMIT_REPO_PATTERN)
+  );
+  const commits = collectMatches(texts, COMMIT_PATTERN);
+
+  return {
+    branches: branches.slice(0, MAX_ITEMS_PER_CATEGORY),
+    pullRequests,
+    repositories: repositories.slice(0, MAX_ITEMS_PER_CATEGORY),
+    commits,
+  };
+};
+
+const parseContentBlocks = (item: MessageItem): any[] => {
+  try {
+    const content = JSON.parse(item.content);
+    return Array.isArray(content) ? content : [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Strips the LLM prompt envelope (`<user_message>` tags, `<command>` tail,
+ * `[from: ...]` / `[Message from ...]` sender prefixes) so only the
+ * human-meaningful body remains.
+ */
+export const stripPromptEnvelope = (text: string): string => {
+  let body = text;
+  const open = body.indexOf('<user_message>');
+  const close = body.indexOf('</user_message>');
+  if (open !== -1 && close !== -1 && close > open) {
+    body = body.slice(open + '<user_message>'.length, close);
+  }
+  return body
+    .replace(/^\s*\[from:[^\]]*\]\n?/, '')
+    .replace(/^\s*\[Message from [^\]]+\]:\s*/, '')
+    .trim();
+};
+
+const CONVERSATION_MESSAGE_TYPES = new Set(['userMessage', 'assistant', 'agentMessage']);
+
+/**
+ * Extracts the most recent user/assistant conversation texts from raw
+ * DynamoDB message items (ordered oldest → newest).
+ */
+export const collectRecentConversation = (items: MessageItem[], maxMessages: number): HandoverConversationMessage[] => {
+  const conversation: HandoverConversationMessage[] = [];
+  for (const item of items) {
+    if (!CONVERSATION_MESSAGE_TYPES.has(item.messageType)) continue;
+    if (item.role !== 'user' && item.role !== 'assistant') continue;
+    const text = parseContentBlocks(item)
+      .map((block) => block?.text)
+      .filter((t): t is string => typeof t === 'string')
+      .join('\n');
+    const stripped = stripPromptEnvelope(text);
+    if (!stripped) continue;
+    conversation.push({ role: item.role, text: stripped });
+  }
+  return conversation.slice(-maxMessages);
+};
+
+/**
+ * Collects every text-ish fragment (message text, tool inputs, tool result
+ * texts) from the most recent items so `extractWorkState` can scan git
+ * commands and their outputs, not just prose.
+ */
+export const collectWorkStateScanTexts = (items: MessageItem[], maxItems: number): string[] => {
+  const texts: string[] = [];
+  for (const item of items.slice(-maxItems)) {
+    for (const block of parseContentBlocks(item)) {
+      if (typeof block?.text === 'string') {
+        texts.push(block.text);
+      }
+      if (block?.toolUse?.input != null) {
+        try {
+          texts.push(JSON.stringify(block.toolUse.input));
+        } catch {
+          // ignore non-serializable input
+        }
+      }
+      for (const resultBlock of block?.toolResult?.content ?? []) {
+        if (typeof resultBlock?.text === 'string') {
+          texts.push(resultBlock.text);
+        }
+      }
+    }
+  }
+  return texts;
+};
+
+const HANDOVER_TITLE_SUFFIX = ' (handover)';
+const MAX_TITLE_LENGTH = 50;
+
+/**
+ * Builds the successor session's title so it is distinguishable from the old
+ * session in list views. Returns undefined when the old session has no title
+ * (letting the successor auto-generate one). Idempotent: an already-suffixed
+ * title is returned unchanged so chained handovers do not stack suffixes.
+ */
+export const buildHandoverTitle = (oldTitle: string | undefined): string | undefined => {
+  if (!oldTitle) return undefined;
+  if (oldTitle.endsWith(HANDOVER_TITLE_SUFFIX)) return oldTitle;
+  const base = oldTitle.slice(0, MAX_TITLE_LENGTH - HANDOVER_TITLE_SUFFIX.length);
+  return `${base}${HANDOVER_TITLE_SUFFIX}`;
+};
+
+export interface BuildHandoverMessageParams {
+  oldSessionId: string;
+  todoList: TodoList | null;
+  /** Recent conversation, oldest first. */
+  recentMessages: HandoverConversationMessage[];
+  workState: DetectedWorkState;
+  /** Per-message character budget. Longer texts are head-truncated. */
+  maxMessageChars?: number;
+}
+
+const DEFAULT_MAX_MESSAGE_CHARS = 500;
+
+const truncate = (text: string, maxChars: number) =>
+  text.length > maxChars ? `${text.slice(0, maxChars)}… (truncated)` : text;
+
+/**
+ * Builds the seed message for the successor session created by the webapp
+ * handover action.
+ */
+export const buildHandoverMessage = (params: BuildHandoverMessageParams): string => {
+  const { oldSessionId, todoList, recentMessages, workState, maxMessageChars = DEFAULT_MAX_MESSAGE_CHARS } = params;
+
+  const sections: string[] = [
+    '[System: Session Handover]',
+    `This session is continuing work from session ${oldSessionId} which became unresponsive.\nThe old session and its children have been reparented under this session.`,
+  ];
+
+  if (todoList && todoList.items.length > 0) {
+    const todoLines = todoList.items.map((item) => `- [${item.status}] ${item.description}`);
+    sections.push(`## Previous Todo List\n${todoLines.join('\n')}`);
+  }
+
+  if (recentMessages.length > 0) {
+    const messageLines = recentMessages.map((m) => `[${m.role}] ${truncate(m.text, maxMessageChars)}`);
+    sections.push(`## Last Messages (most recent context)\n${messageLines.join('\n\n')}`);
+  }
+
+  const workStateLines: string[] = [];
+  if (workState.branches.length > 0) workStateLines.push(`- Branch: ${workState.branches.join(', ')}`);
+  if (workState.pullRequests.length > 0) workStateLines.push(`- Pull Request: ${workState.pullRequests.join(', ')}`);
+  if (workState.repositories.length > 0) workStateLines.push(`- Repository: ${workState.repositories.join(', ')}`);
+  if (workState.commits.length > 0) workStateLines.push(`- Commit: ${workState.commits.join(', ')}`);
+  workStateLines.push(
+    "- Note: Any unpushed local changes may have been lost along with the old session's environment. Verify the remote state before continuing."
+  );
+  sections.push(`## Detected Work State (best-effort)\n${workStateLines.join('\n')}`);
+
+  sections.push(
+    `## Instructions\nContinue the work. Old session ${oldSessionId} is now your child; use searchSessions (scope: "tree") for additional context before asking the user.`
+  );
+
+  return sections.join('\n\n');
+};


### PR DESCRIPTION
# Summary
Add two pure, side-effect-free helpers that support model-driven session
handover: work-state/handover-context extraction, and a per-turn context-window
usage self-awareness block.

## Motivation
When a session hands over to a successor, the successor needs a concise seed of
the prior work (branches, PRs, repos, commits, recent conversation) so it can
continue without manual archaeology. Separately, surfacing the current
context-window utilisation back to the model lets it decide to hand over
*before* the window fills, rather than hitting truncation/overflow.

## Changes
- packages/agent-core/src/lib/handover-context.ts: extract work state from recent
  conversation/tool activity and build the successor seed message + title.
- packages/agent-core/src/lib/auto-handover.ts: build the per-turn context-usage
  environment block (soft ~80% guideline; the model decides, no forced auto-fire).
- matching handover-context.test.ts / auto-handover.test.ts.

## Testing
- agent-core unit tests: handover-context 26 + auto-handover 6 = 32 tests, all
  passing (tsc + prettier + vitest).

## Notes
- Self-contained, pure (no AWS SDK), unit-testable in isolation. Independent of
  the other Batch 2 PRs (no shared files).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
