### PR TITLE
feat: custom agent sub-agents, partial update, and detail page

### DIFF
--- a/packages/agent-core/src/lib/custom-agent.test.ts
+++ b/packages/agent-core/src/lib/custom-agent.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('./aws', () => ({
+  ddb: { send: (...args: any[]) => mockSend(...args) },
+  TableName: 'TestTable',
+}));
+
+import { updateCustomAgent } from './custom-agent';
+
+describe('updateCustomAgent (partial update)', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockSend.mockResolvedValue({
+      Attributes: {
+        PK: 'custom-agent',
+        SK: 'agent-1',
+        name: 'Existing Name',
+        description: 'Existing Description',
+        defaultModel: 'sonnet4.6',
+        systemPrompt: 'Existing system prompt',
+        tools: ['existingTool'],
+        useAllTools: false,
+        mcpConfig: '{"mcpServers":{}}',
+        runtimeType: 'agent-core',
+        includeDefaultKnowledge: true,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    });
+  });
+
+  test('updates only provided fields and always sets updatedAt', async () => {
+    // GIVEN
+    const updates = { description: 'New description' };
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const command = mockSend.mock.calls[0][0];
+    const input = command.input;
+
+    expect(input.TableName).toBe('TestTable');
+    expect(input.Key).toEqual({ PK: 'custom-agent', SK: 'agent-1' });
+
+    // Only description and updatedAt should be in UpdateExpression
+    expect(input.UpdateExpression).toContain('#description = :description');
+    expect(input.UpdateExpression).toContain('#updatedAt = :updatedAt');
+    expect(input.UpdateExpression).not.toContain('#name');
+    expect(input.UpdateExpression).not.toContain('#systemPrompt');
+    expect(input.UpdateExpression).not.toContain('#tools');
+    expect(input.UpdateExpression).not.toContain('#mcpConfig');
+
+    expect(input.ExpressionAttributeValues[':description']).toBe('New description');
+    expect(typeof input.ExpressionAttributeValues[':updatedAt']).toBe('number');
+  });
+
+  test('skips undefined fields in the updates object', async () => {
+    // GIVEN
+    const updates = {
+      name: 'New Name',
+      description: undefined,
+      tools: undefined,
+    } as const;
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#name = :name');
+    expect(input.UpdateExpression).not.toContain('#description');
+    expect(input.UpdateExpression).not.toContain('#tools');
+    expect(input.ExpressionAttributeValues[':name']).toBe('New Name');
+    expect(input.ExpressionAttributeValues[':description']).toBeUndefined();
+  });
+
+  test('allows explicit empty array to overwrite tools', async () => {
+    // GIVEN
+    const updates = { tools: [] };
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#tools = :tools');
+    expect(input.ExpressionAttributeValues[':tools']).toEqual([]);
+  });
+
+  test('allows explicit empty string to overwrite description', async () => {
+    // GIVEN
+    const updates = { description: '' };
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#description = :description');
+    expect(input.ExpressionAttributeValues[':description']).toBe('');
+  });
+
+  test('does not validate mcpConfig when it is not provided', async () => {
+    // GIVEN
+    const updates = { name: 'Just a name change' };
+
+    // WHEN / THEN - no throw even though no mcpConfig
+    await expect(updateCustomAgent('agent-1', updates)).resolves.toBeDefined();
+  });
+
+  test('validates mcpConfig when explicitly provided', async () => {
+    // GIVEN
+    const updates = { mcpConfig: 'not valid json' };
+
+    // WHEN / THEN
+    await expect(updateCustomAgent('agent-1', updates)).rejects.toThrow(/Invalid mcpConfig/);
+  });
+
+  test('does not send the update to DynamoDB when mcpConfig validation fails', async () => {
+    // GIVEN
+    const updates = { mcpConfig: 'not valid json' };
+
+    // WHEN
+    await expect(updateCustomAgent('agent-1', updates)).rejects.toThrow();
+
+    // THEN
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('rejects empty string for mcpConfig (regression: previously silently defaulted)', async () => {
+    // GIVEN
+    const updates = { mcpConfig: '' };
+
+    // WHEN / THEN
+    await expect(updateCustomAgent('agent-1', updates)).rejects.toThrow(/Invalid mcpConfig/);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('updates runtimeType only', async () => {
+    // WHEN
+    await updateCustomAgent('agent-1', { runtimeType: 'ec2' });
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#runtimeType = :runtimeType');
+    expect(input.UpdateExpression).not.toContain('#name');
+    expect(input.ExpressionAttributeValues[':runtimeType']).toBe('ec2');
+  });
+
+  test('allows explicit useAllTools: false to overwrite a true value', async () => {
+    // WHEN
+    await updateCustomAgent('agent-1', { useAllTools: false });
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#useAllTools = :useAllTools');
+    expect(input.ExpressionAttributeValues[':useAllTools']).toBe(false);
+  });
+
+  test('allows explicit includeDefaultKnowledge: false to overwrite a true value', async () => {
+    // WHEN
+    await updateCustomAgent('agent-1', { includeDefaultKnowledge: false });
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#includeDefaultKnowledge = :includeDefaultKnowledge');
+    expect(input.ExpressionAttributeValues[':includeDefaultKnowledge']).toBe(false);
+  });
+
+  test('accepts valid mcpConfig and includes it in update', async () => {
+    // GIVEN
+    const updates = { mcpConfig: JSON.stringify({ mcpServers: {} }) };
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('#mcpConfig = :mcpConfig');
+    expect(input.ExpressionAttributeValues[':mcpConfig']).toBe('{"mcpServers":{}}');
+  });
+
+  test('empty updates object still bumps updatedAt', async () => {
+    // GIVEN
+    const updates = {};
+
+    // WHEN
+    await updateCustomAgent('agent-1', updates);
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toBe('SET #updatedAt = :updatedAt');
+    expect(typeof input.ExpressionAttributeValues[':updatedAt']).toBe('number');
+  });
+
+  test('returns the updated attributes from DynamoDB', async () => {
+    // WHEN
+    const result = await updateCustomAgent('agent-1', { description: 'x' });
+
+    // THEN
+    expect(result.SK).toBe('agent-1');
+    expect(result.name).toBe('Existing Name');
+  });
+
+  test('inferenceMode: null REMOVEs the attribute (reset to inherit)', async () => {
+    // WHEN
+    await updateCustomAgent('agent-1', { inferenceMode: null, description: 'New description' });
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('REMOVE #inferenceMode');
+    expect(input.UpdateExpression).not.toContain('#inferenceMode = :inferenceMode');
+    expect(input.ExpressionAttributeNames['#inferenceMode']).toBe('inferenceMode');
+    expect(input.ExpressionAttributeValues[':inferenceMode']).toBeUndefined();
+    // SET clause still applies for the other fields
+    expect(input.UpdateExpression).toContain('#description = :description');
+    expect(input.UpdateExpression).toContain('#updatedAt = :updatedAt');
+  });
+
+  test('inferenceMode: non-null value is SET, not removed', async () => {
+    // WHEN
+    await updateCustomAgent('agent-1', { inferenceMode: 'kiro-cli' });
+
+    // THEN
+    const input = mockSend.mock.calls[0][0].input;
+    expect(input.UpdateExpression).not.toContain('REMOVE');
+    expect(input.UpdateExpression).toContain('#inferenceMode = :inferenceMode');
+    expect(input.ExpressionAttributeValues[':inferenceMode']).toBe('kiro-cli');
+  });
+});

--- a/packages/agent-core/src/lib/custom-agent.ts
+++ b/packages/agent-core/src/lib/custom-agent.ts
@@ -2,7 +2,6 @@ import { QueryCommand, PutCommand, UpdateCommand, GetCommand, DeleteCommand } fr
 import { CustomAgent, EmptyMcpConfig, mcpConfigSchema } from '../schema';
 import { ddb, TableName } from './aws';
 import { randomBytes } from 'crypto';
-import z from 'zod';
 
 const validateMcpConfig = (mcpConfig: string): void => {
   try {
@@ -76,22 +75,47 @@ export const createCustomAgent = async (
   return customAgent;
 };
 
+/**
+ * Partially update a custom agent. Only keys whose value is not `undefined` are
+ * written; omitted or `undefined` fields keep their existing values in DynamoDB.
+ * `inferenceMode` additionally accepts an explicit `null`, which REMOVEs the
+ * attribute from the item (reset to "inherit from Preferences"). Other fields
+ * intentionally do not accept `null` so required attributes cannot be removed
+ * by accident.
+ *
+ * Behavior notes:
+ * - `updatedAt` is always bumped, even when `updates` is an empty object.
+ * - `mcpConfig` is validated only when explicitly provided. In particular,
+ *   passing an empty string `""` will throw (previously it was silently
+ *   replaced with the default `{"mcpServers":{}}`). Callers that want to
+ *   reset mcpConfig must pass a valid JSON string such as `{"mcpServers":{}}`.
+ * - The caller is expected to have validated the keys of `updates` (e.g. via
+ *   a zod schema); this function does not apply an allowlist of its own.
+ */
 export const updateCustomAgent = async (
   sk: string,
-  updates: Omit<CustomAgent, 'PK' | 'SK' | 'createdAt' | 'updatedAt'>
-): Promise<CustomAgent> => {
-  if (!updates.mcpConfig) {
-    updates.mcpConfig = JSON.stringify({ mcpServers: {} } satisfies z.infer<typeof mcpConfigSchema>);
+  updates: Partial<Omit<CustomAgent, 'PK' | 'SK' | 'createdAt' | 'updatedAt' | 'inferenceMode'>> & {
+    inferenceMode?: CustomAgent['inferenceMode'] | null;
   }
-  validateMcpConfig(updates.mcpConfig);
+): Promise<CustomAgent> => {
+  if (updates.mcpConfig != null) {
+    validateMcpConfig(updates.mcpConfig);
+  }
 
   const now = Date.now();
 
   const updateExpression = [];
+  const removeExpression = [];
   const expressionAttributeNames: Record<string, string> = {};
   const expressionAttributeValues: Record<string, string | number | boolean | string[]> = {};
 
   for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      removeExpression.push(`#${key}`);
+      expressionAttributeNames[`#${key}`] = key;
+      continue;
+    }
     updateExpression.push(`#${key} = :${key}`);
     expressionAttributeNames[`#${key}`] = key;
     expressionAttributeValues[`:${key}`] = value;
@@ -108,7 +132,10 @@ export const updateCustomAgent = async (
         PK: 'custom-agent',
         SK: sk,
       },
-      UpdateExpression: `SET ${updateExpression.join(', ')}`,
+      UpdateExpression: [
+        `SET ${updateExpression.join(', ')}`,
+        ...(removeExpression.length > 0 ? [`REMOVE ${removeExpression.join(', ')}`] : []),
+      ].join(' '),
       ExpressionAttributeNames: expressionAttributeNames,
       ExpressionAttributeValues: expressionAttributeValues,
       ReturnValues: 'ALL_NEW',

--- a/packages/agent-core/src/mcp-server/selection.ts
+++ b/packages/agent-core/src/mcp-server/selection.ts
@@ -18,6 +18,7 @@ import { thinkTool } from '../tools/think';
 import { waitForConditionTool } from '../tools/wait-for';
 import { completeSessionTool } from '../tools/complete-session';
 import { confirmCompleteSessionTool } from '../tools/confirm-complete-session';
+import { confirmCreateAgentTool } from '../tools/confirm-create-agent';
 import { listSessionsTool } from '../tools/list-sessions';
 import { reparentSessionTool } from '../tools/reparent-session';
 import { exportSessionDiagnosticsTool } from '../tools/export-session-diagnostics';
@@ -73,6 +74,7 @@ export const kiroExportedTools: ToolDefinition<unknown>[] = [
   // session lifecycle
   completeSessionTool,
   confirmCompleteSessionTool,
+  confirmCreateAgentTool,
   listSessionsTool,
   reparentSessionTool,
   exportSessionDiagnosticsTool,

--- a/packages/agent-core/src/schema/agent.ts
+++ b/packages/agent-core/src/schema/agent.ts
@@ -37,6 +37,7 @@ export const customAgentSchema = z.object({
   kiroModel: z.string().optional(),
   bedrockDefaultModel: modelTypeSchema.optional(),
   kiroDefaultModel: kiroModelSchema.optional(),
+  parentAgentId: z.string().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/agent-core/src/tools/confirm-create-agent/index.test.ts
+++ b/packages/agent-core/src/tools/confirm-create-agent/index.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+
+const mockCreateCustomAgent = vi.fn();
+
+vi.mock('../../lib/custom-agent', () => ({
+  createCustomAgent: (...args: any[]) => mockCreateCustomAgent(...args),
+}));
+
+import { confirmCreateAgentTool, savePendingCreateAgent, PendingAgentData } from './index';
+
+const mockContext = {
+  workerId: 'test-worker-create-agent-123',
+  toolUseId: 'test-tool-use',
+  globalPreferences: { PK: 'global-config', SK: 'general' },
+};
+
+const sampleAgentData: PendingAgentData = {
+  name: 'Test Agent',
+  description: 'A test agent',
+  defaultModel: 'sonnet4.6',
+  bedrockDefaultModel: 'sonnet4.6',
+  systemPrompt: 'You are a test agent.',
+  tools: ['commandExecution'],
+  useAllTools: false,
+  mcpConfig: '{"mcpServers":{}}',
+  runtimeType: 'agent-core',
+  includeDefaultKnowledge: true,
+};
+
+describe('confirmCreateAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-21T09:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    try {
+      unlinkSync(join(tmpdir(), `.pending-create-agent-${mockContext.workerId}`));
+    } catch {}
+  });
+
+  test('creates agent when pending data exists', async () => {
+    savePendingCreateAgent(mockContext.workerId, sampleAgentData);
+    mockCreateCustomAgent.mockResolvedValue({
+      SK: 'new-agent-id',
+      name: 'Test Agent',
+    });
+
+    const result = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledWith(sampleAgentData);
+    expect(result).toContain('Agent created successfully');
+    expect(result).toContain('new-agent-id');
+    expect(result).toContain('Test Agent');
+  });
+
+  test('returns error when no pending createAgent exists', async () => {
+    const result = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).not.toHaveBeenCalled();
+    expect(result).toContain('No pending createAgent');
+  });
+
+  test('pending data is consumed (cannot confirm twice)', async () => {
+    savePendingCreateAgent(mockContext.workerId, sampleAgentData);
+    mockCreateCustomAgent.mockResolvedValue({
+      SK: 'new-agent-id',
+      name: 'Test Agent',
+    });
+
+    await confirmCreateAgentTool.handler({}, mockContext as any);
+    const secondResult = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledTimes(1);
+    expect(secondResult).toContain('No pending createAgent');
+  });
+
+  test('last createAgent call wins when called multiple times before confirm', async () => {
+    const firstData = { ...sampleAgentData, name: 'First Agent' };
+    const secondData = { ...sampleAgentData, name: 'Second Agent' };
+
+    savePendingCreateAgent(mockContext.workerId, firstData);
+    savePendingCreateAgent(mockContext.workerId, secondData);
+
+    mockCreateCustomAgent.mockResolvedValue({
+      SK: 'second-id',
+      name: 'Second Agent',
+    });
+
+    const result = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledWith(secondData);
+    expect(result).toContain('Second Agent');
+  });
+
+  test('last-wins: first pending is overwritten and not recoverable', async () => {
+    const firstData = { ...sampleAgentData, name: 'First Agent' };
+    const secondData = { ...sampleAgentData, name: 'Second Agent' };
+
+    savePendingCreateAgent(mockContext.workerId, firstData);
+    savePendingCreateAgent(mockContext.workerId, secondData);
+
+    mockCreateCustomAgent.mockResolvedValue({
+      SK: 'second-id',
+      name: 'Second Agent',
+    });
+
+    await confirmCreateAgentTool.handler({}, mockContext as any);
+    const secondConfirm = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledTimes(1);
+    expect(secondConfirm).toContain('No pending createAgent');
+  });
+
+  test('rejects expired pending (TTL 30 minutes)', async () => {
+    savePendingCreateAgent(mockContext.workerId, sampleAgentData);
+
+    vi.advanceTimersByTime(31 * 60 * 1000);
+
+    const result = await confirmCreateAgentTool.handler({}, mockContext as any);
+
+    expect(mockCreateCustomAgent).not.toHaveBeenCalled();
+    expect(result).toContain('expired');
+    expect(result).toContain('30 minutes');
+  });
+});

--- a/packages/agent-core/src/tools/confirm-create-agent/index.ts
+++ b/packages/agent-core/src/tools/confirm-create-agent/index.ts
@@ -1,0 +1,67 @@
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { writeFileSync, readFileSync, unlinkSync } from 'fs';
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { createCustomAgent } from '../../lib/custom-agent';
+import { CustomAgent } from '../../schema';
+
+const PENDING_DIR = tmpdir();
+const PENDING_TTL_MS = 30 * 60 * 1000;
+
+const pendingFilePath = (workerId: string) => join(PENDING_DIR, `.pending-create-agent-${workerId}`);
+
+export type PendingAgentData = Omit<CustomAgent, 'PK' | 'SK' | 'createdAt' | 'updatedAt'>;
+
+interface PendingFile {
+  timestamp: number;
+  data: PendingAgentData;
+}
+
+export const savePendingCreateAgent = (workerId: string, data: PendingAgentData) => {
+  const payload: PendingFile = { timestamp: Date.now(), data };
+  writeFileSync(pendingFilePath(workerId), JSON.stringify(payload), 'utf-8');
+};
+
+export const loadAndDeletePendingCreateAgent = (workerId: string): PendingFile | undefined => {
+  const filePath = pendingFilePath(workerId);
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    unlinkSync(filePath);
+    return JSON.parse(raw) as PendingFile;
+  } catch {
+    return undefined;
+  }
+};
+
+const inputSchema = z.object({});
+
+const name = 'confirmCreateAgent';
+
+export const confirmCreateAgentTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (_input: z.infer<typeof inputSchema>, context) => {
+    const pending = loadAndDeletePendingCreateAgent(context.workerId);
+
+    if (!pending) {
+      return 'No pending createAgent to confirm. Call createAgent first.';
+    }
+
+    const elapsed = Date.now() - pending.timestamp;
+    if (elapsed > PENDING_TTL_MS) {
+      return `The pending createAgent request has expired (requested ${Math.round(elapsed / 60000)} minutes ago, TTL is 30 minutes). Please call createAgent again to start a new request.`;
+    }
+
+    const agent = await createCustomAgent(pending.data);
+
+    return `Agent created successfully.\n- ID: ${agent.SK}\n- Name: ${agent.name}`;
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Confirm and execute a blocked createAgent call. Call this after createAgent returns a confirmation prompt for top-level agent creation. Only call this if the user explicitly approved creating the new top-level agent. If the user did NOT approve, do NOT call this tool.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -19,6 +19,7 @@ export * from './todo';
 export * from './session-title';
 export * from './complete-session';
 export * from './confirm-complete-session';
+export * from './confirm-create-agent';
 export * from './list-sessions';
 export * from './reparent-session';
 export * from './export-session-diagnostics';
@@ -45,6 +46,7 @@ import { updateSessionTitleTool } from './session-title';
 import { waitForConditionTool } from './wait-for';
 import { completeSessionTool } from './complete-session';
 import { confirmCompleteSessionTool } from './confirm-complete-session';
+import { confirmCreateAgentTool } from './confirm-create-agent';
 import { listSessionsTool } from './list-sessions';
 import { reparentSessionTool } from './reparent-session';
 import { exportSessionDiagnosticsTool } from './export-session-diagnostics';
@@ -86,6 +88,7 @@ export const requiredTools = [
   updateSessionTitleTool,
   confirmSendToUserTool,
   confirmCompleteSessionTool,
+  confirmCreateAgentTool,
 ];
 
 /**

--- a/packages/agent-core/src/tools/manage-agent/index.test.ts
+++ b/packages/agent-core/src/tools/manage-agent/index.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockGetCustomAgent = vi.fn();
+const mockUpdateCustomAgent = vi.fn();
+const mockCreateCustomAgent = vi.fn();
+const mockDeleteCustomAgent = vi.fn();
+const mockGetCustomAgents = vi.fn();
+const mockSavePendingCreateAgent = vi.fn();
+
+vi.mock('../../lib/custom-agent', () => ({
+  getCustomAgent: (...args: any[]) => mockGetCustomAgent(...args),
+  getCustomAgents: (...args: any[]) => mockGetCustomAgents(...args),
+  createCustomAgent: (...args: any[]) => mockCreateCustomAgent(...args),
+  updateCustomAgent: (...args: any[]) => mockUpdateCustomAgent(...args),
+  deleteCustomAgent: (...args: any[]) => mockDeleteCustomAgent(...args),
+}));
+
+vi.mock('../confirm-create-agent', () => ({
+  savePendingCreateAgent: (...args: any[]) => mockSavePendingCreateAgent(...args),
+}));
+
+import { createAgentTool, updateAgentTool } from './index';
+import type { GlobalPreferences } from '../../schema';
+
+const existingAgent = {
+  PK: 'custom-agent',
+  SK: 'agent-1',
+  name: 'Original',
+  description: 'Original description',
+  defaultModel: 'sonnet4.6',
+  systemPrompt: 'Original prompt',
+  tools: ['toolA'],
+  useAllTools: false,
+  mcpConfig: '{"mcpServers":{}}',
+  runtimeType: 'agent-core',
+  includeDefaultKnowledge: true,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+const context = {
+  workerId: 'worker-1',
+  toolUseId: 'tool-use-1',
+  globalPreferences: {} as GlobalPreferences,
+};
+
+describe('updateAgentTool (partial update handler)', () => {
+  beforeEach(() => {
+    mockGetCustomAgent.mockReset();
+    mockUpdateCustomAgent.mockReset();
+    mockGetCustomAgent.mockResolvedValue(existingAgent);
+    mockUpdateCustomAgent.mockImplementation(async (_sk: string, updates: any) => ({
+      ...existingAgent,
+      ...updates,
+    }));
+  });
+
+  test('passes only explicitly provided fields to updateCustomAgent', async () => {
+    // WHEN
+    await updateAgentTool.handler({ agentId: 'agent-1', description: 'Changed' } as any, context);
+
+    // THEN
+    expect(mockUpdateCustomAgent).toHaveBeenCalledTimes(1);
+    const [sk, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(sk).toBe('agent-1');
+    expect(data).toEqual({ description: 'Changed' });
+    // Ensure agentId is stripped and no defaults were injected
+    expect(data).not.toHaveProperty('agentId');
+    expect(data).not.toHaveProperty('name');
+    expect(data).not.toHaveProperty('mcpConfig');
+    expect(data).not.toHaveProperty('tools');
+    expect(data).not.toHaveProperty('useAllTools');
+    expect(data).not.toHaveProperty('includeDefaultKnowledge');
+  });
+
+  test('forwards undefined fields verbatim (lib layer is responsible for skipping them)', async () => {
+    // WHEN
+    await updateAgentTool.handler(
+      {
+        agentId: 'agent-1',
+        name: 'New Name',
+        description: undefined,
+        tools: undefined,
+        useAllTools: undefined,
+        mcpConfig: undefined,
+        includeDefaultKnowledge: undefined,
+      } as any,
+      context
+    );
+
+    // THEN
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    // agentId must be stripped; the rest of the payload is passed through as-is.
+    // The lib layer (updateCustomAgent) is responsible for skipping undefined keys.
+    expect(data).not.toHaveProperty('agentId');
+    expect(data.name).toBe('New Name');
+    expect(data.description).toBeUndefined();
+    expect(data.tools).toBeUndefined();
+  });
+
+  test('allows clearing tools by passing an empty array explicitly', async () => {
+    // WHEN
+    await updateAgentTool.handler({ agentId: 'agent-1', tools: [] } as any, context);
+
+    // THEN
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).toEqual({ tools: [] });
+  });
+
+  test('returns not-found message when agent does not exist', async () => {
+    // GIVEN
+    mockGetCustomAgent.mockResolvedValueOnce(undefined);
+
+    // WHEN
+    const result = await updateAgentTool.handler({ agentId: 'missing' } as any, context);
+
+    // THEN
+    expect(result).toContain('not found');
+    expect(mockUpdateCustomAgent).not.toHaveBeenCalled();
+  });
+
+  test('passes multiple fields together when provided', async () => {
+    // WHEN
+    await updateAgentTool.handler(
+      {
+        agentId: 'agent-1',
+        name: 'Renamed',
+        systemPrompt: 'New prompt',
+        useAllTools: true,
+      } as any,
+      context
+    );
+
+    // THEN
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).toEqual({
+      name: 'Renamed',
+      systemPrompt: 'New prompt',
+      useAllTools: true,
+    });
+  });
+
+  test('forwards parentAgentId when provided', async () => {
+    // GIVEN: parent agent exists
+    mockGetCustomAgent
+      .mockResolvedValueOnce(existingAgent) // existing lookup for input.agentId
+      .mockResolvedValueOnce({ ...existingAgent, SK: 'parent-agent-sk', name: 'Parent' });
+
+    // WHEN
+    await updateAgentTool.handler({ agentId: 'agent-1', parentAgentId: 'parent-agent-sk' } as any, context);
+
+    // THEN
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).toEqual({ parentAgentId: 'parent-agent-sk' });
+  });
+
+  test('rejects self-referential parentAgentId on update', async () => {
+    // WHEN
+    const result = await updateAgentTool.handler({ agentId: 'agent-1', parentAgentId: 'agent-1' } as any, context);
+
+    // THEN
+    expect(result).toMatch(/cannot reference itself/);
+    expect(mockUpdateCustomAgent).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-existent parentAgentId on update', async () => {
+    // GIVEN: existing agent lookup returns the agent; parent lookup returns undefined
+    mockGetCustomAgent.mockReset();
+    mockGetCustomAgent.mockResolvedValueOnce(existingAgent).mockResolvedValueOnce(undefined);
+
+    // WHEN
+    const result = await updateAgentTool.handler(
+      { agentId: 'agent-1', parentAgentId: 'missing-parent' } as any,
+      context
+    );
+
+    // THEN
+    expect(result).toMatch(/does not exist/);
+    expect(result).toContain('missing-parent');
+    expect(mockUpdateCustomAgent).not.toHaveBeenCalled();
+  });
+
+  test('forwards inferenceMode when provided', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', inferenceMode: 'kiro-cli' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).toEqual({ inferenceMode: 'kiro-cli' });
+  });
+
+  test('forwards kiroModel when provided (with reverse sync to kiroDefaultModel)', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', kiroModel: 'claude-opus-4.8' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).toEqual({ kiroModel: 'claude-opus-4.8', kiroDefaultModel: 'claude-opus-4.8' });
+  });
+
+  test('does not include kiroModel when not provided (partial update)', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', name: 'Renamed' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data).not.toHaveProperty('kiroModel');
+  });
+
+  test('B-2: legacy defaultModel update triggers reverse sync to bedrockDefaultModel', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', defaultModel: 'sonnet4.6' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data.defaultModel).toBe('sonnet4.6');
+    expect(data.bedrockDefaultModel).toBe('sonnet4.6');
+  });
+
+  test('B-2: legacy kiroModel update triggers reverse sync to kiroDefaultModel', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', kiroModel: 'claude-opus-4.8' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data.kiroModel).toBe('claude-opus-4.8');
+    expect(data.kiroDefaultModel).toBe('claude-opus-4.8');
+  });
+
+  test('B-2: reverse sync does NOT fire when new field is explicitly provided', async () => {
+    await updateAgentTool.handler(
+      { agentId: 'agent-1', defaultModel: 'sonnet3.7', bedrockDefaultModel: 'opus4.8' } as any,
+      context
+    );
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    // New field takes precedence; reverse sync should not overwrite it
+    expect(data.bedrockDefaultModel).toBe('opus4.8');
+    expect(data.defaultModel).toBe('opus4.8'); // forward sync: bedrockDefaultModel -> defaultModel
+  });
+
+  test('B-2: new field update syncs forward to legacy (existing behavior preserved)', async () => {
+    await updateAgentTool.handler({ agentId: 'agent-1', bedrockDefaultModel: 'haiku4.5' } as any, context);
+
+    const [, data] = mockUpdateCustomAgent.mock.calls[0];
+    expect(data.bedrockDefaultModel).toBe('haiku4.5');
+    expect(data.defaultModel).toBe('haiku4.5');
+  });
+});
+
+describe('createAgentTool (parentAgentId validation)', () => {
+  const baseInput = {
+    name: 'New Agent',
+    description: 'desc',
+    defaultModel: 'sonnet4.6',
+    systemPrompt: 'prompt',
+    tools: [],
+    useAllTools: false,
+    mcpConfig: '{"mcpServers":{}}',
+    runtimeType: 'agent-core',
+    includeDefaultKnowledge: true,
+  };
+
+  beforeEach(() => {
+    mockGetCustomAgent.mockReset();
+    mockCreateCustomAgent.mockReset();
+    mockDeleteCustomAgent.mockReset();
+    mockSavePendingCreateAgent.mockReset();
+  });
+
+  test('triggers confirmation gate when parentAgentId is omitted (top-level creation)', async () => {
+    // WHEN
+    const result = await createAgentTool.handler(baseInput as any, context);
+
+    // THEN
+    expect(mockSavePendingCreateAgent).toHaveBeenCalledWith(
+      'worker-1',
+      expect.objectContaining({
+        name: 'New Agent',
+        description: 'desc',
+        defaultModel: 'sonnet4.6',
+        bedrockDefaultModel: 'sonnet4.6',
+        systemPrompt: 'prompt',
+        tools: [],
+        useAllTools: false,
+        mcpConfig: '{"mcpServers":{}}',
+        runtimeType: 'agent-core',
+        includeDefaultKnowledge: true,
+      })
+    );
+    expect(mockCreateCustomAgent).not.toHaveBeenCalled();
+    expect(result).toContain('CONFIRMATION REQUIRED');
+    expect(result).toContain('confirmCreateAgent');
+    expect(result).toContain('New Agent');
+  });
+
+  test('creates with parentAgentId when parent exists', async () => {
+    // GIVEN
+    mockGetCustomAgent.mockResolvedValue({ ...existingAgent, SK: 'parent-sk', name: 'Parent' });
+    mockCreateCustomAgent.mockResolvedValue({
+      ...existingAgent,
+      SK: 'new-sk',
+      name: 'New Agent',
+      parentAgentId: 'parent-sk',
+    });
+
+    // WHEN
+    const result = await createAgentTool.handler({ ...baseInput, parentAgentId: 'parent-sk' } as any, context);
+
+    // THEN
+    expect(mockGetCustomAgent).toHaveBeenCalledWith('parent-sk');
+    expect(mockCreateCustomAgent).toHaveBeenCalledTimes(1);
+    const [payload] = mockCreateCustomAgent.mock.calls[0];
+    expect(payload.parentAgentId).toBe('parent-sk');
+    expect(result).toContain('Parent Agent ID: parent-sk');
+  });
+
+  test('rejects creation when parentAgentId does not exist', async () => {
+    // GIVEN
+    mockGetCustomAgent.mockResolvedValue(undefined);
+
+    // WHEN
+    const result = await createAgentTool.handler({ ...baseInput, parentAgentId: 'missing-parent' } as any, context);
+
+    // THEN
+    expect(result).toMatch(/does not exist/);
+    expect(result).toContain('missing-parent');
+    expect(mockCreateCustomAgent).not.toHaveBeenCalled();
+  });
+
+  test('rolls back and errors when created SK accidentally matches parentAgentId', async () => {
+    // GIVEN: parent lookup succeeds, but the newly generated SK happens to collide
+    mockGetCustomAgent.mockResolvedValue({ ...existingAgent, SK: 'collision-sk', name: 'Parent' });
+    mockCreateCustomAgent.mockResolvedValue({
+      ...existingAgent,
+      SK: 'collision-sk',
+      name: 'New Agent',
+      parentAgentId: 'collision-sk',
+    });
+
+    // WHEN
+    const result = await createAgentTool.handler({ ...baseInput, parentAgentId: 'collision-sk' } as any, context);
+
+    // THEN
+    expect(result).toMatch(/cannot reference itself/);
+    expect(mockDeleteCustomAgent).toHaveBeenCalledWith('collision-sk');
+  });
+
+  test('passes inferenceMode to createCustomAgent when provided (with parentAgentId)', async () => {
+    mockGetCustomAgent.mockResolvedValue({ ...existingAgent, SK: 'parent-sk', name: 'Parent' });
+    mockCreateCustomAgent.mockResolvedValue({
+      ...existingAgent,
+      SK: 'new-sk',
+      name: 'New Agent',
+      inferenceMode: 'kiro-cli',
+      parentAgentId: 'parent-sk',
+    });
+
+    await createAgentTool.handler(
+      { ...baseInput, inferenceMode: 'kiro-cli', parentAgentId: 'parent-sk' } as any,
+      context
+    );
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledTimes(1);
+    const [payload] = mockCreateCustomAgent.mock.calls[0];
+    expect(payload.inferenceMode).toBe('kiro-cli');
+  });
+
+  test('passes kiroModel to createCustomAgent when provided (with parentAgentId)', async () => {
+    mockGetCustomAgent.mockResolvedValue({ ...existingAgent, SK: 'parent-sk', name: 'Parent' });
+    mockCreateCustomAgent.mockResolvedValue({
+      ...existingAgent,
+      SK: 'new-sk',
+      name: 'New Agent',
+      kiroModel: 'deepseek-3.2',
+      parentAgentId: 'parent-sk',
+    });
+
+    await createAgentTool.handler(
+      { ...baseInput, kiroModel: 'deepseek-3.2', parentAgentId: 'parent-sk' } as any,
+      context
+    );
+
+    expect(mockCreateCustomAgent).toHaveBeenCalledTimes(1);
+    const [payload] = mockCreateCustomAgent.mock.calls[0];
+    expect(payload.kiroModel).toBe('deepseek-3.2');
+  });
+});

--- a/packages/agent-core/src/tools/manage-agent/index.ts
+++ b/packages/agent-core/src/tools/manage-agent/index.ts
@@ -7,12 +7,19 @@ import {
   updateCustomAgent,
   deleteCustomAgent,
 } from '../../lib/custom-agent';
-import { modelTypeSchema, runtimeTypeSchema } from '../../schema';
+import { modelTypeSchema, runtimeTypeSchema, inferenceModeSchema, kiroModelSchema } from '../../schema';
+import { savePendingCreateAgent } from '../confirm-create-agent';
 
 const agentFieldsSchema = z.object({
   name: z.string().describe('The name of the agent.'),
   description: z.string().default('').describe('A description of the agent.'),
   defaultModel: modelTypeSchema.describe('The default model to use for this agent.'),
+  bedrockDefaultModel: modelTypeSchema
+    .optional()
+    .describe('The Bedrock model for this agent. Takes priority over defaultModel (legacy).'),
+  kiroDefaultModel: kiroModelSchema
+    .optional()
+    .describe("The Kiro model for this agent. Takes priority over kiroModel (legacy). Omit to use 'auto'."),
   systemPrompt: z.string().describe('The system prompt that defines the agent behavior.'),
   tools: z
     .array(z.string())
@@ -34,6 +41,20 @@ const agentFieldsSchema = z.object({
     .describe(
       'Whether to include default SWE knowledge (communication style, Git workflow, coding conventions) in the system prompt. Only relevant when a custom systemPrompt is provided. Default: true.'
     ),
+  parentAgentId: z
+    .string()
+    .optional()
+    .describe(
+      'Optional ID of the parent agent. When set, this agent is treated as a sub-agent of the specified parent and is hidden from top-level agent selection UIs. Leave unset for standalone agents.'
+    ),
+  inferenceMode: inferenceModeSchema
+    .optional()
+    .describe(
+      "Inference mode for sessions using this agent. 'kiro-cli': use Kiro CLI inference (no Bedrock cost). 'bedrock': use Bedrock direct inference. Omit to fall through to env / default."
+    ),
+  kiroModel: kiroModelSchema
+    .optional()
+    .describe("Model to use when inferenceMode is 'kiro-cli'. Omit to use the default (auto)."),
 });
 
 const listAgentsSchema = z.object({});
@@ -41,11 +62,51 @@ const getAgentSchema = z.object({
   agentId: z.string().describe('The ID (SK) of the agent to retrieve.'),
 });
 const createAgentSchema = agentFieldsSchema;
-const updateAgentSchema = z
-  .object({
-    agentId: z.string().describe('The ID (SK) of the agent to update.'),
-  })
-  .merge(agentFieldsSchema);
+const updateAgentSchema = z.object({
+  agentId: z.string().describe('The ID (SK) of the agent to update.'),
+  name: z.string().optional().describe('The name of the agent.'),
+  description: z.string().optional().describe('A description of the agent.'),
+  defaultModel: modelTypeSchema.optional().describe('The default model to use for this agent.'),
+  bedrockDefaultModel: modelTypeSchema
+    .optional()
+    .describe('The Bedrock model for this agent. Takes priority over defaultModel (legacy).'),
+  kiroDefaultModel: kiroModelSchema
+    .optional()
+    .describe("The Kiro model for this agent. Takes priority over kiroModel (legacy). Omit to use 'auto'."),
+  systemPrompt: z.string().optional().describe('The system prompt that defines the agent behavior.'),
+  tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'List of tool names the agent can use. Use the "listAgents" tool first to see available tool names from existing agents.'
+    ),
+  useAllTools: z
+    .boolean()
+    .optional()
+    .describe('Whether to use all available tools. When true, the tools array is ignored.'),
+  mcpConfig: z.string().optional().describe('MCP server configuration as JSON string.'),
+  runtimeType: runtimeTypeSchema.optional().describe('The runtime type for the agent: "ec2" or "agent-core".'),
+  includeDefaultKnowledge: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to include default SWE knowledge (communication style, Git workflow, coding conventions) in the system prompt.'
+    ),
+  parentAgentId: z
+    .string()
+    .optional()
+    .describe(
+      'Optional ID of the parent agent. When set, this agent is treated as a sub-agent of the specified parent and is hidden from top-level agent selection UIs.'
+    ),
+  inferenceMode: inferenceModeSchema
+    .optional()
+    .describe(
+      "Inference mode for sessions using this agent. 'kiro-cli': use Kiro CLI inference (no Bedrock cost). 'bedrock': use Bedrock direct inference. Omit to fall through to env / default."
+    ),
+  kiroModel: kiroModelSchema
+    .optional()
+    .describe("Model to use when inferenceMode is 'kiro-cli'. Omit to use the default (auto)."),
+});
 const deleteAgentSchema = z.object({
   agentId: z.string().describe('The ID (SK) of the agent to delete.'),
 });
@@ -61,7 +122,7 @@ const agentManagementDescription = `Manage custom agents: list, get, create, upd
 ## Tips:
 - Use "listAgents" first to discover existing agents and their IDs
 - Use "getAgent" to retrieve the full configuration before making updates
-- When updating, provide all fields (not just the changed ones) to avoid accidentally clearing settings
+- "updateAgent" supports partial updates: only fields you specify are changed; omitted fields keep their existing values
 - The tools array should contain tool name strings; check existing agents for valid tool names`;
 
 export const listAgentsTool: ToolDefinition<z.infer<typeof listAgentsSchema>> = {
@@ -76,8 +137,11 @@ export const listAgentsTool: ToolDefinition<z.infer<typeof listAgentsSchema>> = 
       name: a.name,
       description: a.description,
       defaultModel: a.defaultModel,
+      bedrockDefaultModel: a.bedrockDefaultModel,
+      kiroDefaultModel: a.kiroDefaultModel,
       runtimeType: a.runtimeType,
       tools: a.tools,
+      parentAgentId: a.parentAgentId,
       createdAt: new Date(a.createdAt).toISOString(),
       updatedAt: new Date(a.updatedAt).toISOString(),
     }));
@@ -104,11 +168,16 @@ export const getAgentTool: ToolDefinition<z.infer<typeof getAgentSchema>> = {
         name: agent.name,
         description: agent.description,
         defaultModel: agent.defaultModel,
+        bedrockDefaultModel: agent.bedrockDefaultModel,
+        kiroDefaultModel: agent.kiroDefaultModel,
         systemPrompt: agent.systemPrompt,
         tools: agent.tools,
         mcpConfig: agent.mcpConfig,
         runtimeType: agent.runtimeType,
         includeDefaultKnowledge: agent.includeDefaultKnowledge !== false,
+        inferenceMode: agent.inferenceMode,
+        kiroModel: agent.kiroModel,
+        parentAgentId: agent.parentAgentId,
         createdAt: new Date(agent.createdAt).toISOString(),
         updatedAt: new Date(agent.updatedAt).toISOString(),
       },
@@ -126,25 +195,55 @@ export const getAgentTool: ToolDefinition<z.infer<typeof getAgentSchema>> = {
 
 export const createAgentTool: ToolDefinition<z.infer<typeof createAgentSchema>> = {
   name: 'createAgent',
-  handler: async (input) => {
+  handler: async (input, context) => {
+    if (input.parentAgentId) {
+      const parent = await getCustomAgent(input.parentAgentId);
+      if (!parent) {
+        return `Error: parentAgentId '${input.parentAgentId}' does not exist.`;
+      }
+    }
     const agentData = {
       name: input.name,
       description: input.description ?? '',
-      defaultModel: input.defaultModel,
+      defaultModel: input.bedrockDefaultModel ?? input.defaultModel,
+      bedrockDefaultModel: input.bedrockDefaultModel ?? input.defaultModel,
+      kiroDefaultModel: input.kiroDefaultModel ?? input.kiroModel,
       systemPrompt: input.systemPrompt,
       tools: input.tools,
       useAllTools: input.useAllTools ?? false,
       mcpConfig: input.mcpConfig ?? '{"mcpServers":{}}',
       runtimeType: input.runtimeType,
       includeDefaultKnowledge: input.includeDefaultKnowledge ?? true,
+      parentAgentId: input.parentAgentId,
+      inferenceMode: input.inferenceMode,
+      kiroModel: input.kiroDefaultModel ?? input.kiroModel,
     };
+
+    if (!input.parentAgentId) {
+      savePendingCreateAgent(context.workerId, agentData);
+      return [
+        `CONFIRMATION REQUIRED: You are about to create a new top-level agent "${input.name}".`,
+        ``,
+        `Top-level agent creation requires explicit user approval.`,
+        `Please ask the user whether they approve creating this agent, and only call confirmCreateAgent after receiving explicit approval.`,
+        ``,
+        `To proceed: get user approval, then call confirmCreateAgent.`,
+        `To abort: simply do not call confirmCreateAgent.`,
+      ].join('\n');
+    }
+
     const agent = await createCustomAgent(agentData);
-    return `Agent created successfully.\n- ID: ${agent.SK}\n- Name: ${agent.name}`;
+    if (agent.parentAgentId && agent.parentAgentId === agent.SK) {
+      await deleteCustomAgent(agent.SK);
+      return `Error: parentAgentId cannot reference itself.`;
+    }
+    const parentLine = agent.parentAgentId ? `\n- Parent Agent ID: ${agent.parentAgentId}` : '';
+    return `Agent created successfully.\n- ID: ${agent.SK}\n- Name: ${agent.name}${parentLine}`;
   },
   schema: createAgentSchema,
   toolSpec: async () => ({
     name: 'createAgent',
-    description: `Create a new custom agent with all configuration fields.\n\n${agentManagementDescription}`,
+    description: `Create a new custom agent with all configuration fields. Top-level agent creation (parentAgentId not specified) requires user approval and a subsequent call to confirmCreateAgent.\n\n${agentManagementDescription}`,
     inputSchema: { json: zodToJsonSchemaBody(createAgentSchema) },
   }),
 };
@@ -156,24 +255,40 @@ export const updateAgentTool: ToolDefinition<z.infer<typeof updateAgentSchema>> 
     if (!existing) {
       return `Agent with ID "${input.agentId}" not found.`;
     }
-    const agentData = {
-      name: input.name,
-      description: input.description ?? '',
-      defaultModel: input.defaultModel,
-      systemPrompt: input.systemPrompt,
-      tools: input.tools,
-      useAllTools: input.useAllTools ?? false,
-      mcpConfig: input.mcpConfig ?? '{"mcpServers":{}}',
-      runtimeType: input.runtimeType,
-      includeDefaultKnowledge: input.includeDefaultKnowledge ?? true,
-    };
-    const agent = await updateCustomAgent(input.agentId, agentData);
+    if (input.parentAgentId !== undefined && input.parentAgentId !== '') {
+      if (input.parentAgentId === input.agentId) {
+        return `Error: parentAgentId cannot reference itself.`;
+      }
+      const parent = await getCustomAgent(input.parentAgentId);
+      if (!parent) {
+        return `Error: parentAgentId '${input.parentAgentId}' does not exist.`;
+      }
+    }
+    const { agentId, ...rest } = input;
+    const updates: Record<string, unknown> = { ...rest };
+    // Keep legacy `defaultModel` in sync when `bedrockDefaultModel` is updated
+    if (input.bedrockDefaultModel !== undefined) {
+      updates.defaultModel = input.bedrockDefaultModel;
+    }
+    // Keep legacy `kiroModel` in sync when `kiroDefaultModel` is updated
+    if (input.kiroDefaultModel !== undefined) {
+      updates.kiroModel = input.kiroDefaultModel;
+    }
+    // Reverse sync: when legacy fields are updated without new fields, propagate
+    // to new fields so the resolver (which prefers new fields) picks up the change.
+    if (input.defaultModel !== undefined && input.bedrockDefaultModel === undefined) {
+      updates.bedrockDefaultModel = input.defaultModel;
+    }
+    if (input.kiroModel !== undefined && input.kiroDefaultModel === undefined) {
+      updates.kiroDefaultModel = input.kiroModel;
+    }
+    const agent = await updateCustomAgent(agentId, updates);
     return `Agent updated successfully.\n- ID: ${agent.SK}\n- Name: ${agent.name}`;
   },
   schema: updateAgentSchema,
   toolSpec: async () => ({
     name: 'updateAgent',
-    description: `Update an existing agent's configuration. All fields are required to avoid accidentally clearing settings.\n\n${agentManagementDescription}`,
+    description: `Update an existing agent's configuration. Supports partial updates: only fields you specify are changed; omitted fields keep their existing values.\n\n${agentManagementDescription}`,
     inputSchema: { json: zodToJsonSchemaBody(updateAgentSchema) },
   }),
 };

--- a/packages/webapp/src/app/api/agent-icon/route.ts
+++ b/packages/webapp/src/app/api/agent-icon/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPreferences } from '@remote-swe-agents/agent-core/lib';
-import { getBytesFromKey } from '@remote-swe-agents/agent-core/aws';
+import { getBytesFromKey, getHeadFromKey } from '@remote-swe-agents/agent-core/aws';
 import sharp from 'sharp';
+import { getPresetIcon, isPresetIconKey, presetIconSvg } from '@/lib/agent-icon-presets';
 
 export const dynamic = 'force-dynamic';
 
+function etagMatch(ifNoneMatch: string, etag: string): boolean {
+  const normalized = etag.replace(/^W\//, '');
+  return ifNoneMatch.split(',').some((t) => t.trim().replace(/^W\//, '') === normalized);
+}
+
 export async function GET(request: NextRequest) {
   try {
-    // Support explicit key parameter for custom agent icons
     const keyParam = request.nextUrl.searchParams.get('key');
     let iconKey: string | undefined;
 
@@ -22,8 +27,54 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL('/icon-192x192.png', request.url));
     }
 
+    if (isPresetIconKey(iconKey)) {
+      const preset = getPresetIcon(iconKey);
+      if (!preset) {
+        return NextResponse.redirect(new URL('/icon-192x192.png', request.url));
+      }
+      const presetSizeParam = request.nextUrl.searchParams.get('size');
+      const parsedPresetSize = presetSizeParam ? parseInt(presetSizeParam, 10) : NaN;
+      const presetSize =
+        Number.isFinite(parsedPresetSize) && parsedPresetSize > 0 && parsedPresetSize <= 1024 ? parsedPresetSize : 192;
+      const svg = presetIconSvg(preset, presetSize);
+      const presetEtag = `"preset-${preset.id}-s${presetSize}"`;
+      const presetIfNoneMatch = request.headers.get('if-none-match');
+      if (presetIfNoneMatch && etagMatch(presetIfNoneMatch, presetEtag)) {
+        return new NextResponse(null, {
+          status: 304,
+          headers: {
+            ETag: presetEtag,
+            'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400',
+          },
+        });
+      }
+      return new NextResponse(svg, {
+        headers: {
+          'Content-Type': 'image/svg+xml',
+          ETag: presetEtag,
+          'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400',
+        },
+      });
+    }
+
     const sizeParam = request.nextUrl.searchParams.get('size');
     const size = sizeParam ? parseInt(sizeParam, 10) : undefined;
+
+    const ifNoneMatch = request.headers.get('if-none-match');
+
+    const head = await getHeadFromKey(iconKey);
+    const etag = head.ETag ?? undefined;
+    const sizeQualifiedEtag = etag ? (size ? `"${etag.replace(/"/g, '')}-s${size}"` : etag) : undefined;
+
+    if (ifNoneMatch && sizeQualifiedEtag && etagMatch(ifNoneMatch, sizeQualifiedEtag)) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: {
+          ETag: sizeQualifiedEtag,
+          'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400',
+        },
+      });
+    }
 
     const bytes = await getBytesFromKey(iconKey);
     let outputBuffer: Buffer;
@@ -34,11 +85,16 @@ export async function GET(request: NextRequest) {
       outputBuffer = Buffer.from(bytes);
     }
 
+    const responseHeaders: Record<string, string> = {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400',
+    };
+    if (sizeQualifiedEtag) {
+      responseHeaders['ETag'] = sizeQualifiedEtag;
+    }
+
     return new NextResponse(new Uint8Array(outputBuffer), {
-      headers: {
-        'Content-Type': 'image/png',
-        'Cache-Control': 'public, max-age=300, s-maxage=300',
-      },
+      headers: responseHeaders,
     });
   } catch (error) {
     console.error('Failed to serve agent icon:', error);

--- a/packages/webapp/src/app/custom-agent/[agentId]/components/AgentDetailCard.tsx
+++ b/packages/webapp/src/app/custom-agent/[agentId]/components/AgentDetailCard.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState } from 'react';
+import { useAction } from 'next-safe-action/hooks';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { PencilIcon, TrashIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { CustomAgent } from '@remote-swe-agents/agent-core/schema';
+import { modelConfigs, kiroModelConfigs } from '@remote-swe-agents/agent-core/schema';
+import type { KiroModelId } from '@remote-swe-agents/agent-core/schema';
+import CustomAgentForm from '../../components/CustomAgentForm';
+import DuplicateAgentButton from '../../components/DuplicateAgentButton';
+import { deleteCustomAgentAction } from '../../actions';
+import { mcpServersCount } from '../../components/AgentBadges';
+import LocalDateTime from '@/components/LocalDateTime';
+
+type AgentDetailCardProps = {
+  agent: CustomAgent;
+  childAgents: CustomAgent[];
+  availableTools: { name: string; description: string }[];
+};
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">{label}</dt>
+      <dd className="text-sm">{children}</dd>
+    </div>
+  );
+}
+
+export default function AgentDetailCard({ agent, childAgents, availableTools }: AgentDetailCardProps) {
+  const t = useTranslations('customAgent');
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+
+  // The server action redirects to the list on success (NEXT_REDIRECT), so
+  // onSuccess does not run here and the deleteSuccess toast is shown by the
+  // list page. Only onError runs client-side.
+  const { execute: deleteAgent, isPending: isDeleting } = useAction(deleteCustomAgentAction, {
+    onError: ({ error }) => {
+      const errorMessage = typeof error === 'string' ? error : t('deleteError');
+      toast.error(errorMessage);
+    },
+  });
+
+  const handleDelete = () => {
+    const message =
+      childAgents.length > 0
+        ? t('form.confirmDeleteWithChildren', {
+            count: childAgents.length,
+            names: childAgents.map((c) => c.name).join(', '),
+          })
+        : t('form.confirmDelete');
+    if (window.confirm(message)) {
+      // Delete the agent that owns this route: let the server redirect to the
+      // list so the revalidate/notFound race cannot flash a 404.
+      deleteAgent({ id: agent.SK, redirectToListOnSuccess: true });
+    }
+  };
+
+  const activeMark = <span className="text-xs text-blue-600 dark:text-blue-400 ml-1">{t('detail.activeModel')}</span>;
+  const bedrockModelId = agent.bedrockDefaultModel ?? agent.defaultModel;
+  const kiroModelId = (agent.kiroDefaultModel ??
+    (agent.kiroModel && agent.kiroModel in kiroModelConfigs ? agent.kiroModel : 'auto')) as KiroModelId;
+  const mcpCount = mcpServersCount(agent);
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-800 shadow-sm rounded-lg bg-white dark:bg-gray-800">
+      <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-start gap-2 flex-wrap">
+        <div>
+          <h2 className="text-xl font-semibold mb-1">{t('detail.title')}</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t('detail.description')}</p>
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          <DuplicateAgentButton agentId={agent.SK} variant="labeled" />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setEditing(!editing)}
+            className="flex items-center gap-1.5"
+          >
+            <PencilIcon className="h-4 w-4" />
+            {t('detail.edit')}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isDeleting}
+            onClick={handleDelete}
+            className="flex items-center gap-1.5 text-red-600 dark:text-red-400"
+          >
+            <TrashIcon className="h-4 w-4" />
+            {t('form.delete')}
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-6">
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <DetailRow label={t('form.inferenceMode.label')}>
+            {agent.inferenceMode === 'bedrock'
+              ? t('form.inferenceMode.bedrock')
+              : agent.inferenceMode === 'kiro-cli'
+                ? t('form.inferenceMode.kiro')
+                : t('form.inferenceMode.inherit')}
+          </DetailRow>
+          <DetailRow label={t('form.bedrockModel.label')}>
+            {modelConfigs[bedrockModelId]?.name ?? bedrockModelId}
+            {agent.inferenceMode === 'bedrock' && activeMark}
+          </DetailRow>
+          <DetailRow label={t('form.kiroModel.label')}>
+            {kiroModelConfigs[kiroModelId]?.name ?? kiroModelId}
+            {agent.inferenceMode === 'kiro-cli' && activeMark}
+          </DetailRow>
+          <DetailRow label={t('form.runtimeType.label')}>
+            {agent.runtimeType === 'agent-core' ? 'AgentCore Runtime' : 'EC2'}
+          </DetailRow>
+          <DetailRow label={t('form.tools.label')}>
+            {agent.useAllTools ? (
+              t('detail.allToolsEnabled')
+            ) : (
+              <>
+                {t('detail.toolsSelected', { count: agent.tools.length })}
+                {agent.tools.length > 0 && (
+                  <span className="block text-xs text-gray-500 dark:text-gray-400 mt-1">{agent.tools.join(', ')}</span>
+                )}
+              </>
+            )}
+          </DetailRow>
+          <DetailRow label={t('form.mcpConfig.label')}>
+            {mcpCount > 0 ? t('detail.mcpConfigured', { count: mcpCount }) : t('detail.mcpNone')}
+          </DetailRow>
+          <DetailRow label={t('form.systemPrompt.includeDefaultKnowledgeShort')}>
+            {agent.includeDefaultKnowledge === false ? t('detail.excluded') : t('detail.included')}
+          </DetailRow>
+          <DetailRow label={t('detail.createdAt')}>
+            <LocalDateTime timestamp={agent.createdAt} format="date" />
+          </DetailRow>
+        </dl>
+
+        {agent.systemPrompt && (
+          <div className="mt-4">
+            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">
+              {t('form.systemPrompt.label')}
+            </dt>
+            <dd className="text-sm bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 rounded-md p-3 text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+              {agent.systemPrompt}
+            </dd>
+          </div>
+        )}
+
+        {mcpCount > 0 && (
+          <div className="mt-4">
+            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">{t('form.mcpConfig.label')}</dt>
+            <dd className="text-sm bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 rounded-md p-3 text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono overflow-x-auto">
+              {agent.mcpConfig}
+            </dd>
+          </div>
+        )}
+      </div>
+
+      {editing && (
+        <div className="border-t border-gray-200 dark:border-gray-700 p-6">
+          <CustomAgentForm
+            availableTools={availableTools}
+            editingAgent={agent}
+            childAgents={childAgents}
+            onSuccess={() => setEditing(false)}
+            onDeleted={() => router.push('/custom-agent')}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/[agentId]/components/SubAgentList.tsx
+++ b/packages/webapp/src/app/custom-agent/[agentId]/components/SubAgentList.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import type { CustomAgent } from '@remote-swe-agents/agent-core/schema';
+import AgentIconPreview from '../../components/AgentIconPreview';
+import AgentBadges from '../../components/AgentBadges';
+import DuplicateAgentButton from '../../components/DuplicateAgentButton';
+import CustomAgentForm from '../../components/CustomAgentForm';
+import LocalDateTime from '@/components/LocalDateTime';
+
+type SubAgentListProps = {
+  subAgents: CustomAgent[];
+  availableTools: { name: string; description: string }[];
+};
+
+export default function SubAgentList({ subAgents, availableTools }: SubAgentListProps) {
+  const t = useTranslations('customAgent');
+  const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
+
+  if (subAgents.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">{t('detail.subAgents.empty')}</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {subAgents.map((agent) => (
+        <div
+          key={agent.SK}
+          className="border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"
+        >
+          <div
+            className="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+            onClick={() => setExpandedAgentId(expandedAgentId === agent.SK ? null : agent.SK)}
+          >
+            <div className="flex justify-between items-start mb-2 gap-2">
+              <div className="flex items-center gap-3 flex-wrap min-w-0">
+                <AgentIconPreview iconKey={agent.iconKey} size={32} />
+                <h3 className="text-lg font-semibold">{agent.name}</h3>
+                <AgentBadges agent={agent} />
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+                  <LocalDateTime timestamp={agent.createdAt} format="date" />
+                </span>
+                <DuplicateAgentButton agentId={agent.SK} />
+                {expandedAgentId === agent.SK ? (
+                  <ChevronUpIcon className="h-4 w-4 text-gray-500" />
+                ) : (
+                  <ChevronDownIcon className="h-4 w-4 text-gray-500" />
+                )}
+              </div>
+            </div>
+            <p className="text-gray-600 dark:text-gray-400">{agent.description}</p>
+          </div>
+          {expandedAgentId === agent.SK && (
+            <div className="border-t border-gray-200 dark:border-gray-700 p-4">
+              <CustomAgentForm
+                availableTools={availableTools}
+                editingAgent={agent}
+                onSuccess={() => setExpandedAgentId(null)}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/[agentId]/page.tsx
+++ b/packages/webapp/src/app/custom-agent/[agentId]/page.tsx
@@ -1,0 +1,136 @@
+import HeaderWithPreferences from '@/components/HeaderWithPreferences';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeftIcon } from 'lucide-react';
+import { optionalTools } from '@remote-swe-agents/agent-core/tools';
+import { getCustomAgent, getCustomAgents, getSessions } from '@remote-swe-agents/agent-core/lib';
+import AgentIconPreview from '../components/AgentIconPreview';
+import AgentBadges from '../components/AgentBadges';
+import AgentDetailCard from './components/AgentDetailCard';
+import SubAgentList from './components/SubAgentList';
+import LocalDateTime from '@/components/LocalDateTime';
+import { toInitialMessagePreview } from '@/lib/session-list';
+
+export const dynamic = 'force-dynamic';
+
+const RECENT_SESSIONS_SCAN_LIMIT = 200;
+const RECENT_SESSIONS_DISPLAY_LIMIT = 5;
+
+export default async function CustomAgentDetailPage({ params }: { params: Promise<{ agentId: string }> }) {
+  const { agentId } = await params;
+  const t = await getTranslations('customAgent');
+
+  const [availableTools, agent, allAgents, recentSessions] = await Promise.all([
+    Promise.all(
+      optionalTools.map(async (tool) => ({
+        name: tool.name,
+        description: (await tool.toolSpec()).description?.trim() ?? '',
+      }))
+    ),
+    getCustomAgent(agentId),
+    getCustomAgents(),
+    getSessions(RECENT_SESSIONS_SCAN_LIMIT),
+  ]);
+
+  if (!agent) {
+    notFound();
+  }
+
+  const childAgents = allAgents.filter((a) => a.parentAgentId === agent.SK);
+  const agentSessions = recentSessions.filter((s) => s.customAgentId === agent.SK);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
+      <HeaderWithPreferences />
+
+      <main className="flex-grow container max-w-6xl mx-auto px-4 py-6 pt-20">
+        <div className="mb-4">
+          <Link
+            href="/custom-agent"
+            className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+          >
+            <ArrowLeftIcon className="h-4 w-4" />
+            {t('detail.backToList')}
+          </Link>
+        </div>
+
+        <div className="mb-6">
+          <div className="flex items-center gap-3 flex-wrap mb-2">
+            <AgentIconPreview iconKey={agent.iconKey} size={40} />
+            <h1 className="text-3xl font-bold">{agent.name}</h1>
+            <AgentBadges agent={agent} subAgentsCount={childAgents.length} />
+          </div>
+          <p className="text-gray-600 dark:text-gray-400">{agent.description}</p>
+        </div>
+
+        <div className="space-y-6">
+          <AgentDetailCard agent={agent} childAgents={childAgents} availableTools={availableTools} />
+
+          <div className="border border-gray-200 dark:border-gray-800 shadow-sm rounded-lg bg-white dark:bg-gray-800">
+            <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+              <h2 className="text-xl font-semibold mb-1">{t('detail.usage.title')}</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">{t('detail.usage.description')}</p>
+            </div>
+            <div className="p-6">
+              <div className="flex items-baseline gap-2 mb-4">
+                <span className="text-3xl font-bold">{agentSessions.length}</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                  {t('detail.usage.recentSessionCount', { limit: RECENT_SESSIONS_SCAN_LIMIT })}
+                </span>
+              </div>
+              {agentSessions.length > 0 ? (
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    {t('detail.usage.recentSessions')}
+                  </p>
+                  {agentSessions.slice(0, RECENT_SESSIONS_DISPLAY_LIMIT).map((session) => (
+                    <Link
+                      key={session.workerId}
+                      href={`/sessions/${encodeURIComponent(session.workerId)}`}
+                      className="flex justify-between items-center gap-2 border border-gray-200 dark:border-gray-700 rounded-md px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                    >
+                      <span className="text-sm truncate">
+                        {session.title || toInitialMessagePreview(session.initialMessage)}
+                      </span>
+                      <span className="flex items-center gap-2 flex-shrink-0">
+                        <span
+                          className={`px-2 py-0.5 text-xs rounded ${
+                            session.agentStatus === 'completed'
+                              ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
+                              : session.agentStatus === 'working'
+                                ? 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200'
+                                : 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200'
+                          }`}
+                        >
+                          {session.agentStatus}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+                          <LocalDateTime timestamp={session.createdAt} format="date" />
+                        </span>
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-gray-400">{t('detail.usage.noSessions')}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="border border-gray-200 dark:border-gray-800 shadow-sm rounded-lg bg-white dark:bg-gray-800">
+            <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+              <h2 className="text-xl font-semibold mb-1">{t('detail.subAgents.title')}</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t('detail.subAgents.description', { name: agent.name })}
+              </p>
+            </div>
+            <div className="p-6">
+              <SubAgentList subAgents={childAgents} availableTools={availableTools} />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/actions.ts
+++ b/packages/webapp/src/app/custom-agent/actions.ts
@@ -1,9 +1,19 @@
 'use server';
 
 import { authActionClient } from '@/lib/safe-action';
-import { upsertCustomAgentSchema, deleteCustomAgentSchema } from './schemas';
-import { createCustomAgent, updateCustomAgent, deleteCustomAgent } from '@remote-swe-agents/agent-core/lib';
+import { upsertCustomAgentSchema, deleteCustomAgentSchema, duplicateCustomAgentSchema } from './schemas';
+import {
+  createCustomAgent,
+  updateCustomAgent,
+  deleteCustomAgent,
+  getCustomAgent,
+  getCustomAgents,
+} from '@remote-swe-agents/agent-core/lib';
 import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+
+const AGENT_NAME_MAX_LENGTH = 100;
 
 export const upsertCustomAgentAction = authActionClient
   .inputSchema(upsertCustomAgentSchema)
@@ -14,11 +24,13 @@ export const upsertCustomAgentAction = authActionClient
 
       let agent;
       if (id) {
-        // Update existing agent
+        // Update existing agent. inferenceMode === null removes the attribute
+        // (back to "inherit from Preferences").
         agent = await updateCustomAgent(id, agentData);
       } else {
         // Create new agent
-        agent = await createCustomAgent(agentData);
+        const { inferenceMode, ...rest } = agentData;
+        agent = await createCustomAgent(inferenceMode === null ? rest : { ...rest, inferenceMode });
       }
 
       revalidatePath('/custom-agent');
@@ -32,14 +44,70 @@ export const upsertCustomAgentAction = authActionClient
 export const deleteCustomAgentAction = authActionClient
   .inputSchema(deleteCustomAgentSchema)
   .action(async ({ parsedInput }) => {
+    const { id, redirectToListOnSuccess } = parsedInput;
+    let deletedCount: number;
     try {
-      const { id } = parsedInput;
-      await deleteCustomAgent(id);
+      // Cascade delete: also remove all descendant sub-agents so they cannot
+      // become invisible orphans (the list page shows top-level agents only).
+      // Delete leaves first so a partial failure never leaves children behind
+      // without their parent.
+      const allAgents = await getCustomAgents();
+      const idsToDelete = [id];
+      for (let i = 0; i < idsToDelete.length; i++) {
+        const parentId = idsToDelete[i];
+        for (const agent of allAgents) {
+          if (agent.parentAgentId === parentId && !idsToDelete.includes(agent.SK)) {
+            idsToDelete.push(agent.SK);
+          }
+        }
+      }
+      for (const agentId of idsToDelete.reverse()) {
+        await deleteCustomAgent(agentId);
+      }
 
       revalidatePath('/custom-agent');
-      return { success: true };
+      deletedCount = idsToDelete.length;
     } catch (error) {
       console.error('Error deleting custom agent:', error);
       throw new Error('Failed to delete custom agent');
+    }
+
+    // Redirect outside the try/catch so the NEXT_REDIRECT signal thrown by
+    // redirect() is not swallowed by the catch above. When deleting the agent
+    // that owns the current route (detail page), a client-side navigation would
+    // race the server revalidation of that same route and could flash a 404
+    // (getCustomAgent returns null -> notFound()). A server redirect wins the
+    // race deterministically. The list page reads ?deleted=1 to show the
+    // deleteSuccess toast, since redirect() prevents the client onSuccess.
+    if (redirectToListOnSuccess) {
+      redirect('/custom-agent?deleted=1');
+    }
+
+    return { success: true, deletedCount };
+  });
+
+export const duplicateCustomAgentAction = authActionClient
+  .inputSchema(duplicateCustomAgentSchema)
+  .action(async ({ parsedInput }) => {
+    try {
+      const { id } = parsedInput;
+      const source = await getCustomAgent(id);
+      if (!source) {
+        throw new Error('Agent not found');
+      }
+      const t = await getTranslations('customAgent');
+      const suffix = t('copySuffix');
+      const baseName = source.name.slice(0, AGENT_NAME_MAX_LENGTH - suffix.length - 1);
+      const { PK, SK, createdAt, updatedAt, ...fields } = source;
+      const agent = await createCustomAgent({
+        ...fields,
+        name: `${baseName} ${suffix}`,
+      });
+
+      revalidatePath('/custom-agent');
+      return { success: true, agent };
+    } catch (error) {
+      console.error('Error duplicating custom agent:', error);
+      throw new Error('Failed to duplicate custom agent');
     }
   });

--- a/packages/webapp/src/app/custom-agent/components/AgentBadges.tsx
+++ b/packages/webapp/src/app/custom-agent/components/AgentBadges.tsx
@@ -1,0 +1,54 @@
+import type { CustomAgent } from '@remote-swe-agents/agent-core/schema';
+import { mcpConfigSchema } from '@remote-swe-agents/agent-core/schema';
+
+export function mcpServersCount(agent: CustomAgent): number {
+  try {
+    const parsed = mcpConfigSchema.parse(JSON.parse(agent.mcpConfig));
+    return Object.keys(parsed.mcpServers).length;
+  } catch {
+    return 0;
+  }
+}
+
+export function effectiveModel(agent: CustomAgent): string {
+  if (agent.inferenceMode === 'kiro-cli') return agent.kiroDefaultModel ?? agent.kiroModel ?? 'auto';
+  return agent.bedrockDefaultModel ?? agent.defaultModel;
+}
+
+export function inferenceModeLabel(mode: CustomAgent['inferenceMode']): string {
+  if (mode === 'bedrock') return 'Bedrock';
+  if (mode === 'kiro-cli') return 'Kiro';
+  return 'Default';
+}
+
+export default function AgentBadges({ agent, subAgentsCount }: { agent: CustomAgent; subAgentsCount?: number }) {
+  const mcpCount = mcpServersCount(agent);
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {agent.inferenceMode && (
+        <span className="px-2 py-1 text-xs bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 rounded">
+          {inferenceModeLabel(agent.inferenceMode)}
+        </span>
+      )}
+      <span className="px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
+        {effectiveModel(agent)}
+      </span>
+      <span className="px-2 py-1 text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded">
+        {agent.runtimeType}
+      </span>
+      <span className="px-2 py-1 text-xs bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded">
+        Tools: {agent.useAllTools ? 'All' : agent.tools.length}
+      </span>
+      {mcpCount > 0 && (
+        <span className="px-2 py-1 text-xs bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-200 rounded">
+          MCP: {mcpCount}
+        </span>
+      )}
+      {subAgentsCount !== undefined && subAgentsCount > 0 && (
+        <span className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded">
+          Sub-agents: {subAgentsCount}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/components/AgentIconPicker.tsx
+++ b/packages/webapp/src/app/custom-agent/components/AgentIconPicker.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import AgentIconUploader from '@/components/AgentIconUploader';
+import { isPresetIconKey, presetIcons, PRESET_ICON_PREFIX } from '@/lib/agent-icon-presets';
+
+type AgentIconPickerProps = {
+  currentIconKey?: string;
+  onIconKeyChange: (key: string) => void;
+  disabled?: boolean;
+};
+
+export default function AgentIconPicker({ currentIconKey, onIconKeyChange, disabled }: AgentIconPickerProps) {
+  const t = useTranslations('customAgent');
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <AgentIconUploader
+        key={currentIconKey && isPresetIconKey(currentIconKey) ? 'preset-selected' : 'upload'}
+        currentIconKey={currentIconKey && !isPresetIconKey(currentIconKey) ? currentIconKey : undefined}
+        onIconKeyChange={onIconKeyChange}
+        disabled={disabled}
+      />
+      <div className="h-10 border-l border-gray-200 dark:border-gray-700" />
+      {presetIcons.map((preset) => {
+        const key = `${PRESET_ICON_PREFIX}${preset.id}`;
+        const selected = currentIconKey === key;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            title={preset.label}
+            aria-label={t('form.icon.presetAriaLabel', { label: preset.label })}
+            aria-pressed={selected}
+            disabled={disabled}
+            onClick={() => onIconKeyChange(key)}
+            className={`rounded-full flex items-center justify-center flex-shrink-0 transition-all ${
+              selected ? 'ring-2 ring-offset-2 ring-blue-500 dark:ring-offset-gray-800' : 'opacity-70 hover:opacity-100'
+            }`}
+            style={{ width: 44, height: 44, backgroundColor: preset.color }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#ffffff"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ width: 22, height: 22 }}
+            >
+              {preset.paths.map((d) => (
+                <path key={d} d={d} />
+              ))}
+            </svg>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/components/AgentIconPreview.tsx
+++ b/packages/webapp/src/app/custom-agent/components/AgentIconPreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Bot } from 'lucide-react';
+import { getPresetIcon, isPresetIconKey } from '@/lib/agent-icon-presets';
 
 type AgentIconPreviewProps = {
   iconKey?: string;
@@ -8,6 +9,33 @@ type AgentIconPreviewProps = {
 };
 
 export default function AgentIconPreview({ iconKey, size = 32 }: AgentIconPreviewProps) {
+  if (iconKey && isPresetIconKey(iconKey)) {
+    const preset = getPresetIcon(iconKey);
+    if (preset) {
+      return (
+        <div
+          className="rounded-full flex items-center justify-center flex-shrink-0"
+          style={{ width: size, height: size, backgroundColor: preset.color }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ width: size * 0.5, height: size * 0.5 }}
+          >
+            {preset.paths.map((d) => (
+              <path key={d} d={d} />
+            ))}
+          </svg>
+        </div>
+      );
+    }
+  }
+
   if (iconKey) {
     const iconUrl = `/api/agent-icon?key=${encodeURIComponent(iconKey)}`;
     return (

--- a/packages/webapp/src/app/custom-agent/components/CustomAgentForm.tsx
+++ b/packages/webapp/src/app/custom-agent/components/CustomAgentForm.tsx
@@ -5,8 +5,8 @@ import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hoo
 import { useAction } from 'next-safe-action/hooks';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { useState } from 'react';
-import { ChevronDownIcon, WandIcon, TrashIcon } from 'lucide-react';
+import { useState, useEffect, ReactNode } from 'react';
+import { CheckIcon, ChevronDownIcon, PlusIcon, WandIcon, TrashIcon, XIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -20,21 +20,118 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { EmptyMcpConfig, getAvailableModelTypes, modelConfigs } from '@remote-swe-agents/agent-core/schema';
+import {
+  EmptyMcpConfig,
+  getAvailableModelTypes,
+  modelConfigs,
+  kiroModelConfigs,
+  getKiroModelIds,
+  mcpConfigSchema,
+} from '@remote-swe-agents/agent-core/schema';
 import { upsertCustomAgentAction, deleteCustomAgentAction } from '../actions';
 import { upsertCustomAgentSchema } from '../schemas';
-import type { CustomAgent } from '@remote-swe-agents/agent-core/schema';
+import type { CustomAgent, InferenceMode, ModelType, KiroModelId } from '@remote-swe-agents/agent-core/schema';
 import { Form, FormControl, FormField } from '@/components/ui/form';
 import { useRouter } from 'next/navigation';
-import AgentIconUploader from '@/components/AgentIconUploader';
+import AgentIconPicker from './AgentIconPicker';
+import { runDeleteSuccessNavigation } from './delete-navigation';
+
+type McpServerRow = {
+  name: string;
+  command: string;
+  args: string;
+};
+
+const parseMcpRows = (mcpConfig: string | undefined): McpServerRow[] | undefined => {
+  if (!mcpConfig?.trim()) return [];
+  try {
+    const parsed = mcpConfigSchema.parse(JSON.parse(mcpConfig));
+    const rows: McpServerRow[] = [];
+    for (const [name, server] of Object.entries(parsed.mcpServers)) {
+      if ('url' in server || ('env' in server && server.env) || ('enabled' in server && server.enabled !== undefined)) {
+        return undefined;
+      }
+      if ('command' in server) {
+        rows.push({ name, command: server.command, args: server.args.join(', ') });
+      }
+    }
+    return rows;
+  } catch {
+    return undefined;
+  }
+};
+
+const rowsToMcpConfig = (rows: McpServerRow[]): string => {
+  if (rows.length === 0) return JSON.stringify(EmptyMcpConfig, undefined, 2);
+  const mcpServers: Record<string, { command: string; args: string[] }> = {};
+  rows.forEach((row, i) => {
+    mcpServers[row.name || `server-${i + 1}`] = {
+      command: row.command,
+      args: row.args
+        .split(',')
+        .map((a) => a.trim())
+        .filter((a) => a.length > 0),
+    };
+  });
+  return JSON.stringify({ mcpServers }, undefined, 2);
+};
 
 type CustomAgentFormProps = {
   availableTools: { name: string; description: string }[];
   editingAgent?: CustomAgent;
+  childAgents?: CustomAgent[];
   onSuccess?: () => void;
+  // Called instead of the default refresh + onSuccess when a delete succeeds.
+  // Required when the form edits the agent that owns the current page (e.g. the
+  // detail page), because refreshing a deleted agent's force-dynamic route
+  // triggers notFound() -> 404. The caller is responsible for navigating away.
+  onDeleted?: () => void;
 };
 
-export default function CustomAgentForm({ availableTools, editingAgent, onSuccess }: CustomAgentFormProps) {
+function FormSection({
+  step,
+  title,
+  description,
+  defaultOpen,
+  children,
+}: {
+  step: string;
+  title: string;
+  description: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className="w-full flex justify-between items-center p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors rounded-lg"
+      >
+        <span>
+          <span className="text-base font-semibold block">
+            {step}. {title}
+          </span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">{description}</span>
+        </span>
+        <ChevronDownIcon
+          className={`h-4 w-4 text-gray-500 transition-transform flex-shrink-0 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      <div className={`px-4 pb-4 space-y-6 ${open ? '' : 'hidden'}`}>{children}</div>
+    </div>
+  );
+}
+
+export default function CustomAgentForm({
+  availableTools,
+  editingAgent,
+  childAgents,
+  onSuccess,
+  onDeleted,
+}: CustomAgentFormProps) {
   const t = useTranslations('customAgent');
   const isEditing = Boolean(editingAgent);
   const router = useRouter();
@@ -43,6 +140,9 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
   const [includeDefaultKnowledge, setIncludeDefaultKnowledge] = useState<boolean>(
     editingAgent?.includeDefaultKnowledge !== false
   );
+  const initialMcpRows = parseMcpRows(editingAgent?.mcpConfig);
+  const [mcpRows, setMcpRows] = useState<McpServerRow[]>(initialMcpRows ?? []);
+  const [mcpAdvanced, setMcpAdvanced] = useState<boolean>(initialMcpRows === undefined);
 
   const {
     form,
@@ -59,6 +159,8 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
           // Reset form for create mode
           reset();
           setSelectedTools([]);
+          setMcpRows([]);
+          setMcpAdvanced(false);
         }
       },
       onError: ({ error }) => {
@@ -71,7 +173,13 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
         id: editingAgent?.SK,
         name: editingAgent?.name ?? '',
         description: editingAgent?.description ?? '',
-        defaultModel: editingAgent?.defaultModel ?? 'sonnet3.7',
+        defaultModel: editingAgent?.bedrockDefaultModel ?? editingAgent?.defaultModel ?? 'sonnet3.7',
+        bedrockDefaultModel: editingAgent?.bedrockDefaultModel ?? editingAgent?.defaultModel ?? 'sonnet3.7',
+        kiroDefaultModel:
+          editingAgent?.kiroDefaultModel ??
+          (editingAgent?.kiroModel && editingAgent.kiroModel in kiroModelConfigs
+            ? (editingAgent.kiroModel as KiroModelId)
+            : 'auto'),
         systemPrompt: editingAgent?.systemPrompt ?? '',
         tools: editingAgent?.tools ?? [],
         useAllTools: editingAgent?.useAllTools ?? false,
@@ -79,24 +187,28 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
         runtimeType: editingAgent?.runtimeType ?? 'agent-core',
         iconKey: editingAgent?.iconKey ?? '',
         includeDefaultKnowledge: editingAgent?.includeDefaultKnowledge !== false,
+        inferenceMode: editingAgent?.inferenceMode ?? null,
+        kiroModel: editingAgent?.kiroDefaultModel ?? editingAgent?.kiroModel ?? 'auto',
+        parentAgentId: editingAgent?.parentAgentId,
       },
     },
   });
-  const { register, formState, setValue, reset, control } = form;
+  const { register, formState, setValue, reset, control, watch } = form;
+  const selectedInferenceMode = watch('inferenceMode');
+  const currentIconKey = watch('iconKey');
 
-  const { execute: deleteAgent, isPending: isDeleting } = useAction(deleteCustomAgentAction, {
-    onSuccess: () => {
-      toast.success(t('deleteSuccess'));
-      router.refresh();
-      if (onSuccess) {
-        onSuccess();
+  useEffect(() => {
+    if (selectedInferenceMode === 'kiro-cli') {
+      const currentKiroModel = form.getValues('kiroModel');
+      if (!currentKiroModel) {
+        setValue('kiroModel', 'auto');
+        setValue('kiroDefaultModel', 'auto' as KiroModelId);
       }
-    },
-    onError: ({ error }) => {
-      const errorMessage = typeof error === 'string' ? error : t('deleteError');
-      toast.error(errorMessage);
-    },
-  });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedInferenceMode]);
+
+  const { executeAsync: deleteAgent, isPending: isDeleting } = useAction(deleteCustomAgentAction);
 
   const handleToolToggle = (toolName: string, checked: boolean) => {
     let newSelectedTools: string[];
@@ -107,6 +219,25 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
     }
     setSelectedTools(newSelectedTools);
     setValue('tools', newSelectedTools);
+  };
+
+  const applyMcpRows = (rows: McpServerRow[]) => {
+    setMcpRows(rows);
+    setValue('mcpConfig', rowsToMcpConfig(rows), { shouldValidate: true });
+  };
+
+  const handleMcpAdvancedToggle = (advanced: boolean) => {
+    if (advanced) {
+      setMcpAdvanced(true);
+    } else {
+      const rows = parseMcpRows(form.getValues('mcpConfig'));
+      if (rows === undefined) {
+        toast.error(t('form.mcpConfig.structuredUnavailable'));
+        return;
+      }
+      setMcpRows(rows);
+      setMcpAdvanced(false);
+    }
   };
 
   const formatJsonConfig = () => {
@@ -123,11 +254,49 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
     }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!editingAgent?.SK) return;
 
-    if (window.confirm(t('form.confirmDelete'))) {
-      deleteAgent({ id: editingAgent.SK });
+    const message =
+      childAgents && childAgents.length > 0
+        ? t('form.confirmDeleteWithChildren', {
+            count: childAgents.length,
+            names: childAgents.map((c) => c.name).join(', '),
+          })
+        : t('form.confirmDelete');
+    if (!window.confirm(message)) return;
+
+    // Run the delete via executeAsync and drive the success feedback from the
+    // awaited continuation (a closure), NOT from useAction's onSuccess/onError.
+    // next-safe-action fires those callbacks from a useLayoutEffect; on the
+    // sub-agent path the server action's revalidatePath('/custom-agent')
+    // re-renders the parent detail page and unmounts this collapsing row before
+    // that layout effect runs, so the callback (and its toast) is dropped. The
+    // awaited continuation is unaffected by unmount, so the toast always fires.
+    //
+    // When the form owns the current route (detail page, onDeleted set), we ask
+    // the server to redirect to the list, avoiding the revalidate/notFound 404
+    // race. redirect() surfaces as a navigation error that executeAsync neither
+    // resolves nor rejects, so the continuation below simply does not run and
+    // the list page shows the toast via ?deleted=1.
+    // executeAsync rejects on thrown (non-navigation) errors, e.g. a network
+    // failure. Catch it so the user still gets error feedback, matching the old
+    // onError toast. The serverError branch below also uses t('deleteError'):
+    // handleServerError masks the real message to an English default and the
+    // old `typeof error === 'string'` check was always false for the object
+    // error, so the old code effectively always showed the localized string.
+    let result;
+    try {
+      result = await deleteAgent({ id: editingAgent.SK, redirectToListOnSuccess: Boolean(onDeleted) });
+    } catch {
+      toast.error(t('deleteError'));
+      return;
+    }
+    if (result?.data) {
+      toast.success(t('deleteSuccess'));
+      runDeleteSuccessNavigation(router, { onDeleted, onSuccess });
+    } else {
+      toast.error(t('deleteError'));
     }
   };
 
@@ -135,251 +304,474 @@ export default function CustomAgentForm({ availableTools, editingAgent, onSucces
     handleSubmitWithAction(e);
   };
 
+  const handleInferenceTabChange = (mode: InferenceMode | null) => {
+    setValue('inferenceMode', mode, { shouldValidate: true });
+  };
+
+  const inferenceTabs: { mode: InferenceMode | null; label: string }[] = [
+    { mode: null, label: t('form.inferenceMode.inherit') },
+    { mode: 'bedrock', label: t('form.inferenceMode.bedrock') },
+    { mode: 'kiro-cli', label: t('form.inferenceMode.kiro') },
+  ];
+
+  const duplicateMcpNames = Object.entries(
+    mcpRows.reduce<Record<string, number>>((acc, row) => {
+      const name = row.name.trim();
+      if (name) acc[name] = (acc[name] ?? 0) + 1;
+      return acc;
+    }, {})
+  )
+    .filter(([, count]) => count > 1)
+    .map(([name]) => name);
+
   return (
     <Form {...form}>
-      <form onSubmit={handleFormSubmit} className="space-y-6">
-        {/* Agent Name */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.name.label')}
-          </label>
-          <Input
-            {...register('name')}
-            type="text"
-            placeholder={t('form.name.placeholder')}
-            disabled={isPending}
-            className="w-full"
-          />
-          {formState.errors.name && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.name.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.name.description')}</p>
-        </div>
-
-        {/* Agent Icon */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.icon.label')}
-          </label>
-          <AgentIconUploader
-            currentIconKey={editingAgent?.iconKey}
-            onIconKeyChange={(key) => setValue('iconKey', key)}
-            disabled={isPending}
-          />
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.icon.description')}</p>
-        </div>
-
-        {/* Agent Description */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.description.label')}
-          </label>
-          <textarea
-            {...register('description')}
-            placeholder={t('form.description.placeholder')}
-            disabled={isPending}
-            rows={3}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
-          />
-          {formState.errors.description && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.description.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.description.description')}</p>
-        </div>
-
-        {/* Default Model */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.defaultModel.label')}
-          </label>
-          <FormField
-            name="defaultModel"
-            control={control}
-            render={({ field }) => (
-              <Select value={field.value} onValueChange={field.onChange} disabled={isPending}>
-                <FormControl>
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={t('form.defaultModel.placeholder')} />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {getAvailableModelTypes().map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {modelConfigs[type].name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+      <form onSubmit={handleFormSubmit} className="space-y-4">
+        <FormSection
+          step="1"
+          title={t('form.sections.basic.title')}
+          description={t('form.sections.basic.description')}
+          defaultOpen
+        >
+          {/* Agent Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.name.label')}
+            </label>
+            <Input
+              {...register('name')}
+              type="text"
+              placeholder={t('form.name.placeholder')}
+              disabled={isPending}
+              className="w-full"
+            />
+            {formState.errors.name && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.name.message}</p>
             )}
-          />
-          {formState.errors.defaultModel && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.defaultModel.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.defaultModel.description')}</p>
-        </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.name.description')}</p>
+          </div>
 
-        {/* System Prompt */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.systemPrompt.label')}
-          </label>
-          <div className="flex items-center gap-2 mb-3">
-            <Checkbox
-              id="includeDefaultKnowledge"
-              checked={includeDefaultKnowledge}
-              onCheckedChange={(checked) => {
-                const val = checked === true;
-                setIncludeDefaultKnowledge(val);
-                setValue('includeDefaultKnowledge', val);
-              }}
+          {/* Agent Icon */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.icon.label')}
+            </label>
+            <AgentIconPicker
+              currentIconKey={currentIconKey || undefined}
+              onIconKeyChange={(key) => setValue('iconKey', key)}
               disabled={isPending}
             />
-            <label
-              htmlFor="includeDefaultKnowledge"
-              className="text-sm text-gray-700 dark:text-gray-300 cursor-pointer"
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.icon.description')}</p>
+          </div>
+
+          {/* Agent Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.description.label')}
+            </label>
+            <textarea
+              {...register('description')}
+              placeholder={t('form.description.placeholder')}
+              disabled={isPending}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
+            />
+            {formState.errors.description && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.description.message}</p>
+            )}
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.description.description')}</p>
+          </div>
+        </FormSection>
+
+        <FormSection
+          step="2"
+          title={t('form.sections.model.title')}
+          description={t('form.sections.model.description')}
+          defaultOpen={!isEditing}
+        >
+          {/* Unified Inference Mode tabs: selected tab = inferenceMode */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.inferenceMode.label')}
+            </label>
+            <div
+              role="radiogroup"
+              className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-100 dark:bg-gray-800 flex-wrap gap-1"
             >
-              {t('form.systemPrompt.includeDefaultKnowledge')}
-            </label>
-          </div>
-          <textarea
-            {...register('systemPrompt')}
-            placeholder={t('form.systemPrompt.placeholder')}
-            disabled={isPending}
-            rows={6}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
-          />
-          {formState.errors.systemPrompt && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.systemPrompt.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.systemPrompt.description')}</p>
-        </div>
+              {inferenceTabs.map((tab) => {
+                const isActive = selectedInferenceMode === tab.mode;
+                return (
+                  <button
+                    key={tab.mode ?? 'inherit'}
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    disabled={isPending}
+                    onClick={() => handleInferenceTabChange(tab.mode)}
+                    className={`inline-flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                      isActive
+                        ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm ring-1 ring-blue-500'
+                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                    } ${isPending && !isActive ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  >
+                    {isActive && <CheckIcon className="h-4 w-4 text-blue-600 dark:text-blue-400" />}
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.inferenceMode.tabDescription')}</p>
 
-        {/* Tools */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.tools.label')}
-          </label>
-          <div className="flex items-center gap-2 mb-3">
-            <Checkbox
-              id="useAllTools"
-              checked={useAllTools}
-              onCheckedChange={(checked) => {
-                const val = checked === true;
-                setUseAllTools(val);
-                setValue('useAllTools', val);
-              }}
-              disabled={isPending}
-            />
-            <label htmlFor="useAllTools" className="text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
-              {t('form.tools.useAllTools')}
-            </label>
+            <div className="mt-3 border border-gray-200 dark:border-gray-700 rounded-md p-4">
+              {selectedInferenceMode == null && (
+                <p className="text-sm text-gray-600 dark:text-gray-400">{t('form.inferenceMode.inheritDescription')}</p>
+              )}
+              {selectedInferenceMode === 'bedrock' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    {t('form.bedrockModel.label')}
+                  </label>
+                  <FormField
+                    name="defaultModel"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value}
+                        onValueChange={(val) => {
+                          field.onChange(val);
+                          setValue('bedrockDefaultModel', val as ModelType);
+                        }}
+                        disabled={isPending}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder={t('form.bedrockModel.placeholder')} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {getAvailableModelTypes().map((type) => (
+                            <SelectItem key={type} value={type}>
+                              {modelConfigs[type].name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
+                  {formState.errors.defaultModel && (
+                    <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                      {formState.errors.defaultModel.message}
+                    </p>
+                  )}
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.bedrockModel.description')}</p>
+                </div>
+              )}
+              {selectedInferenceMode === 'kiro-cli' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    {t('form.kiroModel.label')}
+                  </label>
+                  <FormField
+                    name="kiroModel"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? 'auto'}
+                        onValueChange={(val) => {
+                          field.onChange(val);
+                          setValue('kiroDefaultModel', val as KiroModelId);
+                        }}
+                        disabled={isPending}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder={t('form.kiroModel.placeholder')} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {getKiroModelIds().map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {kiroModelConfigs[model].name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.kiroModel.description')}</p>
+                </div>
+              )}
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.inferenceMode.retentionNote')}</p>
           </div>
-          {!useAllTools && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="w-full justify-between" disabled={isPending}>
-                  <span className={selectedTools.length === 0 ? 'font-normal text-muted-foreground' : ''}>
-                    {selectedTools.length > 0
-                      ? `${selectedTools.length} tool${selectedTools.length > 1 ? 's' : ''} selected`
-                      : t('form.tools.placeholder')}
-                  </span>
-                  <ChevronDownIcon className="h-4 w-4 opacity-50" />
+        </FormSection>
+
+        <FormSection
+          step="3"
+          title={t('form.sections.behavior.title')}
+          description={t('form.sections.behavior.description')}
+        >
+          {/* System Prompt */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.systemPrompt.label')}
+            </label>
+            <div className="flex items-center gap-2 mb-3">
+              <Checkbox
+                id="includeDefaultKnowledge"
+                checked={includeDefaultKnowledge}
+                onCheckedChange={(checked) => {
+                  const val = checked === true;
+                  setIncludeDefaultKnowledge(val);
+                  setValue('includeDefaultKnowledge', val);
+                }}
+                disabled={isPending}
+              />
+              <label
+                htmlFor="includeDefaultKnowledge"
+                className="text-sm text-gray-700 dark:text-gray-300 cursor-pointer"
+              >
+                {t('form.systemPrompt.includeDefaultKnowledge')}
+              </label>
+            </div>
+            <textarea
+              {...register('systemPrompt')}
+              placeholder={t('form.systemPrompt.placeholder')}
+              disabled={isPending}
+              rows={6}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical"
+            />
+            {formState.errors.systemPrompt && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.systemPrompt.message}</p>
+            )}
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.systemPrompt.description')}</p>
+          </div>
+        </FormSection>
+
+        <FormSection
+          step="4"
+          title={t('form.sections.capabilities.title')}
+          description={t('form.sections.capabilities.description')}
+        >
+          {/* Tools */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.tools.label')}
+            </label>
+            <div className="flex items-center gap-2 mb-3">
+              <Checkbox
+                id="useAllTools"
+                checked={useAllTools}
+                onCheckedChange={(checked) => {
+                  const val = checked === true;
+                  setUseAllTools(val);
+                  setValue('useAllTools', val);
+                }}
+                disabled={isPending}
+              />
+              <label htmlFor="useAllTools" className="text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                {t('form.tools.useAllTools')}
+              </label>
+            </div>
+            {!useAllTools && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="w-full justify-between" disabled={isPending}>
+                    <span className={selectedTools.length === 0 ? 'font-normal text-muted-foreground' : ''}>
+                      {selectedTools.length > 0
+                        ? `${selectedTools.length} tool${selectedTools.length > 1 ? 's' : ''} selected`
+                        : t('form.tools.placeholder')}
+                    </span>
+                    <ChevronDownIcon className="h-4 w-4 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-full min-w-[400px]" align="start">
+                  <DropdownMenuLabel>Available Tools</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <TooltipProvider>
+                    {availableTools.map((tool) => (
+                      <DropdownMenuCheckboxItem
+                        key={tool.name}
+                        checked={selectedTools.includes(tool.name)}
+                        onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
+                        onSelect={(e) => e.preventDefault()}
+                      >
+                        <div className="flex flex-col">
+                          <span className="font-medium">{tool.name}</span>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-sm text-gray-500 cursor-help max-w-lg overflow-hidden text-ellipsis whitespace-nowrap block">
+                                {tool.description}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom" className="max-w-md">
+                              <p className="whitespace-pre-wrap break-words">{tool.description}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </TooltipProvider>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.tools.description')}</p>
+          </div>
+
+          {/* MCP Config */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {t('form.mcpConfig.label')}
+              </label>
+              {mcpAdvanced && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={formatJsonConfig}
+                  disabled={isPending}
+                  className="flex items-center gap-1 text-xs"
+                >
+                  <WandIcon className="h-3 w-3" />
+                  {t('form.mcpConfig.formatJson')}
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-full min-w-[400px]" align="start">
-                <DropdownMenuLabel>Available Tools</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <TooltipProvider>
-                  {availableTools.map((tool) => (
-                    <DropdownMenuCheckboxItem
-                      key={tool.name}
-                      checked={selectedTools.includes(tool.name)}
-                      onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
-                      onSelect={(e) => e.preventDefault()}
-                    >
-                      <div className="flex flex-col">
-                        <span className="font-medium">{tool.name}</span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="text-sm text-gray-500 cursor-help max-w-lg overflow-hidden text-ellipsis whitespace-nowrap block">
-                              {tool.description}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" className="max-w-md">
-                            <p className="whitespace-pre-wrap break-words">{tool.description}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                    </DropdownMenuCheckboxItem>
-                  ))}
-                </TooltipProvider>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.tools.description')}</p>
-        </div>
-
-        {/* MCP Config */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              {t('form.mcpConfig.label')}
-            </label>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={formatJsonConfig}
-              disabled={isPending}
-              className="flex items-center gap-1 text-xs"
-            >
-              <WandIcon className="h-3 w-3" />
-              {t('form.mcpConfig.formatJson')}
-            </Button>
-          </div>
-          <textarea
-            {...register('mcpConfig')}
-            placeholder={t('form.mcpConfig.placeholder')}
-            disabled={isPending}
-            rows={4}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical font-mono text-sm"
-          />
-          {formState.errors.mcpConfig && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.mcpConfig.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.mcpConfig.description')}</p>
-        </div>
-
-        {/* Runtime Type */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('form.runtimeType.label')}
-          </label>
-          <FormField
-            name="runtimeType"
-            control={control}
-            render={({ field }) => (
-              <Select value={field.value} onValueChange={field.onChange} disabled={isPending}>
-                <FormControl>
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={t('form.runtimeType.placeholder')} />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="agent-core">AgentCore Runtime</SelectItem>
-                  <SelectItem value="ec2">EC2</SelectItem>
-                </SelectContent>
-              </Select>
+              )}
+            </div>
+            {!mcpAdvanced ? (
+              <div>
+                {mcpRows.length === 0 && (
+                  <p className="text-sm text-gray-400 dark:text-gray-500 mb-2">{t('form.mcpConfig.noServers')}</p>
+                )}
+                {mcpRows.map((row, i) => (
+                  <div
+                    key={i}
+                    className="flex flex-col sm:flex-row gap-2 mb-2 p-3 sm:p-0 border sm:border-0 border-gray-200 dark:border-gray-700 rounded-md"
+                  >
+                    <Input
+                      type="text"
+                      value={row.name}
+                      placeholder={t('form.mcpConfig.serverNamePlaceholder')}
+                      disabled={isPending}
+                      onChange={(e) =>
+                        applyMcpRows(mcpRows.map((r, j) => (j === i ? { ...r, name: e.target.value } : r)))
+                      }
+                      className="sm:flex-1"
+                    />
+                    <Input
+                      type="text"
+                      value={row.command}
+                      placeholder={t('form.mcpConfig.commandPlaceholder')}
+                      disabled={isPending}
+                      onChange={(e) =>
+                        applyMcpRows(mcpRows.map((r, j) => (j === i ? { ...r, command: e.target.value } : r)))
+                      }
+                      className="sm:flex-1"
+                    />
+                    <div className="flex gap-2 sm:flex-[2]">
+                      <Input
+                        type="text"
+                        value={row.args}
+                        placeholder={t('form.mcpConfig.argsPlaceholder')}
+                        disabled={isPending}
+                        onChange={(e) =>
+                          applyMcpRows(mcpRows.map((r, j) => (j === i ? { ...r, args: e.target.value } : r)))
+                        }
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        disabled={isPending}
+                        aria-label={t('form.mcpConfig.removeServer')}
+                        onClick={() => applyMcpRows(mcpRows.filter((_, j) => j !== i))}
+                        className="flex-shrink-0 text-gray-500 hover:text-red-600 dark:hover:text-red-400"
+                      >
+                        <XIcon className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => applyMcpRows([...mcpRows, { name: '', command: '', args: '' }])}
+                  className="flex items-center gap-1.5"
+                >
+                  <PlusIcon className="h-4 w-4" />
+                  {t('form.mcpConfig.addServer')}
+                </Button>
+                {duplicateMcpNames.length > 0 && (
+                  <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                    {t('form.mcpConfig.duplicateNames', { names: duplicateMcpNames.join(', ') })}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <textarea
+                {...register('mcpConfig')}
+                placeholder={t('form.mcpConfig.placeholder')}
+                disabled={isPending}
+                rows={8}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-vertical font-mono text-sm"
+              />
             )}
-          />
-          {formState.errors.runtimeType && (
-            <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.runtimeType.message}</p>
-          )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.runtimeType.description')}</p>
-        </div>
+            {formState.errors.mcpConfig && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.mcpConfig.message}</p>
+            )}
+            <div className="flex items-center gap-2 mt-3">
+              <Checkbox
+                id="mcpAdvanced"
+                checked={mcpAdvanced}
+                onCheckedChange={(checked) => handleMcpAdvancedToggle(checked === true)}
+                disabled={isPending}
+              />
+              <label htmlFor="mcpAdvanced" className="text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                {t('form.mcpConfig.advancedToggle')}
+              </label>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.mcpConfig.description')}</p>
+          </div>
+        </FormSection>
+
+        <FormSection
+          step="5"
+          title={t('form.sections.runtime.title')}
+          description={t('form.sections.runtime.description')}
+        >
+          {/* Runtime Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              {t('form.runtimeType.label')}
+            </label>
+            <FormField
+              name="runtimeType"
+              control={control}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange} disabled={isPending}>
+                  <FormControl>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder={t('form.runtimeType.placeholder')} />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="agent-core">AgentCore Runtime</SelectItem>
+                    <SelectItem value="ec2">EC2</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {formState.errors.runtimeType && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{formState.errors.runtimeType.message}</p>
+            )}
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('form.runtimeType.description')}</p>
+          </div>
+        </FormSection>
 
         {/* Action Buttons */}
-        <div className="flex justify-end gap-3">
+        <div className="flex justify-end gap-3 pt-2">
           {isEditing && (
             <Button
               type="button"

--- a/packages/webapp/src/app/custom-agent/components/CustomAgentList.tsx
+++ b/packages/webapp/src/app/custom-agent/components/CustomAgentList.tsx
@@ -1,95 +1,44 @@
-'use client';
-
-import { useState } from 'react';
-import { useTranslations, useLocale } from 'next-intl';
-import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import Link from 'next/link';
+import { ChevronRightIcon } from 'lucide-react';
 import type { CustomAgent } from '@remote-swe-agents/agent-core/schema';
-import { mcpConfigSchema } from '@remote-swe-agents/agent-core/schema';
-import CustomAgentForm from './CustomAgentForm';
 import AgentIconPreview from './AgentIconPreview';
-import { formatDate } from '@/lib/utils';
+import AgentBadges from './AgentBadges';
+import DuplicateAgentButton from './DuplicateAgentButton';
+import LocalDateTime from '@/components/LocalDateTime';
 
 type CustomAgentListProps = {
-  initialAgents: CustomAgent[];
-  availableTools: { name: string; description: string }[];
+  agents: CustomAgent[];
+  subAgentCounts: Record<string, number>;
 };
 
-export default function CustomAgentList({ initialAgents, availableTools }: CustomAgentListProps) {
-  const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
-  const locale = useLocale();
-  const localeForDate = locale === 'ja' ? 'ja-JP' : 'en-US';
-
-  const handleCardClick = (agentId: string) => {
-    setExpandedAgentId(expandedAgentId === agentId ? null : agentId);
-  };
-
-  const handleAgentUpdate = () => {
-    // setExpandedAgentId(null);
-    // TODO: Refresh agents list
-  };
-
+export default function CustomAgentList({ agents, subAgentCounts }: CustomAgentListProps) {
   return (
     <div className="space-y-4">
-      {initialAgents.map((agent: CustomAgent) => {
-        let mcpServersCount = 0;
-        try {
-          const parsedMcpConfig = mcpConfigSchema.parse(JSON.parse(agent.mcpConfig));
-          mcpServersCount = Object.keys(parsedMcpConfig.mcpServers).length;
-        } catch {
-          // Ignore parsing errors
-        }
-
-        return (
-          <div
-            key={agent.SK}
-            className="border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"
-          >
-            <div
-              className="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-              onClick={() => handleCardClick(agent.SK)}
-            >
-              <div className="flex justify-between items-start mb-2">
-                <div className="flex items-center gap-3 flex-wrap">
-                  <AgentIconPreview iconKey={agent.iconKey} size={32} />
-                  <h3 className="text-lg font-semibold">{agent.name}</h3>
-                  <div className="flex gap-2 flex-wrap">
-                    <span className="px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
-                      {agent.defaultModel}
-                    </span>
-                    <span className="px-2 py-1 text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded">
-                      {agent.runtimeType}
-                    </span>
-                    <span className="px-2 py-1 text-xs bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded">
-                      Tools: {agent.useAllTools ? 'All' : agent.tools.length}
-                    </span>
-                    {mcpServersCount > 0 && (
-                      <span className="px-2 py-1 text-xs bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-200 rounded">
-                        MCP: {mcpServersCount}
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    {formatDate(new Date(agent.createdAt), localeForDate)}
-                  </span>
-                  {expandedAgentId === agent.SK ? (
-                    <ChevronUpIcon className="h-4 w-4 text-gray-500" />
-                  ) : (
-                    <ChevronDownIcon className="h-4 w-4 text-gray-500" />
-                  )}
-                </div>
+      {agents.map((agent) => (
+        <Link
+          key={agent.SK}
+          href={`/custom-agent/${encodeURIComponent(agent.SK)}`}
+          className="block border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+        >
+          <div className="p-4">
+            <div className="flex justify-between items-start mb-2 gap-2">
+              <div className="flex items-center gap-3 flex-wrap min-w-0">
+                <AgentIconPreview iconKey={agent.iconKey} size={32} />
+                <h3 className="text-lg font-semibold">{agent.name}</h3>
+                <AgentBadges agent={agent} subAgentsCount={subAgentCounts[agent.SK]} />
               </div>
-              <p className="text-gray-600 dark:text-gray-400">{agent.description}</p>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+                  <LocalDateTime timestamp={agent.createdAt} format="date" />
+                </span>
+                <DuplicateAgentButton agentId={agent.SK} />
+                <ChevronRightIcon className="h-4 w-4 text-gray-500" />
+              </div>
             </div>
-            {expandedAgentId === agent.SK && (
-              <div className="border-t border-gray-200 dark:border-gray-700 p-4">
-                <CustomAgentForm availableTools={availableTools} editingAgent={agent} onSuccess={handleAgentUpdate} />
-              </div>
-            )}
+            <p className="text-gray-600 dark:text-gray-400">{agent.description}</p>
           </div>
-        );
-      })}
+        </Link>
+      ))}
     </div>
   );
 }

--- a/packages/webapp/src/app/custom-agent/components/DeleteSuccessToast.tsx
+++ b/packages/webapp/src/app/custom-agent/components/DeleteSuccessToast.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+
+/**
+ * Shows the deleteSuccess toast after a custom agent is deleted from its detail
+ * page. Deletion there uses a server-side redirect('/custom-agent?deleted=1')
+ * to avoid the revalidate/notFound 404 race, which means the client onSuccess
+ * (and its toast) never runs. This listener restores that feedback by reading
+ * the ?deleted=1 marker on the list page, then cleans it from the URL.
+ */
+export default function DeleteSuccessToast() {
+  const t = useTranslations('customAgent');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (searchParams.get('deleted') === '1' && !shown.current) {
+      shown.current = true;
+      toast.success(t('deleteSuccess'));
+      router.replace('/custom-agent');
+    }
+  }, [searchParams, router, t]);
+
+  return null;
+}

--- a/packages/webapp/src/app/custom-agent/components/DuplicateAgentButton.tsx
+++ b/packages/webapp/src/app/custom-agent/components/DuplicateAgentButton.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useAction } from 'next-safe-action/hooks';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { CopyIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { duplicateCustomAgentAction } from '../actions';
+
+type DuplicateAgentButtonProps = {
+  agentId: string;
+  variant?: 'icon' | 'labeled';
+};
+
+export default function DuplicateAgentButton({ agentId, variant = 'icon' }: DuplicateAgentButtonProps) {
+  const t = useTranslations('customAgent');
+  const router = useRouter();
+  const { execute, isPending } = useAction(duplicateCustomAgentAction, {
+    onSuccess: () => {
+      toast.success(t('duplicateSuccess'));
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      const errorMessage = typeof error === 'string' ? error : t('duplicateError');
+      toast.error(errorMessage);
+    },
+  });
+
+  if (variant === 'labeled') {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={() => execute({ id: agentId })}
+        className="flex items-center gap-1.5"
+      >
+        <CopyIcon className="h-4 w-4" />
+        {t('duplicate')}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      disabled={isPending}
+      aria-label={t('duplicate')}
+      title={t('duplicate')}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        execute({ id: agentId });
+      }}
+      className="h-8 w-8 text-gray-500 hover:text-gray-900 dark:hover:text-white"
+    >
+      <CopyIcon className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/packages/webapp/src/app/custom-agent/components/delete-navigation.test.ts
+++ b/packages/webapp/src/app/custom-agent/components/delete-navigation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest';
+import { runDeleteSuccessNavigation } from './delete-navigation';
+
+describe('runDeleteSuccessNavigation', () => {
+  test('when onDeleted is provided: it is called once and refresh is NOT called', () => {
+    const refresh = vi.fn();
+    const onDeleted = vi.fn();
+    const onSuccess = vi.fn();
+
+    runDeleteSuccessNavigation({ refresh }, { onDeleted, onSuccess });
+
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  test('when onDeleted is absent: refresh is called and onSuccess is invoked', () => {
+    const refresh = vi.fn();
+    const onSuccess = vi.fn();
+
+    runDeleteSuccessNavigation({ refresh }, { onSuccess });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('when onDeleted is absent and onSuccess is also absent: refresh is called without throwing', () => {
+    const refresh = vi.fn();
+
+    expect(() => runDeleteSuccessNavigation({ refresh }, {})).not.toThrow();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webapp/src/app/custom-agent/components/delete-navigation.ts
+++ b/packages/webapp/src/app/custom-agent/components/delete-navigation.ts
@@ -1,0 +1,34 @@
+type DeleteSuccessRouter = {
+  refresh: () => void;
+};
+
+type DeleteSuccessNavigationOptions = {
+  onDeleted?: () => void;
+  onSuccess?: () => void;
+};
+
+/**
+ * Navigation performed after a custom agent is successfully deleted.
+ *
+ * When `onDeleted` is provided (e.g. the detail page, which owns the route of
+ * the agent being deleted), the caller is responsible for navigating away.
+ * Refreshing the current route would re-render the now-deleted agent's
+ * force-dynamic page and trigger notFound() -> 404, so we must NOT call
+ * router.refresh() in that case.
+ *
+ * When `onDeleted` is absent (e.g. sub-agent deletion, where the parent detail
+ * page still exists), we keep the historical behavior: refresh the current
+ * route and invoke `onSuccess`.
+ */
+export function runDeleteSuccessNavigation(
+  router: DeleteSuccessRouter,
+  { onDeleted, onSuccess }: DeleteSuccessNavigationOptions
+): void {
+  if (onDeleted) {
+    onDeleted();
+    return;
+  }
+
+  router.refresh();
+  onSuccess?.();
+}

--- a/packages/webapp/src/app/custom-agent/page.tsx
+++ b/packages/webapp/src/app/custom-agent/page.tsx
@@ -1,7 +1,9 @@
+import { Suspense } from 'react';
 import HeaderWithPreferences from '@/components/HeaderWithPreferences';
 import { getTranslations } from 'next-intl/server';
 import CustomAgentForm from './components/CustomAgentForm';
 import CustomAgentList from './components/CustomAgentList';
+import DeleteSuccessToast from './components/DeleteSuccessToast';
 import PreferenceSection from '../preferences/components/PreferenceSection';
 import { optionalTools } from '@remote-swe-agents/agent-core/tools';
 import { getCustomAgents } from '@remote-swe-agents/agent-core/lib';
@@ -20,9 +22,17 @@ export default async function CustomAgentPage() {
     getCustomAgents(),
   ]);
 
+  const topLevelAgents = customAgents.filter((agent) => !agent.parentAgentId);
+  const subAgentCounts = Object.fromEntries(
+    topLevelAgents.map((agent) => [agent.SK, customAgents.filter((a) => a.parentAgentId === agent.SK).length])
+  );
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       <HeaderWithPreferences />
+      <Suspense fallback={null}>
+        <DeleteSuccessToast />
+      </Suspense>
 
       <main className="flex-grow container max-w-6xl mx-auto px-4 py-6 pt-20">
         <div className="mb-6">
@@ -31,9 +41,9 @@ export default async function CustomAgentPage() {
         </div>
 
         <div className="space-y-6">
-          {customAgents.length > 0 && (
+          {topLevelAgents.length > 0 && (
             <PreferenceSection title={t('list.title')} description={t('list.description')}>
-              <CustomAgentList initialAgents={customAgents} availableTools={availableTools} />
+              <CustomAgentList agents={topLevelAgents} subAgentCounts={subAgentCounts} />
             </PreferenceSection>
           )}
 

--- a/packages/webapp/src/app/custom-agent/schemas.ts
+++ b/packages/webapp/src/app/custom-agent/schemas.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
-import { mcpConfigSchema, modelTypeSchema } from '@remote-swe-agents/agent-core/schema';
+import {
+  inferenceModeSchema,
+  kiroModelSchema,
+  mcpConfigSchema,
+  modelTypeSchema,
+} from '@remote-swe-agents/agent-core/schema';
 
 export const upsertCustomAgentSchema = z.object({
   id: z.string().optional(),
   name: z.string().min(1, 'Agent name is required').max(100, 'Agent name must be less than 100 characters'),
   description: z.string().default(''),
   defaultModel: modelTypeSchema,
+  bedrockDefaultModel: modelTypeSchema.optional(),
+  kiroDefaultModel: kiroModelSchema.optional(),
   systemPrompt: z.string().default(''),
   tools: z.array(z.string()),
   useAllTools: z.boolean().optional().default(false),
@@ -26,8 +33,21 @@ export const upsertCustomAgentSchema = z.object({
   runtimeType: z.union([z.literal('ec2'), z.literal('agent-core')]),
   iconKey: z.string().optional().default(''),
   includeDefaultKnowledge: z.boolean().optional().default(true),
+  inferenceMode: inferenceModeSchema.nullable().optional(),
+  kiroModel: z.string().optional(),
+  parentAgentId: z.string().optional(),
 });
 
 export const deleteCustomAgentSchema = z.object({
+  id: z.string().min(1, 'Agent ID is required'),
+  // When true, the server action redirects to the custom-agent list after a
+  // successful delete. The destination is decided server-side (a hardcoded
+  // path) — this is a boolean flag, never a client-supplied path, to avoid
+  // open-redirect. Used by the detail page (which owns the deleted route) to
+  // avoid the revalidate/notFound 404 race.
+  redirectToListOnSuccess: z.boolean().optional().default(false),
+});
+
+export const duplicateCustomAgentSchema = z.object({
   id: z.string().min(1, 'Agent ID is required'),
 });

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -37,7 +37,8 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
   const isMsg = (toolName: string | undefined) =>
     ['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendFileToUser'].includes(toolName ?? '');
   const isHiddenTool = (toolName: string | undefined) =>
-    isMsg(toolName) || ['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser'].includes(toolName ?? '');
+    isMsg(toolName) ||
+    ['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser', 'confirmCompleteSession'].includes(toolName ?? '');
 
   // Collect all completed toolUseIds from toolResult messages
   const completedToolUseIds = new Set<string>();

--- a/packages/webapp/src/lib/agent-icon-presets.ts
+++ b/packages/webapp/src/lib/agent-icon-presets.ts
@@ -1,0 +1,90 @@
+export const PRESET_ICON_PREFIX = 'preset:';
+
+export type PresetIcon = {
+  id: string;
+  label: string;
+  color: string;
+  paths: string[];
+};
+
+export const presetIcons: PresetIcon[] = [
+  {
+    id: 'robot',
+    label: 'Agent',
+    color: '#2563eb',
+    paths: ['M12 8V4H8', 'M4 8h16v12H4z', 'M2 14h2', 'M20 14h2', 'M15 13v2', 'M9 13v2'],
+  },
+  {
+    id: 'runtime',
+    label: 'Runtime',
+    color: '#7c3aed',
+    paths: [
+      'M4 4h16v16H4z',
+      'M9 9h6v6H9z',
+      'M15 2v2',
+      'M15 20v2',
+      'M2 15h2',
+      'M2 9h2',
+      'M20 15h2',
+      'M20 9h2',
+      'M9 2v2',
+      'M9 20v2',
+    ],
+  },
+  {
+    id: 'compute',
+    label: 'Compute',
+    color: '#f97316',
+    paths: ['M2 2h20v8H2z', 'M2 14h20v8H2z', 'M6 6h.01', 'M6 18h.01'],
+  },
+  {
+    id: 'database',
+    label: 'Database',
+    color: '#0284c7',
+    paths: [
+      'M3 5c0-1.7 4-3 9-3s9 1.3 9 3-4 3-9 3-9-1.3-9-3',
+      'M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5',
+      'M3 12c0 1.7 4 3 9 3s9-1.3 9-3',
+    ],
+  },
+  {
+    id: 'cloud',
+    label: 'Cloud',
+    color: '#0d9488',
+    paths: ['M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z'],
+  },
+  {
+    id: 'terminal',
+    label: 'CLI',
+    color: '#374151',
+    paths: ['m4 17 6-6-6-6', 'M12 19h8'],
+  },
+  {
+    id: 'web',
+    label: 'Web',
+    color: '#059669',
+    paths: ['M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20', 'M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20', 'M2 12h20'],
+  },
+  {
+    id: 'docs',
+    label: 'Docs',
+    color: '#e11d48',
+    paths: ['M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20'],
+  },
+];
+
+export const isPresetIconKey = (iconKey: string | undefined): boolean =>
+  Boolean(iconKey && iconKey.startsWith(PRESET_ICON_PREFIX));
+
+export const getPresetIcon = (iconKey: string): PresetIcon | undefined =>
+  presetIcons.find((p) => `${PRESET_ICON_PREFIX}${p.id}` === iconKey);
+
+export const presetIconSvg = (preset: PresetIcon, size: number): string => {
+  const inner = preset.paths.map((d) => `<path d="${d}"/>`).join('');
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 48 48">` +
+    `<circle cx="24" cy="24" r="24" fill="${preset.color}"/>` +
+    `<g transform="translate(12 12)" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${inner}</g>` +
+    `</svg>`
+  );
+};

--- a/packages/webapp/src/lib/session-list.ts
+++ b/packages/webapp/src/lib/session-list.ts
@@ -1,0 +1,50 @@
+import { SessionItem } from '@remote-swe-agents/agent-core/schema';
+import { extractUserMessage } from './message-formatter';
+
+/**
+ * Maximum length of the initialMessage preview shipped to the client.
+ * Session list surfaces render at most a single truncated line
+ * (`lastMessage || initialMessagePreview`), so anything beyond this length
+ * is never displayed.
+ */
+export const SESSION_PREVIEW_MAX_LENGTH = 200;
+
+/**
+ * A SessionItem shrunk for list/sidebar rendering. The full `initialMessage`
+ * is replaced by `initialMessagePreview` so the type system distinguishes
+ * "already truncated for display" from the raw DB item — code that needs the
+ * full message cannot accidentally receive a truncated one.
+ */
+export type SessionListItem = Omit<SessionItem, 'initialMessage'> & {
+  initialMessagePreview: string;
+};
+
+/**
+ * Extract the user-visible part of an initial message and truncate it to the
+ * preview length. Shared by every SSR surface that serializes a one-line
+ * session preview (sessions list, sidebar, cost page, custom agent page).
+ */
+export function toInitialMessagePreview(initialMessage: string): string {
+  return extractUserMessage(initialMessage).slice(0, SESSION_PREVIEW_MAX_LENGTH);
+}
+
+/**
+ * Shrink a SessionItem for list/sidebar rendering.
+ *
+ * `initialMessage` can be several KB per session (full task prompts). With
+ * hundreds of sessions this dominated the /sessions RSC payload (~85% of
+ * ~3MB measured in prod), making the page unusable on slow mobile networks.
+ * The list UI only needs a one-line preview, so we extract the user-visible
+ * part server-side and truncate it before the item crosses the RSC boundary.
+ */
+export function toSessionListItem(session: SessionItem): SessionListItem {
+  const { initialMessage, ...rest } = session;
+  return {
+    ...rest,
+    initialMessagePreview: toInitialMessagePreview(initialMessage),
+  };
+}
+
+export function toSessionListItems(sessions: SessionItem[]): SessionListItem[] {
+  return sessions.map(toSessionListItem);
+}

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -413,7 +413,37 @@
         "label": "Agent Icon",
         "description": "Upload a custom icon for this agent (PNG, JPEG, or WebP)"
       }
-    }
+    },
+    "duplicate": "Duplicate",
+    "duplicateSuccess": "Custom agent duplicated successfully",
+    "duplicateError": "Failed to duplicate custom agent",
+    "detail": {
+      "backToList": "Back to Custom Agents",
+      "title": "Agent Details",
+      "description": "Configuration of this custom agent",
+      "edit": "Edit",
+      "activeModel": "Active",
+      "allToolsEnabled": "All tools enabled",
+      "toolsSelected": "{count} tools selected",
+      "mcpConfigured": "{count} configured",
+      "mcpNone": "None",
+      "included": "Included",
+      "excluded": "Excluded",
+      "createdAt": "Created",
+      "usage": {
+        "title": "Usage",
+        "description": "Sessions run by this agent",
+        "recentSessionCount": "sessions among the {limit} most recent",
+        "recentSessions": "Recent sessions",
+        "noSessions": "No recent sessions for this agent."
+      },
+      "subAgents": {
+        "title": "Sub-agents",
+        "description": "Agents that work under {name}",
+        "empty": "This agent has no sub-agents."
+      }
+    },
+    "copySuffix": "(copy)"
   },
   "notifications": {
     "enable": "Enable push notifications",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -412,7 +412,37 @@
         "label": "エージェントアイコン",
         "description": "エージェントのカスタムアイコンをアップロード（PNG、JPEG、WebP）"
       }
-    }
+    },
+    "duplicate": "複製",
+    "duplicateSuccess": "カスタムエージェントを複製しました",
+    "duplicateError": "カスタムエージェントの複製に失敗しました",
+    "detail": {
+      "backToList": "カスタムエージェント一覧に戻る",
+      "title": "エージェント詳細",
+      "description": "このカスタムエージェントの設定",
+      "edit": "編集",
+      "activeModel": "有効",
+      "allToolsEnabled": "全ツール有効",
+      "toolsSelected": "{count} 個のツールを選択中",
+      "mcpConfigured": "{count} 件設定済み",
+      "mcpNone": "なし",
+      "included": "含む",
+      "excluded": "含まない",
+      "createdAt": "作成日",
+      "usage": {
+        "title": "使用状況",
+        "description": "このエージェントが実行したセッション",
+        "recentSessionCount": "セッション（直近 {limit} 件中）",
+        "recentSessions": "最近のセッション",
+        "noSessions": "このエージェントの最近のセッションはありません。"
+      },
+      "subAgents": {
+        "title": "サブエージェント",
+        "description": "{name} の配下で動作するエージェント",
+        "empty": "このエージェントにサブエージェントはありません。"
+      }
+    },
+    "copySuffix": "(コピー)"
   },
   "notifications": {
     "enable": "プッシュ通知を有効にする",


### PR DESCRIPTION
## Summary
Evolves custom agent management: `parentAgentId` sub-agents (hidden from top-level selection), partial-update semantics for updateAgent, a creation confirmation gate for top-level agents, and a full agent detail page in the webapp.

## Motivation
Multi-agent setups need sub-agents that belong to a coordinator without cluttering the top-level agent picker, and agent creation is consequential enough (affects all future sessions) to deserve an explicit confirm step.

## Changes
- agent-core: `parentAgentId` on the agent schema; `updateAgent` supports partial updates (omitted fields keep existing values); `confirmCreateAgent` gate registered in requiredTools and the MCP selection
- webapp: agent form with model fields (Bedrock + Kiro), custom-agent detail page cluster (AgentDetailCard / SubAgentList / DuplicateAgentButton / AgentIconPicker + icon presets + `/api/agent-icon`)
- Supporting helpers: LocalDateTime + useMounted, session-list preview helpers, `getHeadFromKey` (agent-core S3)

## Testing
- agent-core: `tsc` clean, vitest green, prettier check clean
- webapp: `next build` succeeds, `tsc --noEmit` clean; ported page tests run standalone

## Notes
- Depends on: #5 in this series (`feat/mcp-server-…`), already merged (independent of #6, can be opened in parallel with it).
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
