### PR TITLE
feat(agent-core): add session management tools

### DIFF
--- a/packages/agent-core/src/tools/complete-session/index.test.ts
+++ b/packages/agent-core/src/tools/complete-session/index.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockUpdateSessionAgentStatus = vi.fn();
+const mockStopWorkerInstance = vi.fn();
+const mockSendWebappEvent = vi.fn();
+const mockSavePendingCompleteSession = vi.fn();
+
+vi.mock('../../lib', () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  updateSessionAgentStatus: (...args: any[]) => mockUpdateSessionAgentStatus(...args),
+  stopWorkerInstance: (...args: any[]) => mockStopWorkerInstance(...args),
+}));
+
+vi.mock('../../lib/events', () => ({
+  sendWebappEvent: (...args: any[]) => mockSendWebappEvent(...args),
+}));
+
+vi.mock('../confirm-complete-session', () => ({
+  savePendingCompleteSession: (...args: any[]) => mockSavePendingCompleteSession(...args),
+}));
+
+import { completeSessionTool } from './index';
+
+const mockContext = {
+  workerId: 'test-worker-123',
+  toolUseId: 'test-tool-use',
+  globalPreferences: { PK: 'global-config', SK: 'general' },
+};
+
+describe('completeSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('child session (has parentSessionId)', () => {
+    test('completes itself immediately without confirmation', async () => {
+      mockGetSession.mockResolvedValue({
+        agentStatus: 'working',
+        runtimeType: 'agent-core',
+        parentSessionId: 'parent-123',
+      });
+
+      const result = await completeSessionTool.handler({}, mockContext as any);
+
+      expect(mockSavePendingCompleteSession).not.toHaveBeenCalled();
+      expect(mockUpdateSessionAgentStatus).toHaveBeenCalledWith('test-worker-123', 'completed');
+      expect(mockSendWebappEvent).toHaveBeenCalledWith('test-worker-123', {
+        type: 'agentStatusUpdate',
+        status: 'completed',
+      });
+      expect(mockStopWorkerInstance).toHaveBeenCalledWith('test-worker-123', 'agent-core');
+      expect(result).toContain('completed');
+    });
+
+    test('completes itself when explicitly specifying own sessionId', async () => {
+      mockGetSession.mockResolvedValue({
+        agentStatus: 'working',
+        runtimeType: 'agent-core',
+        parentSessionId: 'parent-123',
+      });
+
+      const result = await completeSessionTool.handler({ sessionId: 'test-worker-123' }, mockContext as any);
+
+      expect(mockSavePendingCompleteSession).not.toHaveBeenCalled();
+      expect(mockUpdateSessionAgentStatus).toHaveBeenCalledWith('test-worker-123', 'completed');
+      expect(mockStopWorkerInstance).toHaveBeenCalledWith('test-worker-123', 'agent-core');
+      expect(result).toContain('completed');
+    });
+
+    test('rejects completing another session', async () => {
+      mockGetSession.mockResolvedValue({
+        agentStatus: 'working',
+        runtimeType: 'agent-core',
+        parentSessionId: 'parent-123',
+      });
+
+      const result = await completeSessionTool.handler({ sessionId: 'other-session-456' }, mockContext as any);
+
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+      expect(result).toContain('Permission denied');
+    });
+  });
+
+  describe('top-level session (no parentSessionId)', () => {
+    test('self-completion triggers confirmation guard', async () => {
+      mockGetSession.mockResolvedValue({ agentStatus: 'working', runtimeType: 'agent-core' });
+
+      const result = await completeSessionTool.handler({}, mockContext as any);
+
+      expect(mockSavePendingCompleteSession).toHaveBeenCalledWith('test-worker-123');
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+      expect(result).toContain('CONFIRMATION REQUIRED');
+      expect(result).toContain('Confirm Complete Session');
+    });
+
+    test('self-completion with explicit sessionId also triggers confirmation guard', async () => {
+      mockGetSession.mockResolvedValue({ agentStatus: 'working', runtimeType: 'agent-core' });
+
+      const result = await completeSessionTool.handler({ sessionId: 'test-worker-123' }, mockContext as any);
+
+      expect(mockSavePendingCompleteSession).toHaveBeenCalledWith('test-worker-123');
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+      expect(result).toContain('CONFIRMATION REQUIRED');
+      expect(result).toContain('Confirm Complete Session');
+    });
+
+    test('completing another session succeeds immediately', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ agentStatus: 'working', runtimeType: 'agent-core' }) // caller
+        .mockResolvedValueOnce({ agentStatus: 'working', runtimeType: 'ec2' }); // target
+
+      const result = await completeSessionTool.handler({ sessionId: 'other-session-456' }, mockContext as any);
+
+      expect(mockGetSession).toHaveBeenCalledWith('test-worker-123');
+      expect(mockGetSession).toHaveBeenCalledWith('other-session-456');
+      expect(mockSavePendingCompleteSession).not.toHaveBeenCalled();
+      expect(mockUpdateSessionAgentStatus).toHaveBeenCalledWith('other-session-456', 'completed');
+      expect(mockSendWebappEvent).toHaveBeenCalledWith('other-session-456', {
+        type: 'agentStatusUpdate',
+        status: 'completed',
+      });
+      expect(mockStopWorkerInstance).toHaveBeenCalledWith('other-session-456', 'ec2');
+      expect(result).toContain('completed');
+    });
+
+    test('completing another session that does not exist returns not found', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ agentStatus: 'working', runtimeType: 'agent-core' }) // caller
+        .mockResolvedValueOnce(undefined); // target
+
+      const result = await completeSessionTool.handler({ sessionId: 'nonexistent' }, mockContext as any);
+
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(result).toContain('not found');
+    });
+  });
+
+  describe('common cases', () => {
+    test('is idempotent - no-op if already completed', async () => {
+      mockGetSession.mockResolvedValue({ agentStatus: 'completed', runtimeType: 'ec2' });
+
+      const result = await completeSessionTool.handler({}, mockContext as any);
+
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+      expect(result).toContain('already completed');
+    });
+
+    test('returns not found when caller session does not exist', async () => {
+      mockGetSession.mockResolvedValue(undefined);
+
+      const result = await completeSessionTool.handler({}, mockContext as any);
+
+      expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+      expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+      expect(result).toContain('not found');
+    });
+  });
+});

