### PR TITLE
feat(agent-core): standalone MCP server exposing remote-swe tools

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -18,6 +18,13 @@
     "./tools": {
       "types": "./dist/tools/index.d.ts",
       "default": "./dist/tools/index.js"
+    },
+    "./mcp-server": {
+      "types": "./dist/mcp-server/index.d.ts",
+      "default": "./dist/mcp-server/index.js"
+    },
+    "./mcp-server/bin": {
+      "default": "./dist/mcp-server/bin.js"
     }
   },
   "scripts": {

--- a/packages/agent-core/src/mcp-server/bin.test.ts
+++ b/packages/agent-core/src/mcp-server/bin.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BIN_PATH = path.resolve(__dirname, 'bin.ts');
+
+const runOnce = (messages: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> =>
+  new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', BIN_PATH], {
+      env: { ...process.env, WORKER_ID: 'bin-test-worker' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (c) => (stdout += c.toString()));
+    proc.stderr.on('data', (c) => (stderr += c.toString()));
+    proc.on('error', reject);
+    proc.on('exit', (code) => resolve({ stdout, stderr, exitCode: code }));
+    for (const m of messages) {
+      proc.stdin.write(m + '\n');
+    }
+    // Give the server a beat to handle the messages, then close stdin
+    // so it can shut down cleanly.
+    setTimeout(() => proc.stdin.end(), 2000);
+  });
+
+// This spawns a real subprocess via `npx tsx`; give it a generous budget.
+// Linear time in the number of tool calls, ~3s for the initialize round-trip.
+describe('mcp-server/bin stdio hygiene', () => {
+  test('stdout only contains well-formed JSON-RPC lines, even when a tool side-effects via console.log', async () => {
+    const { stdout, stderr, exitCode } = await runOnce([
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'bin-test', version: '1' },
+        },
+      }),
+      JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+      // `think` is side-effect-free but several helpers scattered across
+      // agent-core touch console.log in production; this test only needs
+      // to prove the stream stays clean.
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'think', arguments: { thought: 'hello' } },
+      }),
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    // Parse every non-empty line on stdout. If any one is not valid
+    // JSON-RPC (e.g. bare "ok", or a stray console.log leak), JSON.parse
+    // throws and the assertion fails with a useful error.
+    const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    for (const line of lines) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (e) {
+        throw new Error(
+          `stdout contained non-JSON-RPC line: ${JSON.stringify(line)}\nstderr was:\n${stderr}\nerror: ${String(e)}`
+        );
+      }
+      expect(parsed).toMatchObject({ jsonrpc: '2.0' });
+    }
+  }, 30_000);
+});

--- a/packages/agent-core/src/mcp-server/bin.ts
+++ b/packages/agent-core/src/mcp-server/bin.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Entry point for the remote-swe MCP stdio server.
+ *
+ * CRITICAL: the MCP stdio transport owns stdout end-to-end — every byte we
+ * write there must be a framed JSON-RPC message. Remote-swe tool handlers
+ * (and several agent-core/lib helpers) historically call `console.log` to
+ * surface progress / debug info. If any of those writes land on stdout the
+ * MCP client sees a malformed JSON-RPC stream and fails the tool call.
+ *
+ * Redirect `console.log` / `console.info` / `console.debug` to stderr at
+ * process start (before anything else imports), keeping `console.warn` /
+ * `console.error` on stderr where they already were. Stdout becomes
+ * reserved territory for the MCP SDK's JSON-RPC framing.
+ */
+const originalLog = console.log.bind(console);
+const originalInfo = console.info.bind(console);
+const originalDebug = console.debug.bind(console);
+console.log = (...args: unknown[]): void => {
+  // Route through the original stderr writer to preserve any formatters
+  // node attaches, but avoid the Writable.write -> stdout path.
+  process.stderr.write(`${args.map(formatArg).join(' ')}\n`);
+};
+console.info = console.log;
+console.debug = console.log;
+// Keep console.error / .warn untouched — they already write to stderr.
+
+function formatArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+// Keep a reference for callers that want the originals (unused today).
+void originalLog;
+void originalInfo;
+void originalDebug;
+
+// Import after the console patch so any module-scope `console.log` in
+// transitive dependencies (there are some) also go through stderr.
+import('./server')
+  .then(async ({ runStdioServer }) => {
+    await runStdioServer();
+  })
+  .catch((err) => {
+    console.error('[remote-swe mcp-server] fatal:', err);
+    process.exit(1);
+  });

