### PR TITLE
chore: remove sendImageToUser tool references

### DIFF
--- a/packages/agent-core/src/lib/search-sessions.ts
+++ b/packages/agent-core/src/lib/search-sessions.ts
@@ -47,12 +47,7 @@ export const SEARCHABLE_MESSAGE_TYPES = new Set([
   'communicationLog',
 ]);
 
-export const MSG_TOOLS = new Set([
-  'sendMessageToUser',
-  'sendMessageToUserIfNecessary',
-  'sendImageToUser',
-  'sendFileToUser',
-]);
+export const MSG_TOOLS = new Set(['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendFileToUser']);
 
 export function extractTextFromContent(content: any[], messageType: string): string {
   if (messageType === 'toolUse') {

--- a/packages/agent-core/src/lib/self-narration-filter.ts
+++ b/packages/agent-core/src/lib/self-narration-filter.ts
@@ -323,7 +323,6 @@ export const shouldSuppressWakeupMonologue = (opts: {
 export const NON_WORK_TOOL_NAMES = new Set<string>([
   'sendMessageToUser',
   'sendMessageToUserIfNecessary',
-  'sendImageToUser',
   'sendFileToUser',
   'sendMessageToAgent',
   'acknowledgeAgent',

--- a/packages/agent-core/src/lib/user-delivery-dedup.test.ts
+++ b/packages/agent-core/src/lib/user-delivery-dedup.test.ts
@@ -140,7 +140,6 @@ describe('isMessageDeliveryToolName', () => {
   test('matches the user-facing message-delivery tools', () => {
     expect(isMessageDeliveryToolName('sendMessageToUser')).toBe(true);
     expect(isMessageDeliveryToolName('sendMessageToUserIfNecessary')).toBe(true);
-    expect(isMessageDeliveryToolName('sendImageToUser')).toBe(true);
     expect(isMessageDeliveryToolName('sendFileToUser')).toBe(true);
   });
 

--- a/packages/agent-core/src/lib/user-delivery-dedup.ts
+++ b/packages/agent-core/src/lib/user-delivery-dedup.ts
@@ -138,7 +138,6 @@ export const recordUserDelivery = async (
 export const MESSAGE_DELIVERY_TOOL_NAMES = [
   'sendMessageToUser',
   'sendMessageToUserIfNecessary',
-  'sendImageToUser',
   'sendFileToUser',
 ] as const;
 

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionContentSearch.test.ts
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionContentSearch.test.ts
@@ -144,7 +144,6 @@ describe('MSG_TOOLS (search-content-lib)', () => {
   it('includes user-visible message-sending tools', () => {
     expect(MSG_TOOLS.has('sendMessageToUser')).toBe(true);
     expect(MSG_TOOLS.has('sendMessageToUserIfNecessary')).toBe(true);
-    expect(MSG_TOOLS.has('sendImageToUser')).toBe(true);
     expect(MSG_TOOLS.has('sendFileToUser')).toBe(true);
   });
 

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -301,25 +301,6 @@ export default function SessionPageClient({
                   },
                 ]);
               }
-            } else if (['sendImageToUser'].includes(event.toolName)) {
-              const input = JSON.parse(event.input);
-              const messageText = input.message;
-              // TODO: share the same logic with backend
-              const ext = '.' + input.imagePath.split('.').at(-1);
-              const key = `${workerId}/${event.toolUseId}${ext}`;
-
-              setMessages((prev) => [
-                ...prev,
-                {
-                  id: Date.now().toString(),
-                  role: 'assistant',
-                  content: messageText,
-                  timestamp: new Date(event.timestamp),
-                  type: 'message',
-                  imageKeys: [key],
-                  thinkingBudget: event.thinkingBudget,
-                },
-              ]);
             } else if (['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser'].includes(event.toolName)) {
               // Agent-to-agent tools are silent in local view; shown via agentMessage events on parent
             } else {

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -1,5 +1,4 @@
 import {
-  getAttachedImageKey,
   getAttachedFileKey,
   isImageKey,
   getConversationHistory,
@@ -36,7 +35,7 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
 
   const messages: MessageView[] = [];
   const isMsg = (toolName: string | undefined) =>
-    ['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendImageToUser', 'sendFileToUser'].includes(toolName ?? '');
+    ['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendFileToUser'].includes(toolName ?? '');
   const isHiddenTool = (toolName: string | undefined) =>
     isMsg(toolName) || ['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser'].includes(toolName ?? '');
 
@@ -65,28 +64,7 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const input = block.toolUse?.input as any;
 
-            if (toolName === 'sendImageToUser') {
-              const messageText = formatMessage(input?.message ?? '');
-              const key = getAttachedImageKey(workerId, toolUseId, input.imagePath);
-
-              // Extract reasoning content if available
-              let reasoningText: string | undefined;
-              const reasoningBlocks = message.content?.filter((block) => block.reasoningContent) ?? [];
-              if (reasoningBlocks.length > 0) {
-                reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
-              }
-
-              messages.push({
-                id: `${item.SK}-${i}-${toolUseId}`,
-                role: 'assistant',
-                content: messageText,
-                timestamp: new Date(parseInt(item.SK)),
-                type: 'message',
-                imageKeys: [key],
-                thinkingBudget: item.thinkingBudget,
-                reasoningText,
-              });
-            } else if (toolName === 'sendFileToUser') {
+            if (toolName === 'sendFileToUser') {
               const messageText = formatMessage(input?.message ?? '');
               const key = getAttachedFileKey(workerId, toolUseId, input.filePath);
               const isToolComplete = completedToolUseIds.has(toolUseId);


### PR DESCRIPTION
## Summary
Removes the remaining string references to the retired `sendImageToUser`
tool across the agent-core delivery/dedup allowlists and the webapp session
renderer.

## Motivation
Historical `sendImageToUser` `toolUse` events can simply fall back to the
generic tool-rendering path, so the dedicated handling is unnecessary.

## Changes
- `agent-core/search-sessions.ts`: drop from `MSG_TOOLS`
- `agent-core/self-narration-filter.ts`: drop from `NON_WORK_TOOL_NAMES`
- `agent-core/user-delivery-dedup.ts`: drop from `MESSAGE_DELIVERY_TOOL_NAMES`
- `webapp/sessions/[workerId]/page.tsx`: remove historical `sendImageToUser`
  render branch, drop from `isMsg`, remove now-unused `getAttachedImageKey` import
- `webapp/.../SessionPageClient.tsx`: remove realtime `sendImageToUser` render branch
- Update associated unit test expectations

Historical `sendImageToUser` `toolUse` events now fall through to the generic
tool-rendering path (degraded display, no crash).

## Testing
- `npm run build -w packages/agent-core` (tsc) — pass
- vitest agent-core (user-delivery-dedup, self-narration-filter, search-sessions) — 78 passed
- vitest webapp (SessionContentSearch) — 26 passed
- prettier `format:check` (agent-core, webapp) — pass

## Notes
- The pre-existing `PageProps` tsc diagnostic in `page.tsx` is unrelated to
  this change (the `.next/types` global is only generated during `next build`);
  it reproduces on untouched `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
