### PR TITLE
fix: use camelCase tool names to comply with Bedrock API requirements

### DIFF
--- a/packages/agent-core/src/tools/complete-session/index.ts
+++ b/packages/agent-core/src/tools/complete-session/index.ts
@@ -11,7 +11,7 @@ const inputSchema = z.object({
     .describe('The session ID to complete. Defaults to the current session if not specified.'),
 });
 
-const name = 'Complete Session';
+const name = 'completeSession';
 
 export const completeSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,

--- a/packages/agent-core/src/tools/confirm-complete-session/index.ts
+++ b/packages/agent-core/src/tools/confirm-complete-session/index.ts
@@ -27,7 +27,7 @@ export const loadAndDeletePendingCompleteSession = (workerId: string): boolean =
 
 const inputSchema = z.object({});
 
-const name = 'Confirm Complete Session';
+const name = 'confirmCompleteSession';
 
 export const confirmCompleteSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,

--- a/packages/agent-core/src/tools/export-session-diagnostics/index.ts
+++ b/packages/agent-core/src/tools/export-session-diagnostics/index.ts
@@ -23,7 +23,7 @@ const inputSchema = z.object({
     .describe('Maximum number of sessions to export in tree mode. Default: 50.'),
 });
 
-const name = 'Export Session Diagnostics';
+const name = 'exportSessionDiagnostics';
 
 interface ExportResult {
   sessionId: string;

--- a/packages/agent-core/src/tools/list-sessions/index.ts
+++ b/packages/agent-core/src/tools/list-sessions/index.ts
@@ -25,7 +25,7 @@ const inputSchema = z.object({
     ),
 });
 
-const name = 'List Sessions';
+const name = 'listSessions';
 
 export const listSessionsTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,

--- a/packages/agent-core/src/tools/reparent-session/index.ts
+++ b/packages/agent-core/src/tools/reparent-session/index.ts
@@ -7,7 +7,7 @@ const inputSchema = z.object({
   newParentSessionId: z.string().describe('The session ID of the new parent.'),
 });
 
-const name = 'Reparent Session';
+const name = 'reparentSession';
 
 export const reparentSessionTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,


### PR DESCRIPTION
## Problem

New session management tools had names with spaces (e.g. `'Complete Session'`), which caused Bedrock API validation errors:

```
Value 'Complete Session' at 'toolConfig.tools.22.member.toolSpec.name' failed to satisfy constraint: 
Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

## Fix

Renamed affected tools to use camelCase:
- `'Complete Session'` → `'completeSession'`
- `'Confirm Complete Session'` → `'confirmCompleteSession'`
- `'Export Session Diagnostics'` → `'exportSessionDiagnostics'`
- `'List Sessions'` → `'listSessions'`
- `'Reparent Session'` → `'reparentSession'`