--- a/packages/agent-core/src/tools/complete-session/index.ts
+++ b/packages/agent-core/src/tools/complete-session/index.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { getSession, updateSessionAgentStatus, stopWorkerInstance } from '../../lib';
+import { sendWebappEvent } from '../../lib/events';
+import { savePendingCompleteSession } from '../confirm-complete-session';
+
+const inputSchema = z.object({
+  sessionId: z
+    .string()
+    .optional()
+    .describe('The session ID to complete. Defaults to the current session if not specified.'),
+});
+
+const name = 'Complete Session';
+
+export const completeSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const targetSessionId = input.sessionId ?? context.workerId;
+    const isSelf = targetSessionId === context.workerId;
+
+    const callerSession = await getSession(context.workerId);
+    if (!callerSession) {
+      return 'Caller session not found.';
+    }
+
+    const isChild = !!callerSession.parentSessionId;
+
+    if (isChild && !isSelf) {
+      return 'Permission denied: child/sub-agent sessions can only complete themselves, not other sessions.';
+    }
+
+    const targetSession = isSelf ? callerSession : await getSession(targetSessionId);
+    if (!targetSession) {
+      return 'Target session not found.';
+    }
+    if (targetSession.agentStatus === 'completed') {
+      return 'Session is already completed.';
+    }
+
+    if (!isChild && isSelf) {
+      savePendingCompleteSession(context.workerId);
+      return [
+        `CONFIRMATION REQUIRED: You are about to complete a top-level session.`,
+        ``,
+        `Only call Confirm Complete Session if the user EXPLICITLY instructed you to end/close/complete this session.`,
+        `If the user did NOT give such instruction, your mission is still in progress — do NOT complete.`,
+        ``,
+        `To proceed: call Confirm Complete Session.`,
+        `To abort: simply do not call Confirm Complete Session and continue working.`,
+      ].join('\n');
+    }
+
+    await updateSessionAgentStatus(targetSessionId, 'completed');
+    await sendWebappEvent(targetSessionId, { type: 'agentStatusUpdate', status: 'completed' });
+
+    const runtimeType = targetSession.runtimeType ?? 'ec2';
+    await stopWorkerInstance(targetSessionId, runtimeType);
+
+    return 'Session marked as completed and worker stopped.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Complete a session by ID, stopping its worker. If a new message arrives later, the session will automatically resume.
+
+This action is idempotent — calling it on an already-completed session is a no-op.
+
+Parameters:
+- sessionId (optional): The ID of the session to complete. Defaults to the current session if omitted.
+
+Permission model:
+- Child/sub-agent sessions: Can only complete themselves (the default). Specifying another session's ID will be rejected.
+- Top-level sessions (no parent): Can complete any session by ID.
+  - Completing another session: Executes immediately with no confirmation.
+  - Completing itself (self-completion): Triggers a confirmation guard — you must then call Confirm Complete Session to proceed. This guard exists because top-level sessions should only self-complete when the user explicitly asks.
+
+You can determine whether you are a child session by checking the Session Hierarchy section in your context. If it says "You are a child agent" or shows a Parent session, you are a child session. If there is no Session Hierarchy section or it says "You are a parent agent", you are a top-level session.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/confirm-complete-session/index.test.ts
+++ b/packages/agent-core/src/tools/confirm-complete-session/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+
+const mockGetSession = vi.fn();
+const mockUpdateSessionAgentStatus = vi.fn();
+const mockStopWorkerInstance = vi.fn();
+const mockSendWebappEvent = vi.fn();
+
+vi.mock('../../lib', () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  updateSessionAgentStatus: (...args: any[]) => mockUpdateSessionAgentStatus(...args),
+  stopWorkerInstance: (...args: any[]) => mockStopWorkerInstance(...args),
+}));
+
+vi.mock('../../lib/events', () => ({
+  sendWebappEvent: (...args: any[]) => mockSendWebappEvent(...args),
+}));
+
+import { confirmCompleteSessionTool, savePendingCompleteSession } from './index';
+
+const mockContext = {
+  workerId: 'test-worker-confirm-123',
+  toolUseId: 'test-tool-use',
+  globalPreferences: { PK: 'global-config', SK: 'general' },
+};
+
+describe('confirmCompleteSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    try {
+      unlinkSync(join(tmpdir(), `.pending-complete-session-${mockContext.workerId}`));
+    } catch {}
+  });
+
+  test('completes session when pending flag exists', async () => {
+    savePendingCompleteSession(mockContext.workerId);
+    mockGetSession.mockResolvedValue({ agentStatus: 'working', runtimeType: 'agent-core' });
+
+    const result = await confirmCompleteSessionTool.handler({}, mockContext as any);
+
+    expect(mockUpdateSessionAgentStatus).toHaveBeenCalledWith('test-worker-confirm-123', 'completed');
+    expect(mockSendWebappEvent).toHaveBeenCalledWith('test-worker-confirm-123', {
+      type: 'agentStatusUpdate',
+      status: 'completed',
+    });
+    expect(mockStopWorkerInstance).toHaveBeenCalledWith('test-worker-confirm-123', 'agent-core');
+    expect(result).toContain('completed');
+  });
+
+  test('falls back to ec2 runtime when runtimeType is undefined', async () => {
+    savePendingCompleteSession(mockContext.workerId);
+    mockGetSession.mockResolvedValue({ agentStatus: 'working' });
+
+    const result = await confirmCompleteSessionTool.handler({}, mockContext as any);
+
+    expect(mockStopWorkerInstance).toHaveBeenCalledWith('test-worker-confirm-123', 'ec2');
+    expect(result).toContain('completed');
+  });
+
+  test('returns error when no pending completeSession exists', async () => {
+    const result = await confirmCompleteSessionTool.handler({}, mockContext as any);
+
+    expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+    expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+    expect(result).toContain('No pending completeSession');
+  });
+
+  test('returns error when session not found', async () => {
+    savePendingCompleteSession(mockContext.workerId);
+    mockGetSession.mockResolvedValue(undefined);
+
+    const result = await confirmCompleteSessionTool.handler({}, mockContext as any);
+
+    expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+    expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+    expect(result).toContain('Session not found');
+  });
+
+  test('returns error when session is already completed', async () => {
+    savePendingCompleteSession(mockContext.workerId);
+    mockGetSession.mockResolvedValue({ agentStatus: 'completed', runtimeType: 'agent-core' });
+
+    const result = await confirmCompleteSessionTool.handler({}, mockContext as any);
+
+    expect(mockUpdateSessionAgentStatus).not.toHaveBeenCalled();
+    expect(mockStopWorkerInstance).not.toHaveBeenCalled();
+    expect(result).toContain('already completed');
+  });
+});