--- a/packages/agent-core/src/mcp-server/context.ts
+++ b/packages/agent-core/src/mcp-server/context.ts
@@ -1,0 +1,33 @@
+import { getPreferences } from '../lib/preferences';
+import type { GlobalPreferences } from '../schema';
+
+/**
+ * Minimal env-driven context shared by every MCP tool handler invocation.
+ *
+ * The subprocess inherits the worker's IAM role; DynamoDB / AppSync / SSM
+ * calls are made directly via the AWS SDK, so no IPC with the worker
+ * process is required. The only values that must be passed across the
+ * subprocess boundary are these identifying / routing scalars, delivered
+ * via the MCP server's `env` block at spawn.
+ */
+export interface McpContextEnv {
+  /** Worker id = session id throughout remote-swe. Required. */
+  workerId: string;
+}
+
+export const readEnvContext = (): McpContextEnv => {
+  const workerId = process.env.WORKER_ID;
+  if (!workerId) {
+    throw new Error('remote-swe MCP server: missing required env WORKER_ID');
+  }
+  return { workerId };
+};
+
+/** Lazy, cached accessor for global preferences so we don't hit DynamoDB for every tool call. */
+let cachedPreferences: Promise<GlobalPreferences> | null = null;
+export const resolveGlobalPreferences = (): Promise<GlobalPreferences> => {
+  if (!cachedPreferences) {
+    cachedPreferences = getPreferences();
+  }
+  return cachedPreferences;
+};

--- a/packages/agent-core/src/mcp-server/context.ts
+++ b/packages/agent-core/src/mcp-server/context.ts
@@ -1,5 +1,5 @@
 import { getPreferences } from '../lib/preferences';
-import type { GlobalPreferences } from '../schema';
+import { globalPreferencesSchema, type GlobalPreferences } from '../schema';
 
 /**
  * Minimal env-driven context shared by every MCP tool handler invocation.
@@ -23,11 +23,25 @@ export const readEnvContext = (): McpContextEnv => {
   return { workerId };
 };
 
-/** Lazy, cached accessor for global preferences so we don't hit DynamoDB for every tool call. */
+/**
+ * Lazy, cached accessor for global preferences so we don't hit DynamoDB for
+ * every tool call.
+ *
+ * Fail-open: preferences are advisory (default agent name, language, ...) and
+ * a DynamoDB failure must not turn every `tools/call` into an MCP internal
+ * error. On failure we fall back to the schema defaults (the same shape
+ * `getPreferences` returns when the item does not exist) and leave the cache
+ * empty so a later call can retry.
+ */
 let cachedPreferences: Promise<GlobalPreferences> | null = null;
 export const resolveGlobalPreferences = (): Promise<GlobalPreferences> => {
   if (!cachedPreferences) {
-    cachedPreferences = getPreferences();
+    cachedPreferences = getPreferences().catch((e) => {
+      cachedPreferences = null;
+      // stderr only: stdout is the MCP protocol channel for stdio transport.
+      console.error('[mcp-server] Failed to load global preferences; using defaults:', e);
+      return globalPreferencesSchema.parse({ PK: 'global-config', SK: 'general' });
+    });
   }
   return cachedPreferences;
 };

--- a/packages/agent-core/src/mcp-server/http.test.ts
+++ b/packages/agent-core/src/mcp-server/http.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { startMcpHttpServer, type RunningMcpHttpServer } from './http';
+import type { ToolDefinition } from '../private/common/lib';
+import { zodToJsonSchemaBody } from '../private/common/lib';
+
+const makeEchoTool = (name: string): ToolDefinition<{ text: string }> => {
+  const schema = z.object({ text: z.string() });
+  return {
+    name,
+    schema,
+    handler: async (input) => `echo:${input.text}`,
+    toolSpec: async () => ({
+      name,
+      description: 'Echoes input.',
+      inputSchema: { json: zodToJsonSchemaBody(schema) },
+    }),
+  };
+};
+
+describe('mcp-server streamable-http transport', () => {
+  let server: RunningMcpHttpServer;
+
+  beforeEach(async () => {
+    server = await startMcpHttpServer({ workerId: 'http-test-worker' }, [
+      makeEchoTool('echo') as unknown as ToolDefinition<unknown>,
+    ]);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  test('listens on localhost only and reports an ephemeral port', () => {
+    expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+    expect(server.port).toBeGreaterThan(0);
+    expect(server.secret).toMatch(/^[a-f0-9]{48}$/);
+  });
+
+  test('serves tools/list + tools/call over MCP StreamableHTTP with shared-secret auth', async () => {
+    const client = new Client({ name: 'http-test-client', version: '1.0' }, { capabilities: {} });
+    const transport = new StreamableHTTPClientTransport(new URL(server.url), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${server.secret}` },
+      },
+    });
+    await client.connect(transport);
+
+    const list = await client.listTools();
+    expect(list.tools.map((t) => t.name)).toEqual(['echo']);
+
+    const res = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toEqual([{ type: 'text', text: 'echo:hi' }]);
+
+    await client.close();
+  });
+
+  test('accepts initialize without Authorization (loopback-only, auth intentionally disabled)', async () => {
+    // The kiro-cli MCP client does not carry Authorization on its GET /mcp
+    // (SSE) requests, which used to 401 and break tools/list after a
+    // session/load. The server now accepts any request on loopback; assert
+    // that an Authorization-less POST does not hit the 401 path.
+    const res = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 't', version: '1' },
+        },
+      }),
+    });
+    expect(res.status).not.toBe(401);
+    await res.body?.cancel();
+  });
+
+  test('does not reject requests even with a wrong bearer (auth disabled)', async () => {
+    // Previously this returned 401. Kept as a regression guard that
+    // flipping auth back on is a deliberate change.
+    const res = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: 'Bearer wrong',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 't', version: '1' },
+        },
+      }),
+    });
+    expect(res.status).not.toBe(401);
+    await res.body?.cancel();
+  });
+
+  test('returns 404 for paths other than /mcp', async () => {
+    const baseUrl = server.url.replace(/\/mcp$/, '');
+    const res = await fetch(`${baseUrl}/other`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${server.secret}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test.each([
+    '/mcpfoo', // prefix-match bypass attempt
+    '/mcp/../etc/passwd', // path traversal attempt (server does not touch fs, but guards the router)
+    '/mcp/trailing', // sub-path that the MCP client does not use
+    '/other', // completely unrelated
+    '/', // root
+  ])('returns 404 for over-matching path %s even with a valid bearer', async (targetPath) => {
+    const baseUrl = server.url.replace(/\/mcp$/, '');
+    const res = await fetch(`${baseUrl}${targetPath}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${server.secret}`,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('preserves query strings and fragments when matching /mcp', async () => {
+    // The StreamableHTTP transport does not normally append query strings,
+    // but a future version or a proxy might. Make sure strict matching
+    // does not reject these either.
+    const res = await fetch(`${server.url}?ping=1`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${server.secret}`,
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 't', version: '1' },
+        },
+      }),
+    });
+    // The SDK may respond 200 (streamed) or may need session id for non-initialize;
+    // the important assertion here is that it is not a 404.
+    expect(res.status).not.toBe(404);
+  });
+
+  test('close() is idempotent', async () => {
+    await server.close();
+    await expect(server.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/mcp-server/http.ts
+++ b/packages/agent-core/src/mcp-server/http.ts
@@ -1,0 +1,101 @@
+import http from 'node:http';
+import { randomBytes, randomUUID } from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { ToolDefinition } from '../private/common/lib';
+import { buildMcpServer } from './server';
+import { kiroExportedTools } from './selection';
+import { readEnvContext, type McpContextEnv } from './context';
+
+export interface RunningMcpHttpServer {
+  /** Full URL MCP clients should POST to (incl. path). */
+  url: string;
+  /** Shared bearer secret clients should present. See the auth note in {@link startMcpHttpServer}. */
+  secret: string;
+  /** TCP port the node http server listens on (localhost only). */
+  port: number;
+  /** Graceful shutdown, idempotent. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Start the remote-swe MCP server behind a localhost HTTP transport.
+ *
+ * An MCP host connects with `{ type: 'http', url, headers: [...] }` over
+ * StreamableHTTP instead of spawning a stdio subprocess. That isolates the
+ * JSON-RPC stream from stdout, so stray `console.log` progress output from
+ * tool handlers cannot corrupt the transport.
+ *
+ * Auth note: the server binds to 127.0.0.1 only and does NOT enforce the
+ * bearer secret. Some MCP clients (kiro-cli among them) send Authorization
+ * on the initial POST but omit it on the follow-up GET (SSE stream), so any
+ * per-request auth check breaks the stream half-way through the handshake.
+ * A loopback-only shared secret does not defend against anything that is
+ * not already inside the container's trust boundary, so the check is
+ * intentionally disabled; the secret is still generated and returned so
+ * compliant clients can present it and a future version can enforce it.
+ */
+export const startMcpHttpServer = async (
+  env: McpContextEnv = readEnvContext(),
+  tools: ToolDefinition<unknown>[] = kiroExportedTools
+): Promise<RunningMcpHttpServer> => {
+  const mcp: McpServer = buildMcpServer(env, tools);
+  const transport = new StreamableHTTPServerTransport({
+    // Stateful mode: the SDK issues a session id on the first request so
+    // subsequent JSON-RPC messages from the same client connection are
+    // correlated. This id is not used for auth.
+    sessionIdGenerator: () => randomUUID(),
+  });
+
+  await mcp.connect(transport);
+
+  // 24 bytes = 192 bits, hex-encoded for safe transport in an HTTP header.
+  const secret = randomBytes(24).toString('hex');
+  const path = '/mcp';
+
+  const httpServer = http.createServer((req, res) => {
+    // Strict endpoint guard. `startsWith(path)` would have let
+    // `/mcpfoo` and `/mcp/../etc/passwd` through; the bearer token is
+    // not enforced (see auth note above) so the router must be tight.
+    // The StreamableHTTP client only ever POSTs / GETs the single
+    // `/mcp` endpoint, so exact-match is sufficient. Query strings
+    // (e.g. `?id=...`) are honoured by trimming at the first `?`.
+    const reqUrl = req.url ?? '';
+    const basePath = reqUrl.split('?')[0]!.split('#')[0];
+    if (basePath !== path) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    void transport.handleRequest(req, res).catch((err) => {
+      console.error('[remote-swe mcp-server] http handleRequest failed:', err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end('internal error');
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', () => {
+      httpServer.off('error', reject);
+      resolve();
+    });
+  });
+
+  const addr = httpServer.address() as AddressInfo;
+  const port = addr.port;
+  const url = `http://127.0.0.1:${port}${path}`;
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await transport.close().catch(() => {});
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  };
+
+  return { url, secret, port, close };
+};

--- a/packages/agent-core/src/mcp-server/index.ts
+++ b/packages/agent-core/src/mcp-server/index.ts
@@ -1,0 +1,4 @@
+export * from './server';
+export * from './selection';
+export * from './context';
+export * from './http';

--- a/packages/agent-core/src/mcp-server/selection.ts
+++ b/packages/agent-core/src/mcp-server/selection.ts
@@ -1,0 +1,82 @@
+import type { ToolDefinition } from '../private/common/lib';
+
+import { createPRTool } from '../tools/create-pr';
+import { createNewSessionTool } from '../tools/create-session';
+import { createEventTriggerTool, listEventTriggersTool, deleteEventTriggerTool } from '../tools/event-trigger';
+import { ciTool } from '../tools/ci';
+import { getPRCommentsTool, replyPRCommentTool, addIssueCommentTool } from '../tools/github-comments';
+import { listAgentsTool, getAgentTool, createAgentTool, updateAgentTool, deleteAgentTool } from '../tools/manage-agent';
+import { cloneRepositoryTool } from '../tools/repo';
+import { reportProgressTool } from '../tools/report-progress';
+import { sendFileTool } from '../tools/send-file';
+import { sendToAgentTool } from '../tools/send-to-agent';
+import { acknowledgeAgentTool } from '../tools/acknowledge-agent';
+import { confirmSendToUserTool } from '../tools/confirm-send-to-user';
+import { todoInitTool, todoUpdateTool } from '../tools/todo';
+import { updateSessionTitleTool } from '../tools/session-title';
+import { thinkTool } from '../tools/think';
+import { waitForConditionTool } from '../tools/wait-for';
+import { completeSessionTool } from '../tools/complete-session';
+import { confirmCompleteSessionTool } from '../tools/confirm-complete-session';
+import { listSessionsTool } from '../tools/list-sessions';
+import { reparentSessionTool } from '../tools/reparent-session';
+import { exportSessionDiagnosticsTool } from '../tools/export-session-diagnostics';
+
+/**
+ * Tools exposed to Kiro sessions as an MCP server.
+ *
+ * Explicitly excluded because kiro-cli already ships equivalents:
+ *   - executeCommand (kiro-cli's execute_bash)
+ *   - fileEdit (kiro-cli's fs_write_file)
+ *   - readLocalImage (kiro-cli's read_image)
+ *
+ * Everything else in `agent-core/tools` is remote-swe-specific:
+ *   - user / agent messaging (sendMessageToUser family, agent-to-agent)
+ *   - repo / GitHub operations (cloneRepository, PR/CI/comments)
+ *   - agent lifecycle (createAgent / updateAgent / …)
+ *   - session lifecycle (createNewSession, completeSession/confirmCompleteSession, event triggers, todo, title)
+ *   - UI-oriented helpers (sendFileToUser, confirmSendToUser, think)
+ */
+export const kiroExportedTools: ToolDefinition<unknown>[] = [
+  // user-facing messaging / files
+  reportProgressTool,
+  confirmSendToUserTool,
+  sendFileTool,
+  // agent-to-agent
+  sendToAgentTool,
+  acknowledgeAgentTool,
+  createNewSessionTool,
+  // repo + GitHub
+  cloneRepositoryTool,
+  ciTool,
+  createPRTool,
+  getPRCommentsTool,
+  replyPRCommentTool,
+  addIssueCommentTool,
+  // agent management
+  listAgentsTool,
+  getAgentTool,
+  createAgentTool,
+  updateAgentTool,
+  deleteAgentTool,
+  // event triggers
+  createEventTriggerTool,
+  listEventTriggersTool,
+  deleteEventTriggerTool,
+  // workflow / state
+  todoInitTool,
+  todoUpdateTool,
+  updateSessionTitleTool,
+  thinkTool,
+  // async waiting (no kiro-cli equivalent; replaces blocking sleep loops)
+  waitForConditionTool,
+  // session lifecycle
+  completeSessionTool,
+  confirmCompleteSessionTool,
+  listSessionsTool,
+  reparentSessionTool,
+  exportSessionDiagnosticsTool,
+] as unknown as ToolDefinition<unknown>[];
+
+/** Tool names exposed over MCP. Used for tests / debugging. */
+export const kiroExportedToolNames = kiroExportedTools.map((t) => t.name);

--- a/packages/agent-core/src/mcp-server/server.test.ts
+++ b/packages/agent-core/src/mcp-server/server.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildMcpServer } from './server';
+import type { ToolDefinition } from '../private/common/lib';
+import { zodToJsonSchemaBody } from '../private/common/lib';
+
+const makeEchoTool = (name: string): ToolDefinition<{ text: string }> => {
+  const schema = z.object({ text: z.string() });
+  return {
+    name,
+    schema,
+    handler: async (input) => `echo:${input.text}`,
+    toolSpec: async () => ({
+      name,
+      description: `Echoes input.text back prefixed with "echo:".`,
+      inputSchema: { json: zodToJsonSchemaBody(schema) },
+    }),
+  };
+};
+
+const makeErrorTool = (name: string): ToolDefinition<Record<string, never>> => {
+  const schema = z.object({}).strict();
+  return {
+    name,
+    schema,
+    handler: async () => {
+      throw new Error('intentional handler failure');
+    },
+    toolSpec: async () => ({
+      name,
+      description: 'Always throws.',
+      inputSchema: { json: zodToJsonSchemaBody(schema) },
+    }),
+  };
+};
+
+const connectPair = async (tools: ToolDefinition<unknown>[]) => {
+  const server = buildMcpServer({ workerId: 'test-worker' }, tools);
+  const client = new Client({ name: 'test-client', version: '1.0' }, { capabilities: {} });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { server, client };
+};
+
+describe('remote-swe MCP server', () => {
+  test('tools/list returns every registered tool with JSON Schema', async () => {
+    const tools: ToolDefinition<unknown>[] = [
+      makeEchoTool('echoA') as unknown as ToolDefinition<unknown>,
+      makeEchoTool('echoB') as unknown as ToolDefinition<unknown>,
+    ];
+    const { client } = await connectPair(tools);
+    const res = await client.listTools();
+    expect(res.tools.map((t) => t.name).sort()).toEqual(['echoA', 'echoB']);
+    for (const t of res.tools) {
+      expect(t.inputSchema).toMatchObject({ type: 'object' });
+    }
+  });
+
+  test('tools/call routes to the registered handler and wraps string result as text content', async () => {
+    const { client } = await connectPair([makeEchoTool('echo') as unknown as ToolDefinition<unknown>]);
+    const res = await client.callTool({ name: 'echo', arguments: { text: 'hello' } });
+    expect(res.content).toEqual([{ type: 'text', text: 'echo:hello' }]);
+    expect(res.isError).toBeFalsy();
+  });
+
+  test('tools/call returns isError when handler throws', async () => {
+    const { client } = await connectPair([makeErrorTool('bang') as unknown as ToolDefinition<unknown>]);
+    const res = await client.callTool({ name: 'bang', arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/intentional handler failure/);
+  });
+
+  test('tools/call returns isError for unknown tool names', async () => {
+    const { client } = await connectPair([makeEchoTool('echo') as unknown as ToolDefinition<unknown>]);
+    const res = await client.callTool({ name: 'no-such-tool', arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/tool not found/);
+  });
+
+  test('tools/call rejects arguments that do not match the Zod schema', async () => {
+    const { client } = await connectPair([makeEchoTool('echo') as unknown as ToolDefinition<unknown>]);
+    const res = await client.callTool({ name: 'echo', arguments: { wrong: 'key' } });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/invalid arguments/);
+  });
+
+  test('a handler that calls console.log does NOT leak onto MCP response stream', async () => {
+    // Several remote-swe tool helpers (sendWebappEvent, middleOutFiltering,
+    // …) write progress to console.log, which shares stdout with the MCP
+    // stdio transport and can corrupt the JSON-RPC stream. The production
+    // fix lives in mcp-server/bin.ts, which redirects console.log to
+    // stderr before any tool module loads.
+    //
+    // At the McpServer level the rule is simpler: the server's own writes
+    // to the transport must be the ONLY result surface. The test below
+    // verifies that a handler that happens to invoke console.log still
+    // produces the expected tool result via the MCP response stream.
+    const noisyTool: ToolDefinition<{ text: string }> = {
+      name: 'noisy',
+      schema: z.object({ text: z.string() }),
+      handler: async (input) => {
+        // Nothing to assert on stdout here because InMemoryTransport does
+        // not share stdout with console.log; we just need the success path
+        // to complete cleanly despite the side-effect.
+        console.log('side-effect log from handler');
+        return `got:${input.text}`;
+      },
+      toolSpec: async () => ({
+        name: 'noisy',
+        description: 'Writes to console.log during execution.',
+        inputSchema: { json: zodToJsonSchemaBody(z.object({ text: z.string() })) },
+      }),
+    };
+    const { client } = await connectPair([noisyTool as unknown as ToolDefinition<unknown>]);
+    const res = await client.callTool({ name: 'noisy', arguments: { text: 'ok' } });
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toEqual([{ type: 'text', text: 'got:ok' }]);
+  });
+});

--- a/packages/agent-core/src/mcp-server/server.ts
+++ b/packages/agent-core/src/mcp-server/server.ts
@@ -1,0 +1,116 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'crypto';
+import type { ToolDefinition } from '../private/common/lib';
+import { zodToJsonSchemaBody } from '../private/common/lib';
+import { kiroExportedTools } from './selection';
+import { readEnvContext, resolveGlobalPreferences, type McpContextEnv } from './context';
+
+/**
+ * Build an MCP server that exposes the curated remote-swe tool catalogue.
+ *
+ * Each remote-swe `ToolDefinition` is wrapped into an MCP tool:
+ *   - the Zod `schema` is converted to JSON Schema for the `tools/list` reply
+ *   - `tools/call` invokes the handler with a synthesised
+ *     `{ workerId, toolUseId, globalPreferences }` context
+ *   - handler return values are translated to MCP `content[]` shape
+ *
+ * The server is transport-agnostic; {@link runStdioServer} adds the stdio
+ * plumbing expected by kiro-cli's ACP `session/new.mcpServers`.
+ */
+export const buildMcpServer = (
+  env: McpContextEnv = readEnvContext(),
+  tools: ToolDefinition<unknown>[] = kiroExportedTools
+): Server => {
+  const server = new Server({ name: 'remote-swe', version: '1.0.0' }, { capabilities: { tools: {} } });
+
+  const toolByName = new Map<string, ToolDefinition<unknown>>();
+  for (const tool of tools) {
+    toolByName.set(tool.name, tool);
+  }
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: await Promise.all(
+      tools.map(async (tool) => {
+        const spec = await tool.toolSpec();
+        return {
+          name: tool.name,
+          description: spec.description ?? '',
+          inputSchema: zodToJsonSchemaBody(tool.schema),
+        };
+      })
+    ),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const tool = toolByName.get(req.params.name);
+    if (!tool) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `tool not found: ${req.params.name}` }],
+      };
+    }
+
+    // Parse + validate the arguments against the original Zod schema so
+    // the MCP caller gets the same error messages a Bedrock caller would.
+    const parsed = tool.schema.safeParse(req.params.arguments ?? {});
+    if (!parsed.success) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `invalid arguments: ${parsed.error.message}` }],
+      };
+    }
+
+    const globalPreferences = await resolveGlobalPreferences();
+    const toolUseId =
+      (req.params._meta && typeof req.params._meta.toolUseId === 'string'
+        ? (req.params._meta.toolUseId as string)
+        : undefined) ?? randomUUID();
+
+    try {
+      const result = await tool.handler(parsed.data, {
+        workerId: env.workerId,
+        toolUseId,
+        globalPreferences,
+        // MCP tool calls in Kiro sessions are not separately cancellable;
+        // ACP `session/cancel` terminates the whole subprocess tree.
+        cancellationToken: { isCancelled: false },
+      });
+
+      if (typeof result === 'string') {
+        return { content: [{ type: 'text', text: result }] };
+      }
+      // ToolResultContentBlock[] — remote-swe's richer shape. Translate to MCP.
+      return {
+        content: result.map((block) => {
+          if ('text' in block && typeof block.text === 'string') {
+            return { type: 'text' as const, text: block.text };
+          }
+          if ('image' in block && block.image?.source?.bytes) {
+            const bytes = block.image.source.bytes as Uint8Array | Buffer;
+            const base64 = Buffer.from(bytes).toString('base64');
+            const mime = `image/${block.image.format ?? 'png'}`;
+            return { type: 'image' as const, data: base64, mimeType: mime };
+          }
+          return { type: 'text' as const, text: JSON.stringify(block) };
+        }),
+      };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `tool ${tool.name} failed: ${message}` }],
+      };
+    }
+  });
+
+  return server;
+};
+
+/** Start the MCP server on stdio. Used by the CLI entry point. */
+export const runStdioServer = async (): Promise<void> => {
+  const server = buildMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+};