--- a/packages/agent-core/src/tools/confirm-complete-session/index.ts
+++ b/packages/agent-core/src/tools/confirm-complete-session/index.ts
@@ -1,0 +1,65 @@
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { writeFileSync, readFileSync, unlinkSync } from 'fs';
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { getSession, updateSessionAgentStatus, stopWorkerInstance } from '../../lib';
+import { sendWebappEvent } from '../../lib/events';
+
+const PENDING_DIR = tmpdir();
+
+const pendingFilePath = (workerId: string) => join(PENDING_DIR, `.pending-complete-session-${workerId}`);
+
+export const savePendingCompleteSession = (workerId: string) => {
+  writeFileSync(pendingFilePath(workerId), 'pending', 'utf-8');
+};
+
+export const loadAndDeletePendingCompleteSession = (workerId: string): boolean => {
+  const filePath = pendingFilePath(workerId);
+  try {
+    readFileSync(filePath, 'utf-8');
+    unlinkSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const inputSchema = z.object({});
+
+const name = 'Confirm Complete Session';
+
+export const confirmCompleteSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (_input: z.infer<typeof inputSchema>, context) => {
+    const hasPending = loadAndDeletePendingCompleteSession(context.workerId);
+
+    if (!hasPending) {
+      return 'No pending completeSession to confirm. Call completeSession first.';
+    }
+
+    const session = await getSession(context.workerId);
+    if (!session) {
+      return 'Session not found.';
+    }
+    if (session.agentStatus === 'completed') {
+      return 'Session is already completed.';
+    }
+
+    await updateSessionAgentStatus(context.workerId, 'completed');
+    await sendWebappEvent(context.workerId, { type: 'agentStatusUpdate', status: 'completed' });
+
+    const runtimeType = session.runtimeType ?? 'ec2';
+    await stopWorkerInstance(context.workerId, runtimeType);
+
+    return 'Session marked as completed and worker stopped.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Confirm and execute a blocked completeSession call. Call this after completeSession returns a confirmation prompt. Only call this if the user explicitly asked you to close/complete the session. If the user did NOT instruct you to complete, do NOT call this tool.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/export-session-diagnostics/index.ts
+++ b/packages/agent-core/src/tools/export-session-diagnostics/index.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { getSession, getDescendantSessions } from '../../lib/sessions';
+import { getConversationHistory } from '../../lib/messages';
+import type { SessionItem, MessageItem } from '../../schema';
+
+const inputSchema = z.object({
+  sessionId: z.string().describe('The session ID to export diagnostics for.'),
+  includeTree: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe('When true, recursively export all descendant sessions. Default: false.'),
+  outputPath: z.string().optional().describe('Output directory path. Default: /tmp/session-diagnostics/<sessionId>/'),
+  maxSessions: z
+    .number()
+    .int()
+    .positive()
+    .default(50)
+    .optional()
+    .describe('Maximum number of sessions to export in tree mode. Default: 50.'),
+});
+
+const name = 'Export Session Diagnostics';
+
+interface ExportResult {
+  sessionId: string;
+  outputPath: string;
+  messageCount: number;
+  children?: ExportResult[];
+}
+
+async function exportSingleSession(session: SessionItem, outputDir: string): Promise<ExportResult> {
+  mkdirSync(outputDir, { recursive: true });
+
+  const { items } = await getConversationHistory(session.workerId);
+
+  const sessionMetadata = {
+    workerId: session.workerId,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    agentStatus: session.agentStatus,
+    instanceStatus: session.instanceStatus,
+    title: session.title,
+    parentSessionId: session.parentSessionId,
+    customAgentId: session.customAgentId,
+    runtimeType: session.runtimeType,
+    agentName: session.agentName,
+    sessionCost: session.sessionCost,
+    lastMessage: session.lastMessage,
+    lastMessageAt: session.lastMessageAt,
+    handedOverTo: session.handedOverTo,
+    rewindState: session.rewindState,
+  };
+
+  const messages = items.map((item: MessageItem) => ({
+    SK: item.SK,
+    role: item.role,
+    messageType: item.messageType,
+    tokenCount: item.tokenCount,
+    content: safeParseContent(item.content),
+    thinkingBudget: item.thinkingBudget,
+    senderSessionId: item.senderSessionId,
+    senderAgentName: item.senderAgentName,
+    targetSessionId: item.targetSessionId,
+    targetAgentName: item.targetAgentName,
+    isAcknowledge: item.isAcknowledge,
+    timestamp: parseInt(item.SK, 10),
+  }));
+
+  writeFileSync(path.join(outputDir, 'session.json'), JSON.stringify(sessionMetadata, null, 2));
+  writeFileSync(path.join(outputDir, 'messages.json'), JSON.stringify(messages, null, 2));
+
+  return {
+    sessionId: session.workerId,
+    outputPath: outputDir,
+    messageCount: messages.length,
+  };
+}
+
+function safeParseContent(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return content;
+  }
+}
+
+async function exportSessionTree(
+  session: SessionItem,
+  outputDir: string,
+  descendants: SessionItem[]
+): Promise<ExportResult> {
+  const result = await exportSingleSession(session, outputDir);
+
+  const children = descendants.filter((s) => s.parentSessionId === session.workerId);
+  if (children.length > 0) {
+    const childrenDir = path.join(outputDir, 'children');
+    mkdirSync(childrenDir, { recursive: true });
+
+    result.children = [];
+    for (const child of children) {
+      const childDir = path.join(childrenDir, child.workerId);
+      const childResult = await exportSessionTree(child, childDir, descendants);
+      result.children.push(childResult);
+    }
+  }
+
+  return result;
+}
+
+export const exportSessionDiagnosticsTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const { sessionId, includeTree, maxSessions } = input;
+
+    const session = await getSession(sessionId);
+    if (!session) {
+      return `Error: Session ${sessionId} not found.`;
+    }
+
+    if (sessionId !== context.workerId) {
+      const callerSession = await getSession(context.workerId);
+      if (!callerSession) {
+        return 'Error: Could not retrieve current session information.';
+      }
+
+      const callerIsTopLevel = !callerSession.parentSessionId;
+      const callerIsTargetParent = session.parentSessionId === context.workerId;
+
+      if (!callerIsTopLevel && !callerIsTargetParent) {
+        return "Permission denied: only the target's current parent, the target itself, or a top-level session can export another session's diagnostics.";
+      }
+    }
+
+    const outputDir = input.outputPath ?? `/tmp/session-diagnostics/${sessionId}`;
+
+    if (!includeTree) {
+      const result = await exportSingleSession(session, outputDir);
+      return (
+        `Exported session diagnostics to ${result.outputPath}\n` +
+        `- session.json: session metadata\n` +
+        `- messages.json: ${result.messageCount} message(s)\n`
+      );
+    }
+
+    const descendants = await getDescendantSessions(sessionId);
+    const limit = maxSessions ?? 50;
+    const totalSessions = 1 + descendants.length;
+
+    if (totalSessions > limit) {
+      return `Error: Session tree contains ${totalSessions} sessions, which exceeds the maxSessions limit of ${limit}. Increase maxSessions or export individual sessions.`;
+    }
+
+    const result = await exportSessionTree(session, outputDir, descendants);
+
+    const totalMessages = countMessages(result);
+
+    return (
+      `Exported session tree diagnostics to ${outputDir}\n` +
+      `- Total sessions: ${totalSessions}\n` +
+      `- Total messages: ${totalMessages}\n` +
+      `- Structure:\n${formatTree(result, '  ')}`
+    );
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Export session diagnostics data (DynamoDB records) to local files for debugging.
+
+Dumps the full session metadata and all messages (including errors, tool use details, and raw content) to JSON files on disk.
+
+Use this when searchSessions doesn't provide enough detail — for example when you need to inspect raw tool use payloads, error messages, token counts, or the complete message timeline.
+
+Permission: When exporting another session's diagnostics (sessionId != self), the caller must be one of:
+- The target session's current parent
+- The target session itself
+- A top-level (no parent) session
+
+Parameters:
+- sessionId (required): The session to export.
+- includeTree (optional, default: false): When true, recursively exports all descendant sessions in a nested folder structure.
+- outputPath (optional): Output directory. Default: /tmp/session-diagnostics/<sessionId>/
+- maxSessions (optional, default: 50): Maximum number of sessions to export in tree mode. Returns an error if exceeded.
+
+Output structure (single session):
+  <outputPath>/session.json    — session metadata (status, agent, title, etc.)
+  <outputPath>/messages.json   — all messages in chronological order
+
+Output structure (tree mode):
+  <sessionId>/
+    session.json
+    messages.json
+    children/
+      <child-id>/
+        session.json
+        messages.json
+        children/
+          ...`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};
+
+function countMessages(result: ExportResult): number {
+  let count = result.messageCount;
+  if (result.children) {
+    for (const child of result.children) {
+      count += countMessages(child);
+    }
+  }
+  return count;
+}
+
+function formatTree(result: ExportResult, indent: string): string {
+  let output = `${indent}${result.sessionId} (${result.messageCount} msgs)\n`;
+  if (result.children) {
+    for (const child of result.children) {
+      output += formatTree(child, indent + '  ');
+    }
+  }
+  return output;
+}

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -17,6 +17,11 @@ export * from './wait-for';
 export * from './read-image';
 export * from './todo';
 export * from './session-title';
+export * from './complete-session';
+export * from './confirm-complete-session';
+export * from './list-sessions';
+export * from './reparent-session';
+export * from './export-session-diagnostics';
 
 import { ciTool } from './ci';
 import { commandExecutionTool } from './command-execution';
@@ -36,6 +41,11 @@ import { readImageTool } from './read-image';
 import { todoInitTool, todoUpdateTool } from './todo';
 import { updateSessionTitleTool } from './session-title';
 import { waitForConditionTool } from './wait-for';
+import { completeSessionTool } from './complete-session';
+import { confirmCompleteSessionTool } from './confirm-complete-session';
+import { listSessionsTool } from './list-sessions';
+import { reparentSessionTool } from './reparent-session';
+import { exportSessionDiagnosticsTool } from './export-session-diagnostics';
 
 /**
  * Tools that require GitHub configuration.
@@ -61,6 +71,7 @@ export const requiredTools = [
   sendFileTool,
   updateSessionTitleTool,
   confirmSendToUserTool,
+  confirmCompleteSessionTool,
 ];
 
 /**
@@ -89,6 +100,10 @@ export const optionalTools = [
   createEventTriggerTool,
   listEventTriggersTool,
   deleteEventTriggerTool,
+  completeSessionTool,
+  listSessionsTool,
+  reparentSessionTool,
+  exportSessionDiagnosticsTool,
 ];
 
 /**

--- a/packages/agent-core/src/tools/list-sessions/index.test.ts
+++ b/packages/agent-core/src/tools/list-sessions/index.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockGetSession = vi.fn();
+const mockGetChildSessions = vi.fn();
+const mockGetDescendantSessions = vi.fn();
+const mockGetSessions = vi.fn();
+const mockResolveAgentDisplayName = vi.fn();
+
+vi.mock('../../lib/sessions', () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  getChildSessions: (...args: any[]) => mockGetChildSessions(...args),
+  getDescendantSessions: (...args: any[]) => mockGetDescendantSessions(...args),
+  getSessions: (...args: any[]) => mockGetSessions(...args),
+}));
+
+vi.mock('../../lib/agent-messaging', () => ({
+  resolveAgentDisplayName: (...args: any[]) => mockResolveAgentDisplayName(...args),
+}));
+
+import { listSessionsTool } from './index';
+import type { GlobalPreferences } from '../../schema';
+
+const context = {
+  workerId: 'session-caller-001',
+  toolUseId: 'tool-use-1',
+  globalPreferences: {} as GlobalPreferences,
+};
+
+const makeSession = (id: string, status = 'working', title?: string, parentId?: string) => ({
+  PK: 'sessions',
+  SK: id,
+  workerId: id,
+  agentStatus: status,
+  title,
+  parentSessionId: parentId,
+  createdAt: Date.now(),
+  agentName: undefined,
+});
+
+describe('listSessionsTool handler', () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+    mockGetChildSessions.mockReset();
+    mockGetDescendantSessions.mockReset();
+    mockGetSessions.mockReset();
+    mockResolveAgentDisplayName.mockReset();
+    mockResolveAgentDisplayName.mockImplementation((s) => s.agentName ?? s.workerId);
+  });
+
+  describe('scope=children (default)', () => {
+    test('lists own children without permission check', async () => {
+      const children = [
+        makeSession('child-1', 'working', 'Task A', 'session-caller-001'),
+        makeSession('child-2', 'completed', 'Task B', 'session-caller-001'),
+      ];
+      mockGetChildSessions.mockResolvedValue(children);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'all' }, context);
+
+      expect(mockGetChildSessions).toHaveBeenCalledWith('session-caller-001');
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(result).toContain('Child sessions of session-caller-001');
+      expect(result).toContain('child-1');
+      expect(result).toContain('child-2');
+      expect(result).toContain('2 total');
+    });
+
+    test('returns empty message when no children', async () => {
+      mockGetChildSessions.mockResolvedValue([]);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'all' }, context);
+
+      expect(result).toBe('No sessions found.');
+    });
+
+    test('filters active sessions', async () => {
+      const children = [
+        makeSession('child-1', 'working', 'Task A'),
+        makeSession('child-2', 'completed', 'Task B'),
+        makeSession('child-3', 'waiting', 'Task C'),
+      ];
+      mockGetChildSessions.mockResolvedValue(children);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'active' }, context);
+
+      expect(result).toContain('child-1');
+      expect(result).not.toContain('child-2');
+      expect(result).toContain('child-3');
+      expect(result).toContain('2 total');
+    });
+
+    test('filters completed sessions', async () => {
+      const children = [makeSession('child-1', 'working', 'Task A'), makeSession('child-2', 'completed', 'Task B')];
+      mockGetChildSessions.mockResolvedValue(children);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'completed' }, context);
+
+      expect(result).not.toContain('child-1');
+      expect(result).toContain('child-2');
+      expect(result).toContain('1 total');
+    });
+  });
+
+  describe('scope=descendants', () => {
+    test('lists descendants of self without permission check', async () => {
+      const descendants = [
+        makeSession('child-1', 'working', 'Sub A'),
+        makeSession('grandchild-1', 'completed', 'Sub Sub A'),
+      ];
+      mockGetDescendantSessions.mockResolvedValue(descendants);
+
+      const result = await listSessionsTool.handler({ scope: 'descendants', statusFilter: 'all' }, context);
+
+      expect(mockGetDescendantSessions).toHaveBeenCalledWith('session-caller-001');
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(result).toContain('Descendant sessions of session-caller-001');
+      expect(result).toContain('child-1');
+      expect(result).toContain('grandchild-1');
+    });
+  });
+
+  describe('scope=all', () => {
+    test('lists all sessions without permission check', async () => {
+      const all = [
+        makeSession('session-1', 'working'),
+        makeSession('session-2', 'completed'),
+        makeSession('session-3', 'waiting'),
+      ];
+      mockGetSessions.mockResolvedValue(all);
+
+      const result = await listSessionsTool.handler({ scope: 'all', statusFilter: 'all' }, context);
+
+      expect(mockGetSessions).toHaveBeenCalledWith(0);
+      expect(result).toContain('All sessions');
+      expect(result).toContain('3 total');
+    });
+
+    test('applies statusFilter to all sessions', async () => {
+      const all = [makeSession('session-1', 'working'), makeSession('session-2', 'completed')];
+      mockGetSessions.mockResolvedValue(all);
+
+      const result = await listSessionsTool.handler({ scope: 'all', statusFilter: 'completed' }, context);
+
+      expect(result).not.toContain('session-1');
+      expect(result).toContain('session-2');
+      expect(result).toContain('1 total');
+    });
+  });
+
+  describe('permission checks (another session)', () => {
+    test('allows when caller is top-level (no parent)', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ workerId: 'session-caller-001', parentSessionId: undefined })
+        .mockResolvedValueOnce({ workerId: 'other-session', parentSessionId: 'some-parent' });
+      mockGetChildSessions.mockResolvedValue([]);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'other-session', statusFilter: 'all' },
+        context
+      );
+
+      expect(result).toBe('No sessions found.');
+    });
+
+    test('allows when caller is target parent', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ workerId: 'session-caller-001', parentSessionId: 'grandparent' })
+        .mockResolvedValueOnce({ workerId: 'target-session', parentSessionId: 'session-caller-001' });
+      mockGetChildSessions.mockResolvedValue([makeSession('grandchild', 'working')]);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'target-session', statusFilter: 'all' },
+        context
+      );
+
+      expect(result).toContain('grandchild');
+    });
+
+    test('allows when caller is target itself', async () => {
+      const selfContext = { ...context, workerId: 'target-session' };
+      mockGetChildSessions.mockResolvedValue([]);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'target-session', statusFilter: 'all' },
+        selfContext
+      );
+
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(result).toBe('No sessions found.');
+    });
+
+    test('denies when caller is unrelated non-top-level session', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ workerId: 'session-caller-001', parentSessionId: 'some-parent' })
+        .mockResolvedValueOnce({ workerId: 'other-session', parentSessionId: 'different-parent' });
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'other-session', statusFilter: 'all' },
+        context
+      );
+
+      expect(result).toContain('Permission denied');
+    });
+
+    test('returns error when target session not found', async () => {
+      mockGetSession
+        .mockResolvedValueOnce({ workerId: 'session-caller-001', parentSessionId: undefined })
+        .mockResolvedValueOnce(undefined);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'nonexistent', statusFilter: 'all' },
+        context
+      );
+
+      expect(result).toContain('Error: Session nonexistent not found');
+    });
+
+    test('returns error when caller session not found', async () => {
+      mockGetSession.mockResolvedValueOnce(undefined);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'children', sessionId: 'other-session', statusFilter: 'all' },
+        context
+      );
+
+      expect(result).toContain('Error: Could not retrieve current session information');
+    });
+
+    test('no permission check for scope=all even with sessionId', async () => {
+      const all = [makeSession('s1', 'working')];
+      mockGetSessions.mockResolvedValue(all);
+
+      const result = await listSessionsTool.handler(
+        { scope: 'all', sessionId: 'other-session', statusFilter: 'all' },
+        context
+      );
+
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(result).toContain('All sessions');
+    });
+  });
+
+  describe('display formatting', () => {
+    test('shows title when present', async () => {
+      mockGetChildSessions.mockResolvedValue([makeSession('child-1', 'working', 'My Task')]);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'all' }, context);
+
+      expect(result).toContain('— My Task');
+    });
+
+    test('omits title dash when no title', async () => {
+      mockGetChildSessions.mockResolvedValue([makeSession('child-1', 'working')]);
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'all' }, context);
+
+      expect(result).not.toContain('—');
+    });
+
+    test('uses agentName from resolveAgentDisplayName', async () => {
+      const session = { ...makeSession('child-1', 'working'), agentName: 'My Agent' };
+      mockGetChildSessions.mockResolvedValue([session]);
+      mockResolveAgentDisplayName.mockResolvedValue('My Agent');
+
+      const result = await listSessionsTool.handler({ scope: 'children', statusFilter: 'all' }, context);
+
+      expect(result).toContain('My Agent');
+    });
+  });
+});

--- a/packages/agent-core/src/tools/list-sessions/index.ts
+++ b/packages/agent-core/src/tools/list-sessions/index.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { getSession, getChildSessions, getDescendantSessions, getSessions } from '../../lib/sessions';
+import { resolveAgentDisplayName } from '../../lib/agent-messaging';
+import { SessionItem } from '../../schema';
+
+const inputSchema = z.object({
+  scope: z
+    .enum(['children', 'descendants', 'all'])
+    .default('children')
+    .describe(
+      'Scope of sessions to list: "children" (direct children, default), "descendants" (full subtree), "all" (every session).'
+    ),
+  sessionId: z
+    .string()
+    .optional()
+    .describe(
+      'The session ID to list children/descendants of. Defaults to the current session. Ignored when scope is "all".'
+    ),
+  statusFilter: z
+    .enum(['all', 'active', 'completed'])
+    .default('all')
+    .describe(
+      'Filter by status: "all" (default), "active" (agentStatus != completed), "completed" (agentStatus == completed).'
+    ),
+});
+
+const name = 'List Sessions';
+
+export const listSessionsTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const scope = input.scope ?? 'children';
+    const statusFilter = input.statusFilter ?? 'all';
+    const targetSessionId = input.sessionId ?? context.workerId;
+
+    if (scope !== 'all' && targetSessionId !== context.workerId) {
+      const callerSession = await getSession(context.workerId);
+      if (!callerSession) {
+        return 'Error: Could not retrieve current session information.';
+      }
+
+      const targetSession = await getSession(targetSessionId);
+      if (!targetSession) {
+        return `Error: Session ${targetSessionId} not found.`;
+      }
+
+      const callerIsTopLevel = !callerSession.parentSessionId;
+      const callerIsTargetParent = targetSession.parentSessionId === context.workerId;
+      // Self-case (callerIsTarget) is already bypassed by the outer guard (targetSessionId !== context.workerId).
+
+      if (!callerIsTopLevel && !callerIsTargetParent) {
+        return "Permission denied: only the target's current parent, the target itself, or a top-level session can list another session's children/descendants.";
+      }
+    }
+
+    let sessions: SessionItem[];
+
+    switch (scope) {
+      case 'children':
+        sessions = await getChildSessions(targetSessionId);
+        break;
+      case 'descendants':
+        sessions = await getDescendantSessions(targetSessionId);
+        break;
+      case 'all':
+        sessions = await getSessions(0);
+        break;
+    }
+
+    if (statusFilter === 'active') {
+      sessions = sessions.filter((s) => s.agentStatus !== 'completed');
+    } else if (statusFilter === 'completed') {
+      sessions = sessions.filter((s) => s.agentStatus === 'completed');
+    }
+
+    if (sessions.length === 0) {
+      return 'No sessions found.';
+    }
+
+    const scopeLabel =
+      scope === 'children'
+        ? `Child sessions of ${targetSessionId}`
+        : scope === 'descendants'
+          ? `Descendant sessions of ${targetSessionId}`
+          : 'All sessions';
+    const filterLabel = statusFilter !== 'all' ? ` (filter: ${statusFilter})` : '';
+
+    const lines: string[] = [`${scopeLabel}${filterLabel} (${sessions.length} total):\n`];
+    for (const session of sessions) {
+      const displayName = await resolveAgentDisplayName(session);
+      lines.push(
+        `- ${displayName} (ID: ${session.workerId}) [${session.agentStatus ?? 'unknown'}]` +
+          (session.title ? ` — ${session.title}` : '')
+      );
+    }
+    return lines.join('\n');
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `List sessions by scope: direct children, full descendant tree, or all sessions.
+
+Scopes:
+- "children" (default): Direct child sessions of the target.
+- "descendants": Full recursive subtree (children, grandchildren, etc.).
+- "all": Every session in the system. This is a broad query — use only from top-level or authorized sessions.
+
+Permission: When listing another session's children/descendants (sessionId != self), the caller must be one of:
+- The target session's current parent
+- The target session itself
+- A top-level (no parent) session
+No permission check is needed for scope="all" or when listing your own children.
+
+Parameters:
+- scope: "children" | "descendants" | "all" (default: "children")
+- sessionId (optional): Target session. Defaults to current session. Ignored for scope="all".
+- statusFilter: "all" | "active" | "completed" (default: "all")`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/reparent-session/index.ts
+++ b/packages/agent-core/src/tools/reparent-session/index.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { getSession, reparentSessions } from '../../lib/sessions';
+
+const inputSchema = z.object({
+  sessionId: z.string().describe('The session ID to reparent (move under a new parent).'),
+  newParentSessionId: z.string().describe('The session ID of the new parent.'),
+});
+
+const name = 'Reparent Session';
+
+export const reparentSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const { sessionId, newParentSessionId } = input;
+
+    const callerSession = await getSession(context.workerId);
+    if (!callerSession) {
+      return 'Error: Could not retrieve current session information.';
+    }
+
+    const targetSession = await getSession(sessionId);
+    if (!targetSession) {
+      return `Error: Session ${sessionId} not found.`;
+    }
+
+    const callerIsTopLevel = !callerSession.parentSessionId;
+    const callerIsTargetParent = targetSession.parentSessionId === context.workerId;
+    const callerIsTarget = context.workerId === sessionId;
+
+    if (!callerIsTopLevel && !callerIsTargetParent && !callerIsTarget) {
+      return "Permission denied: only the target's current parent, the target itself, or a top-level session can reparent.";
+    }
+
+    if (sessionId === newParentSessionId) {
+      return 'Error: Cannot set a session as its own parent.';
+    }
+
+    const newParent = await getSession(newParentSessionId);
+    if (!newParent) {
+      return `Error: New parent session ${newParentSessionId} not found.`;
+    }
+
+    const oldParentId = targetSession.parentSessionId ?? '(top-level)';
+
+    try {
+      await reparentSessions(newParentSessionId, [sessionId]);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return `Error: Reparent failed — ${message}`;
+    }
+
+    return (
+      `Successfully reparented session ${sessionId} under ${newParentSessionId}.\n` +
+      `- Previous parent: ${oldParentId}\n` +
+      `- New parent: ${newParentSessionId}\n` +
+      `Note: The webapp sidebar will reflect the change on next page load or realtime update.`
+    );
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Move a session under a different parent session (reparent).
+
+This updates the session's parentSessionId in DynamoDB. The session hierarchy in both the system prompt and the webapp sidebar will reflect the change.
+
+Safety:
+- Cycle detection is enforced: you cannot create circular parent chains.
+- A session cannot be its own parent.
+
+Permission: allowed when the caller is one of:
+- The target session's current parent
+- The target session itself
+- A top-level (no parent) session
+
+Parameters:
+- sessionId: The session to move.
+- newParentSessionId: The session that will become the new parent.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};


### PR DESCRIPTION
## Summary
Adds five session-management tools to the agent-core tool registry, giving
agents first-class control over the session lifecycle and hierarchy.

## Motivation
Multi-agent workflows need to inspect and manage the session tree at runtime:
complete a finished session, list children/descendants, move a session under
a new parent, and export diagnostics for debugging. These tools expose that
capability to the model with appropriate permission checks.

## Changes
- **completeSession(sessionId)** — mark a session complete and stop its worker.
  Top-level self-completion is guarded by a confirmation prompt; child sessions
  may only complete themselves.
- **confirmCompleteSession** — confirm a guarded completeSession call (registered
  as a required tool).
- **listSessions** — list sessions by scope (`children` / `descendants` / `all`)
  with an optional status filter (`all` / `active` / `completed`) and
  parent/self/top-level permission checks.
- **reparentSession** — move a session under a new parent, with cycle detection
  and permission checks.
- **exportSessionDiagnostics** — dump session metadata and message history to
  local JSON for debugging, optionally across the descendant tree.
- Register the tools in `tools/index.ts` (confirmCompleteSession in requiredTools;
  the rest in optionalTools).

completeSession / confirmCompleteSession set `agentStatus='completed'`, emit an
`agentStatusUpdate` webapp event, and stop the worker instance.

## Testing
- `npm run build -w packages/agent-core` (tsc) — pass
- `vitest run` for the new tools — 31 passed (completeSession 9, confirmCompleteSession 5, listSessions 17)
- full agent-core suite — 299 passed
- prettier `format:check` (agent-core) — pass

## Notes
- reparentSession / listSessions / exportSessionDiagnostics build on session
  helpers already in `lib/sessions` (getChildSessions, getDescendantSessions,
  reparentSessions, getAllSessionsIncludingChildren).
- A related `confirmCreateAgent` gate is intentionally left for a follow-up PR:
  it depends on the sub-agent (`parentAgentId`) evolution of the agent-management
  tools, which is not yet upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