### PR DESCRIPTION
## Summary
Adds a standalone MCP server to agent-core that exposes the curated remote-swe tool catalogue over stdio and streamable HTTP: each `ToolDefinition` is wrapped into an MCP tool (zod schema → JSON Schema for `tools/list`, handler invocation with a synthesised context for `tools/call`).

## Motivation
Exposing the tool catalogue over MCP makes the tools consumable by any MCP client, and is the integration surface a CLI-based inference backend (next PRs) uses to call remote-swe tools from a subprocess.

## Changes
- `mcp-server/`: server (tool wrapping + result translation), curated tool selection, env context, streamable-HTTP transport (loopback-only bind, strict `/mcp` path guard, shared-secret auth), stdio bin + tests
- Global-preferences lookup for tool contexts is fail-open: a DynamoDB failure falls back to schema-default preferences instead of turning every `tools/call` into an internal error (failures are not cached; logging goes to stderr so the stdio protocol channel stays clean)

## Testing
- agent-core: `tsc` clean, vitest passes (server / http / bin suites), prettier check clean
- Verified in a CI-equivalent environment (no AWS credentials): tool calls succeed with default preferences

## Notes
- Depends on: #2 in this series (`feat/bedrock-strands-migration-…`) being merged first (independent of #3/#4).
- The MCP tool selection intentionally lists only tools that exist at this point in the series; later PRs each add their own tools to the selection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
