### PR TITLE
feat(webapp): Kiro CLI inference mode UI

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -19,6 +19,7 @@ import { IRepository } from 'aws-cdk-lib/aws-ecr';
 import { VapidKeys } from './constructs/vapid-keys';
 import { Preview } from './constructs/preview';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { UserParamsCleaner } from './constructs/user-params-cleaner';
 
 export interface MainStackProps extends cdk.StackProps {
   readonly signPayloadHandler: EdgeFunction;
@@ -150,6 +151,11 @@ export class MainStack extends cdk.Stack {
           proxyCodeDirectory: join(__dirname, '../../packages/microvm-preview-proxy'),
         })
       : undefined;
+    // Sweep runtime-created per-user SSM parameters (e.g. Kiro API keys) on
+    // stack deletion. They are created by the webapp via `ssm:PutParameter`,
+    // outside of CloudFormation's lifecycle, so they would otherwise leak
+    // after `cdk destroy`.
+    new UserParamsCleaner(this, 'UserParamsCleaner');
 
     const kiroApiKeyParameter = props.kiroApiKeyParameterName
       ? StringParameter.fromStringParameterAttributes(this, 'KiroApiKey', {

--- a/cdk/lib/constructs/user-params-cleaner/index.ts
+++ b/cdk/lib/constructs/user-params-cleaner/index.ts
@@ -1,0 +1,122 @@
+import { Construct } from 'constructs';
+import { Arn, ArnFormat, CustomResource, Duration, Stack } from 'aws-cdk-lib';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Runtime, Code, SingletonFunction } from 'aws-cdk-lib/aws-lambda';
+import { Provider } from 'aws-cdk-lib/custom-resources';
+
+/**
+ * Cleans up SSM Parameters created at runtime under `/${stackName}/users/` on stack deletion.
+ *
+ * The webapp Lambda creates per-user SSM Parameters (e.g. Kiro API keys) at runtime via
+ * `ssm:PutParameter`. These parameters are not managed by CloudFormation, so they are left
+ * behind after `cdk destroy`, polluting the SSM namespace. This construct installs a
+ * Custom Resource whose `onDelete` hook sweeps those parameters.
+ *
+ * Create/Update events are no-ops. The cleanup is best-effort: failures are logged but
+ * never block the stack deletion.
+ */
+export class UserParamsCleaner extends Construct {
+  public readonly customResource: CustomResource;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const stackName = Stack.of(this).stackName;
+    const pathPrefix = `/${stackName}/users/`;
+
+    const userParamsArn = Arn.format(
+      {
+        service: 'ssm',
+        resource: 'parameter',
+        resourceName: `${stackName}/users/*`,
+        arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+      },
+      Stack.of(this)
+    );
+
+    const handler = new SingletonFunction(this, 'Handler', {
+      uuid: 'user-params-cleaner-singleton',
+      runtime: Runtime.NODEJS_22_X,
+      handler: 'index.handler',
+      code: Code.fromInline(`
+const { SSMClient, GetParametersByPathCommand, DeleteParametersCommand } = require('@aws-sdk/client-ssm');
+
+exports.handler = async (event) => {
+  const physicalResourceId = event.PhysicalResourceId || 'user-params-cleaner';
+
+  // Create and Update are no-ops. Cleanup runs only on stack deletion.
+  if (event.RequestType !== 'Delete') {
+    return { PhysicalResourceId: physicalResourceId };
+  }
+
+  const pathPrefix = event.ResourceProperties.PathPrefix;
+  const ssm = new SSMClient({});
+
+  console.log('Starting cleanup under path: ' + pathPrefix);
+
+  const names = [];
+  let nextToken;
+  try {
+    do {
+      const resp = await ssm.send(new GetParametersByPathCommand({
+        Path: pathPrefix,
+        Recursive: true,
+        MaxResults: 10,
+        NextToken: nextToken,
+      }));
+      for (const p of resp.Parameters || []) {
+        if (p.Name) names.push(p.Name);
+      }
+      nextToken = resp.NextToken;
+    } while (nextToken);
+  } catch (err) {
+    // Best-effort cleanup: never block stack deletion.
+    console.error('Failed to list parameters. Skipping cleanup.', err);
+    return { PhysicalResourceId: physicalResourceId };
+  }
+
+  console.log('Found ' + names.length + ' parameter(s) to delete');
+
+  // DeleteParameters accepts at most 10 names per request.
+  for (let i = 0; i < names.length; i += 10) {
+    const batch = names.slice(i, i + 10);
+    try {
+      const resp = await ssm.send(new DeleteParametersCommand({ Names: batch }));
+      if (resp.DeletedParameters && resp.DeletedParameters.length > 0) {
+        console.log('Deleted: ' + resp.DeletedParameters.join(', '));
+      }
+      if (resp.InvalidParameters && resp.InvalidParameters.length > 0) {
+        // Already gone or inaccessible. Treated as expected.
+        console.warn('Skipped (not found or invalid): ' + resp.InvalidParameters.join(', '));
+      }
+    } catch (err) {
+      // Continue with remaining batches even if one fails.
+      console.error('Failed to delete batch: ' + batch.join(', '), err);
+    }
+  }
+
+  return { PhysicalResourceId: physicalResourceId };
+};
+      `),
+      timeout: Duration.minutes(5),
+    });
+
+    handler.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['ssm:GetParametersByPath', 'ssm:DeleteParameters'],
+        resources: [userParamsArn],
+      })
+    );
+
+    const provider = new Provider(this, 'Provider', {
+      onEventHandler: handler,
+    });
+
+    this.customResource = new CustomResource(this, 'Resource', {
+      serviceToken: provider.serviceToken,
+      properties: {
+        PathPrefix: pathPrefix,
+      },
+    });
+  }
+}

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -1,4 +1,4 @@
-import { IgnoreMode, Duration, CfnOutput, Stack } from 'aws-cdk-lib';
+import { IgnoreMode, Duration, CfnOutput, Stack, Arn, ArnFormat } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { DockerImageFunction, DockerImageCode, Architecture } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
@@ -102,11 +102,30 @@ export class Webapp extends Construct {
               VAPID_PRIVATE_KEY_PARAMETER_NAME: props.vapidKeys.privateKeyParameter.parameterName,
             }
           : {}),
+        STACK_NAME: Stack.of(this).stackName,
       },
       memorySize: 1769,
       architecture: Architecture.ARM_64,
     });
     props.workerAmiIdParameter.grantRead(handler);
+
+    // Grant SSM access for per-user Kiro API keys
+    handler.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['ssm:GetParameter', 'ssm:PutParameter', 'ssm:DeleteParameter'],
+        resources: [
+          Arn.format(
+            {
+              service: 'ssm',
+              resource: 'parameter',
+              resourceName: `${Stack.of(this).stackName}/users/*/kiro-api-key`,
+              arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            },
+            Stack.of(this)
+          ),
+        ],
+      })
+    );
     asyncJob.handler.grantInvoke(handler);
     storage.table.grantReadWriteData(handler);
     storage.bucket.grantReadWrite(handler);

--- a/cdk/lib/constructs/worker/agent-core-runtime.ts
+++ b/cdk/lib/constructs/worker/agent-core-runtime.ts
@@ -122,33 +122,28 @@ export class AgentCoreRuntime extends Construct implements IGrantable {
     props.vapidKeys.grantRead(role);
     props.bus.api.grantPublishAndSubscribe(role);
     props.bus.api.grantConnect(role);
-    // Kiro CLI inference mode wiring. Fully inert unless the stack opts in:
-    // when neither a Kiro API key parameter nor an inference mode is
-    // configured, no grant, no env var, nothing is added and the synthesized
-    // template is identical to a stack without this feature.
-    const kiroEnabled = !!(props.kiroApiKeyParameter || props.inferenceMode);
     props.kiroApiKeyParameter?.grantRead(role);
-    if (kiroEnabled) {
-      // Grant SSM read access for per-user Kiro API keys. These parameters are
-      // created outside CloudFormation (via `ssm:PutParameter` at runtime), so
-      // the grant is expressed as a wildcard on the per-user prefix.
-      role.addToPrincipalPolicy(
-        new PolicyStatement({
-          actions: ['ssm:GetParameter'],
-          resources: [
-            Arn.format(
-              {
-                service: 'ssm',
-                resource: 'parameter',
-                resourceName: `${Stack.of(this).stackName}/users/*/kiro-api-key`,
-                arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
-              },
-              Stack.of(this)
-            ),
-          ],
-        })
-      );
-    }
+    // Grant SSM read access for per-user Kiro API keys. These parameters are
+    // created at runtime by the webapp (via `ssm:PutParameter`), outside of
+    // CloudFormation, so the grant is expressed as a wildcard on the per-user
+    // prefix. Users can enable Kiro CLI mode per session from the webapp
+    // regardless of the stack-level opt-in props, so this grant is always on.
+    role.addToPrincipalPolicy(
+      new PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [
+          Arn.format(
+            {
+              service: 'ssm',
+              resource: 'parameter',
+              resourceName: `${Stack.of(this).stackName}/users/*/kiro-api-key`,
+              arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            },
+            Stack.of(this)
+          ),
+        ],
+      })
+    );
 
     // Lambda MicroVMs permissions for preview functionality
     role.addToPrincipalPolicy(
@@ -223,7 +218,7 @@ export class AgentCoreRuntime extends Construct implements IGrantable {
         ...(props.previewMicrovmImageArn ? { PREVIEW_MICROVM_IMAGE_ARN: props.previewMicrovmImageArn } : {}),
         // STACK_NAME is what the worker uses to resolve per-user Kiro API key
         // parameter paths (`/${STACK_NAME}/users/<id>/kiro-api-key`).
-        ...(kiroEnabled ? { STACK_NAME: Stack.of(this).stackName } : {}),
+        STACK_NAME: Stack.of(this).stackName,
         ...(props.kiroApiKeyParameter ? { KIRO_API_KEY_SSM_PARAM: props.kiroApiKeyParameter.parameterName } : {}),
         ...(props.inferenceMode ? { INFERENCE_MODE: props.inferenceMode } : {}),
       },

--- a/cdk/lib/constructs/worker/index.ts
+++ b/cdk/lib/constructs/worker/index.ts
@@ -239,17 +239,12 @@ export class Worker extends Construct {
     });
     const userData = launchTemplate.userData!;
 
-    // Kiro CLI inference mode wiring. Fully inert unless the stack opts in:
-    // when neither a Kiro API key parameter nor an inference mode is
-    // configured, no env line and no install step is added, keeping the
-    // rendered user data identical to a stack without this feature.
-    const kiroEnabled = !!(props.kiroApiKeyParameter || props.inferenceMode);
-    const kiroEnvironmentLines = kiroEnabled
-      ? `\nEnvironment=STACK_NAME=${Stack.of(this).stackName}\nEnvironment=INFERENCE_MODE=${props.inferenceMode ?? ''}`
-      : '';
-    const kiroInstallCommands = kiroEnabled
-      ? `\n\n# Install kiro-cli\nsudo -u ubuntu bash -c 'curl -fsSL https://cli.kiro.dev/install | bash'`
-      : '';
+    // Kiro CLI inference mode wiring. Users can enable Kiro CLI mode per
+    // session from the webapp (with a per-user API key) regardless of the
+    // stack-level opt-in props, so the CLI install and the env plumbing are
+    // always present; only the stack-wide defaults remain prop-driven.
+    const kiroEnvironmentLines = `\nEnvironment=STACK_NAME=${Stack.of(this).stackName}\nEnvironment=INFERENCE_MODE=${props.inferenceMode ?? ''}`;
+    const kiroInstallCommands = `\n\n# Install kiro-cli\nsudo -u ubuntu bash -c 'curl -fsSL https://cli.kiro.dev/install | bash'`;
 
     userData.addCommands(
       `

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2377,6 +2377,141 @@ exports.handler = async function (event, context) {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SingletonLambdauserparamscleanersingleton2877582C": {
+      "DependsOn": [
+        "SingletonLambdauserparamscleanersingletonServiceRoleDefaultPolicy3C002D1B",
+        "SingletonLambdauserparamscleanersingletonServiceRole4DDAEC8D",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "
+const { SSMClient, GetParametersByPathCommand, DeleteParametersCommand } = require('@aws-sdk/client-ssm');
+
+exports.handler = async (event) => {
+  const physicalResourceId = event.PhysicalResourceId || 'user-params-cleaner';
+
+  // Create and Update are no-ops. Cleanup runs only on stack deletion.
+  if (event.RequestType !== 'Delete') {
+    return { PhysicalResourceId: physicalResourceId };
+  }
+
+  const pathPrefix = event.ResourceProperties.PathPrefix;
+  const ssm = new SSMClient({});
+
+  console.log('Starting cleanup under path: ' + pathPrefix);
+
+  const names = [];
+  let nextToken;
+  try {
+    do {
+      const resp = await ssm.send(new GetParametersByPathCommand({
+        Path: pathPrefix,
+        Recursive: true,
+        MaxResults: 10,
+        NextToken: nextToken,
+      }));
+      for (const p of resp.Parameters || []) {
+        if (p.Name) names.push(p.Name);
+      }
+      nextToken = resp.NextToken;
+    } while (nextToken);
+  } catch (err) {
+    // Best-effort cleanup: never block stack deletion.
+    console.error('Failed to list parameters. Skipping cleanup.', err);
+    return { PhysicalResourceId: physicalResourceId };
+  }
+
+  console.log('Found ' + names.length + ' parameter(s) to delete');
+
+  // DeleteParameters accepts at most 10 names per request.
+  for (let i = 0; i < names.length; i += 10) {
+    const batch = names.slice(i, i + 10);
+    try {
+      const resp = await ssm.send(new DeleteParametersCommand({ Names: batch }));
+      if (resp.DeletedParameters && resp.DeletedParameters.length > 0) {
+        console.log('Deleted: ' + resp.DeletedParameters.join(', '));
+      }
+      if (resp.InvalidParameters && resp.InvalidParameters.length > 0) {
+        // Already gone or inaccessible. Treated as expected.
+        console.warn('Skipped (not found or invalid): ' + resp.InvalidParameters.join(', '));
+      }
+    } catch (err) {
+      // Continue with remaining batches even if one fails.
+      console.error('Failed to delete batch: ' + batch.join(', '), err);
+    }
+  }
+
+  return { PhysicalResourceId: physicalResourceId };
+};
+      ",
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "SingletonLambdauserparamscleanersingletonServiceRole4DDAEC8D",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SingletonLambdauserparamscleanersingletonServiceRole4DDAEC8D": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SingletonLambdauserparamscleanersingletonServiceRoleDefaultPolicy3C002D1B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ssm:DeleteParameters",
+                "ssm:GetParametersByPath",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/TestMainStack/users/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SingletonLambdauserparamscleanersingletonServiceRoleDefaultPolicy3C002D1B",
+        "Roles": [
+          {
+            "Ref": "SingletonLambdauserparamscleanersingletonServiceRole4DDAEC8D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SingletonLambdavapidkeygeneratorsingleton2607D629": {
       "DependsOn": [
         "SingletonLambdavapidkeygeneratorsingletonServiceRoleDefaultPolicy61E91644",
@@ -3762,6 +3897,140 @@ exports.handler = async (event) => {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "UserParamsCleaner47C9605B": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "PathPrefix": "/TestMainStack/users/",
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "UserParamsCleanerProviderframeworkonEvent690A113C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "UserParamsCleanerProviderframeworkonEvent690A113C": {
+      "DependsOn": [
+        "UserParamsCleanerProviderframeworkonEventServiceRoleDefaultPolicy41FBD0E0",
+        "UserParamsCleanerProviderframeworkonEventServiceRole761092D2",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
+          "S3Key": "REDACTED",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (TestMainStack/UserParamsCleaner/Provider)",
+        "Environment": {
+          "Variables": {
+            "USER_ON_EVENT_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "SingletonLambdauserparamscleanersingleton2877582C",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "Handler": "framework.onEvent",
+        "LoggingConfig": {
+          "ApplicationLogLevel": "FATAL",
+          "LogFormat": "JSON",
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "UserParamsCleanerProviderframeworkonEventServiceRole761092D2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs24.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "UserParamsCleanerProviderframeworkonEventServiceRole761092D2": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "UserParamsCleanerProviderframeworkonEventServiceRoleDefaultPolicy41FBD0E0": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SingletonLambdauserparamscleanersingleton2877582C",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "SingletonLambdauserparamscleanersingleton2877582C",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "lambda:GetFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SingletonLambdauserparamscleanersingleton2877582C",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "UserParamsCleanerProviderframeworkonEventServiceRoleDefaultPolicy41FBD0E0",
+        "Roles": [
+          {
+            "Ref": "UserParamsCleanerProviderframeworkonEventServiceRole761092D2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "VapidKeysD8C7EC6E": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -4552,6 +4821,7 @@ exports.handler = async (event) => {
             "SKILL_BUCKET_NAME": {
               "Ref": "StorageSkillBucket76CA6B72",
             },
+            "STACK_NAME": "TestMainStack",
             "SUBNET_ID_LIST": {
               "Fn::Join": [
                 "",
@@ -4733,6 +5003,15 @@ exports.handler = async (event) => {
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "ssm:DeleteParameter",
+                "ssm:GetParameter",
+                "ssm:PutParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/TestMainStack/users/*/kiro-api-key",
             },
             {
               "Action": "lambda:InvokeFunction",
@@ -5366,6 +5645,11 @@ exports.handler = async (event) => {
               },
             },
             {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/TestMainStack/users/*/kiro-api-key",
+            },
+            {
               "Action": [
                 "lambda-microvms:CreateMicrovmAuthToken",
                 "lambda-microvms:GetMicrovm",
@@ -5553,6 +5837,7 @@ exports.handler = async (event) => {
             "Ref": "StorageSkillBucket76CA6B72",
           },
           "SLACK_BOT_TOKEN_PARAMETER_NAME": "/remote-swe/slack/bot-token",
+          "STACK_NAME": "TestMainStack",
           "TABLE_NAME": {
             "Ref": "StorageHistory251A3AE8",
           },
@@ -6979,6 +7264,10 @@ phases:
 
               Environment=EVENT_TRIGGER_RESOURCE_PREFIX=tesger3a47e907
 
+              Environment=STACK_NAME=TestMainStack
+
+              Environment=INFERENCE_MODE=
+
 
               [Install]
 
@@ -7104,6 +7393,11 @@ phases:
               systemctl enable fluent-bit
 
               systemctl enable myapp
+
+
+              # Install kiro-cli
+
+              sudo -u ubuntu bash -c 'curl -fsSL https://cli.kiro.dev/install | bash'
 
               \\      "
   - name: validate
@@ -7808,6 +8102,10 @@ phases:
 
               Environment=EVENT_TRIGGER_RESOURCE_PREFIX=tesger3a47e907
 
+              Environment=STACK_NAME=TestMainStack
+
+              Environment=INFERENCE_MODE=
+
 
               [Install]
 
@@ -7933,6 +8231,11 @@ phases:
               systemctl enable fluent-bit
 
               systemctl enable myapp
+
+
+              # Install kiro-cli
+
+              sudo -u ubuntu bash -c 'curl -fsSL https://cli.kiro.dev/install | bash'
 
               \\      "
   - name: validate
@@ -8284,6 +8587,8 @@ Environment=EVENT_TRIGGER_TTL_SFN_ROLE_ARN=",
                   },
                   "
 Environment=EVENT_TRIGGER_RESOURCE_PREFIX=tesger3a47e907
+Environment=STACK_NAME=TestMainStack
+Environment=INFERENCE_MODE=
 
 [Install]
 WantedBy=multi-user.target
@@ -8356,6 +8661,9 @@ EOF
 systemctl daemon-reload
 systemctl enable fluent-bit
 systemctl enable myapp
+
+# Install kiro-cli
+sudo -u ubuntu bash -c 'curl -fsSL https://cli.kiro.dev/install | bash'
       
 systemctl start fluent-bit
 systemctl start myapp",

--- a/packages/agent-core/src/lib/create-session.ts
+++ b/packages/agent-core/src/lib/create-session.ts
@@ -1,7 +1,15 @@
 import { TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { ddb, TableName } from './aws';
-import { MessageItem, ModelType, RuntimeType, SessionItem, defaultAgentConfig } from '../schema';
+import {
+  InferenceMode,
+  KiroModelId,
+  MessageItem,
+  ModelType,
+  RuntimeType,
+  SessionItem,
+  defaultAgentConfig,
+} from '../schema';
 import { getOrCreateWorkerInstance, updateInstanceStatus } from './worker-manager';
 import { sendWorkerEvent } from './events';
 import { getCustomAgent } from './custom-agent';
@@ -37,6 +45,25 @@ export interface CreateSessionParams {
    * this simply records who created the session so it can send messages back.
    */
   creatorSessionId?: string;
+  /**
+   * Inference mode to bake into the session at creation time.
+   * Once set, the session uses this backend for its entire lifetime regardless of
+   * user/custom-agent preference changes. If omitted, the worker falls back to the
+   * dynamic resolution chain (customAgent > userPreferences > env > default).
+   */
+  inferenceMode?: InferenceMode;
+  /**
+   * Model selection for kiro-cli mode. Only used when inferenceMode === 'kiro-cli'.
+   */
+  kiroModel?: string;
+  /**
+   * New symmetric Bedrock model field. Takes priority over legacy `defaultModel`.
+   */
+  bedrockDefaultModel?: ModelType;
+  /**
+   * New symmetric Kiro model field. Takes priority over legacy `kiroModel`.
+   */
+  kiroDefaultModel?: KiroModelId;
 }
 
 /**
@@ -58,6 +85,10 @@ export const createSession = async (params: CreateSessionParams): Promise<string
     slackChannelId,
     slackMentionUserId,
     creatorSessionId,
+    inferenceMode,
+    kiroModel,
+    bedrockDefaultModel,
+    kiroDefaultModel,
   } = params;
   const agent = await getCustomAgent(customAgentId);
   const runtimeType: RuntimeType = agent?.runtimeType ?? defaultAgentConfig.runtimeType;
@@ -153,6 +184,10 @@ export const createSession = async (params: CreateSessionParams): Promise<string
               ...(creatorSessionId ? { creatorSessionId } : {}),
               ...(slackChannelId ? { slackChannelId } : {}),
               ...(slackThreadTs ? { slackThreadTs } : {}),
+              ...(inferenceMode ? { inferenceMode } : {}),
+              ...(inferenceMode === 'kiro-cli' && kiroModel ? { kiroModel } : {}),
+              ...(bedrockDefaultModel ? { bedrockDefaultModel } : {}),
+              ...(kiroDefaultModel ? { kiroDefaultModel } : {}),
             } satisfies SessionItem,
           },
         },

--- a/packages/webapp/src/app/preferences/actions.ts
+++ b/packages/webapp/src/app/preferences/actions.ts
@@ -2,8 +2,18 @@
 
 import { authActionClient } from '@/lib/safe-action';
 import { savePromptSchema } from './schemas';
-import { writeCommonPrompt, updatePreferences } from '@remote-swe-agents/agent-core/lib';
-import { updateGlobalPreferenceSchema } from '@remote-swe-agents/agent-core/schema';
+import {
+  writeCommonPrompt,
+  updatePreferences,
+  putKiroApiKey,
+  deleteKiroApiKey,
+  getKiroApiKey,
+  updateUserPreferences,
+  getUserPreferences,
+  sanitizeUserId,
+} from '@remote-swe-agents/agent-core/lib';
+import { updateGlobalPreferenceSchema, updateUserPreferencesSchema } from '@remote-swe-agents/agent-core/schema';
+import { z } from 'zod';
 
 export const updateAdditionalSystemPrompt = authActionClient
   .inputSchema(savePromptSchema)
@@ -26,3 +36,59 @@ export const updateGlobalPreferences = authActionClient
   .action(async ({ parsedInput }) => {
     return await updatePreferences(parsedInput);
   });
+
+export const saveKiroApiKeyAction = authActionClient
+  .inputSchema(z.object({ apiKey: z.string().min(1) }))
+  .action(async ({ parsedInput, ctx }) => {
+    try {
+      sanitizeUserId(ctx.userId);
+      await putKiroApiKey(ctx.userId, parsedInput.apiKey);
+      return { success: true };
+    } catch (error) {
+      console.error('Error saving Kiro API key:', error);
+      throw new Error('Failed to save Kiro API key');
+    }
+  });
+
+export const deleteKiroApiKeyAction = authActionClient.inputSchema(z.object({})).action(async ({ ctx }) => {
+  try {
+    sanitizeUserId(ctx.userId);
+    await deleteKiroApiKey(ctx.userId);
+    return { success: true };
+  } catch (error) {
+    console.error('Error deleting Kiro API key:', error);
+    throw new Error('Failed to delete Kiro API key');
+  }
+});
+
+export const checkKiroApiKeyAction = authActionClient.inputSchema(z.object({})).action(async ({ ctx }) => {
+  try {
+    sanitizeUserId(ctx.userId);
+    const key = await getKiroApiKey(ctx.userId);
+    return { hasKey: key !== undefined };
+  } catch (error) {
+    console.error('Error checking Kiro API key:', error);
+    throw new Error('Failed to check Kiro API key');
+  }
+});
+
+export const updateUserPreferencesAction = authActionClient
+  .inputSchema(updateUserPreferencesSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const input = { ...parsedInput };
+    if ('kiroModel' in input && !input.kiroModel) {
+      input.kiroModel = 'auto';
+    }
+    if ('kiroDefaultModel' in input && !input.kiroDefaultModel) {
+      input.kiroDefaultModel = 'auto' as any;
+    }
+    // Keep legacy fields in sync with new fields
+    if (input.kiroDefaultModel) {
+      input.kiroModel = input.kiroDefaultModel as string;
+    }
+    return await updateUserPreferences(ctx.userId, input);
+  });
+
+export const getUserPreferencesAction = authActionClient.inputSchema(z.object({})).action(async ({ ctx }) => {
+  return await getUserPreferences(ctx.userId);
+});

--- a/packages/webapp/src/app/preferences/components/GlobalPreferencesForm.tsx
+++ b/packages/webapp/src/app/preferences/components/GlobalPreferencesForm.tsx
@@ -2,29 +2,60 @@
 
 import { toast } from 'sonner';
 import { useOptimisticAction } from 'next-safe-action/hooks';
+import { useAction } from 'next-safe-action/hooks';
 import { useTranslations } from 'next-intl';
-import { updateGlobalPreferences } from '../actions';
+import {
+  updateGlobalPreferences,
+  saveKiroApiKeyAction,
+  deleteKiroApiKeyAction,
+  checkKiroApiKeyAction,
+  updateUserPreferencesAction,
+  getUserPreferencesAction,
+} from '../actions';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { TrashIcon, KeyIcon, CheckIcon } from 'lucide-react';
 import AgentIconUploader from '@/components/AgentIconUploader';
 import {
   GlobalPreferences,
+  InferenceMode,
   ModelType,
+  KiroModelId,
   getAvailableModelTypes,
+  getKiroModelIds,
   modelConfigs,
+  kiroModelConfigs,
 } from '@remote-swe-agents/agent-core/schema';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 interface GlobalPreferencesFormProps {
   preference: GlobalPreferences;
 }
+
+// Map internal inference mode identifiers to i18n translation keys.
+// The mode value `'kiro-cli'` is an implementation detail; the user-facing
+// translation key is `'kiro'`.
+const inferenceModeI18nKey: Record<InferenceMode, string> = {
+  bedrock: 'bedrock',
+  'kiro-cli': 'kiro',
+};
 
 export default function GlobalPreferencesForm({ preference }: GlobalPreferencesFormProps) {
   const t = useTranslations('preferences');
   const [currentPreference, setCurrentPreference] = useState<GlobalPreferences>(preference);
   const [agentName, setAgentName] = useState(preference.defaultAgentName || '');
 
+  // Per-user Kiro settings. `savedMode` is the server-authoritative default
+  // inference mode for new sessions. `hasApiKey` reflects whether a Kiro API
+  // key is stored; it is independent from the mode selection.
+  const [savedMode, setSavedMode] = useState<InferenceMode>('bedrock');
+  const [kiroModel, setKiroModel] = useState<KiroModelId>('auto');
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [hasApiKey, setHasApiKey] = useState(false);
+
+  // Global preferences optimistic action
   const { execute, optimisticState, isPending } = useOptimisticAction(updateGlobalPreferences, {
     currentState: {
       modelOverride: currentPreference.modelOverride,
@@ -42,10 +73,89 @@ export default function GlobalPreferencesForm({ preference }: GlobalPreferencesF
       toast.success(t('updateSuccess'));
       setCurrentPreference(data);
     },
-    onError: () => {
-      toast.error(t('updateError'));
+    onError: () => toast.error(t('updateError')),
+  });
+
+  // Per-user preferences fetcher — used as the source of truth after mutations.
+  const { execute: execGetUserPrefs } = useAction(getUserPreferencesAction, {
+    onSuccess: ({ data }) => {
+      if (data) {
+        if (data.inferenceMode) setSavedMode(data.inferenceMode);
+        if (data.kiroDefaultModel) setKiroModel(data.kiroDefaultModel as KiroModelId);
+        else if (data.kiroModel) setKiroModel(data.kiroModel as KiroModelId);
+      }
     },
   });
+
+  // Optimistic mode switch with rollback via refetch on error.
+  const {
+    execute: execUpdateMode,
+    optimisticState: optimisticMode,
+    isPending: isUpdatingMode,
+  } = useOptimisticAction(updateUserPreferencesAction, {
+    currentState: { mode: savedMode },
+    updateFn: (_state, input) => ({ mode: (input.inferenceMode ?? _state.mode) as InferenceMode }),
+    onSuccess: ({ input }) => {
+      if (input.inferenceMode) setSavedMode(input.inferenceMode);
+      toast.success(t('inferenceModeUpdateSuccess'));
+    },
+    onError: () => {
+      toast.error(t('inferenceModeUpdateError'));
+      // Rollback local state from server.
+      execGetUserPrefs({});
+    },
+  });
+
+  // Non-mode user-pref updates (e.g. kiroModel).
+  const { execute: execUpdateUserPrefs, isPending: isUpdatingUserPrefs } = useAction(updateUserPreferencesAction, {
+    onSuccess: () => toast.success(t('updateSuccess')),
+    onError: () => toast.error(t('updateError')),
+  });
+
+  // API key save — pure save, no mode mutation. Refetch to resync authoritative state.
+  const { execute: execSaveKey, isPending: isSavingKey } = useAction(saveKiroApiKeyAction, {
+    onSuccess: () => {
+      toast.success(t('kiroApiKeySaveSuccess'));
+      setApiKeyInput('');
+      setHasApiKey(true);
+      execCheckKey({});
+    },
+    onError: () => toast.error(t('kiroApiKeySaveError')),
+  });
+
+  // API key delete — pure delete, no mode mutation. Refetch to resync.
+  const { execute: execDeleteKey, isPending: isDeletingKey } = useAction(deleteKiroApiKeyAction, {
+    onSuccess: () => {
+      toast.success(t('kiroApiKeyDeleteSuccess'));
+      setHasApiKey(false);
+      execCheckKey({});
+    },
+    onError: () => toast.error(t('kiroApiKeyDeleteError')),
+  });
+
+  const { execute: execCheckKey } = useAction(checkKiroApiKeyAction, {
+    onSuccess: ({ data }) => {
+      if (data) setHasApiKey(data.hasKey);
+    },
+  });
+
+  useEffect(() => {
+    execCheckKey({});
+    execGetUserPrefs({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const kiroModelIds = getKiroModelIds();
+  const selectedMode = optimisticMode.mode;
+
+  // Mode switching and API key save/delete are independent actions by design.
+  // We intentionally allow switching to Kiro before an API key is
+  // configured so the user can pick the mode first and then enter the key in
+  // the section that appears below.
+  const handleSelectMode = (mode: InferenceMode) => {
+    if (mode === selectedMode) return;
+    execUpdateMode({ inferenceMode: mode });
+  };
 
   return (
     <div className="space-y-6">
@@ -87,29 +197,143 @@ export default function GlobalPreferencesForm({ preference }: GlobalPreferencesF
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('defaultAgentIconDescription')}</p>
       </div>
 
+      {/* Default Inference Mode — Segment Control.
+          This is the user-level default used as the initial value when
+          creating new sessions. It is not coupled to API key save/delete.
+          Switching to Kiro is allowed before an API key is configured so the
+          user can follow the natural flow (pick Kiro → enter key → save). */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('defaultModel')}</label>
-        <Select
-          defaultValue={optimisticState.modelOverride}
-          onValueChange={(value: ModelType) => execute({ modelOverride: value })}
-          disabled={isPending}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select a model" />
-            {isPending && (
-              <div className="ml-2 animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-gray-600"></div>
-            )}
-          </SelectTrigger>
-          <SelectContent>
-            {getAvailableModelTypes().map((type) => (
-              <SelectItem key={type} value={type}>
-                {modelConfigs[type].name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('defaultModelDescription')}</p>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('inferenceMode')}</label>
+        <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-100 dark:bg-gray-800">
+          {(['bedrock', 'kiro-cli'] as const).map((mode) => {
+            const isActive = selectedMode === mode;
+            const isDisabled = isUpdatingMode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                disabled={isDisabled}
+                onClick={() => handleSelectMode(mode)}
+                className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  isActive
+                    ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                } ${isDisabled && !isActive ? 'opacity-50 cursor-not-allowed' : ''}`}
+              >
+                {t(`inferenceModes.${inferenceModeI18nKey[mode]}`)}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('inferenceModeDescription')}</p>
+        {selectedMode === 'kiro-cli' && !hasApiKey && (
+          <p className="text-sm text-amber-600 dark:text-amber-400 mt-1">{t('kiroApiKeyRequired')}</p>
+        )}
       </div>
+
+      {/* Kiro API Key — only visible when the default inference mode is Kiro.
+          Saving and deleting the API key remain independent from mode
+          switching, so this conditional render does not re-introduce a race
+          between "key is saved" and "mode is switched". */}
+      {selectedMode === 'kiro-cli' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <KeyIcon className="inline h-4 w-4 mr-1" />
+            {t('kiroApiKey')}
+          </label>
+          {hasApiKey ? (
+            <div className="flex items-center gap-3">
+              <div className="flex-1 flex items-center gap-2 px-3 py-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-md">
+                <CheckIcon className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <span className="text-sm text-green-700 dark:text-green-300">
+                  {t('kiroApiKeyConfigured')} (••••••••)
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => {
+                  if (window.confirm(t('kiroApiKeyDeleteConfirm'))) execDeleteKey({});
+                }}
+                disabled={isDeletingKey}
+              >
+                <TrashIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex gap-2">
+              <Input
+                type="password"
+                value={apiKeyInput}
+                onChange={(e) => setApiKeyInput(e.target.value)}
+                placeholder={t('kiroApiKeyPlaceholder')}
+                disabled={isSavingKey}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={() => execSaveKey({ apiKey: apiKeyInput })}
+                disabled={isSavingKey || !apiKeyInput}
+              >
+                {isSavingKey ? '...' : t('save')}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Bedrock Model — shown when the selected default mode is Bedrock. */}
+      {selectedMode === 'bedrock' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('defaultModel')}</label>
+          <Select
+            defaultValue={optimisticState.modelOverride}
+            onValueChange={(value: ModelType) => execute({ modelOverride: value })}
+            disabled={isPending}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a model" />
+            </SelectTrigger>
+            <SelectContent>
+              {getAvailableModelTypes().map((type) => (
+                <SelectItem key={type} value={type}>
+                  {modelConfigs[type].name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('defaultModelDescription')}</p>
+        </div>
+      )}
+
+      {/* Kiro Model — shown when the selected default mode is Kiro and a key is set. */}
+      {selectedMode === 'kiro-cli' && hasApiKey && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('kiroModel')}</label>
+          <Select
+            value={kiroModel}
+            onValueChange={(value) => {
+              const modelId = value as KiroModelId;
+              setKiroModel(modelId);
+              execUpdateUserPrefs({ kiroModel: modelId, kiroDefaultModel: modelId });
+            }}
+            disabled={isUpdatingUserPrefs}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {kiroModelIds.map((model) => (
+                <SelectItem key={model} value={model}>
+                  {kiroModelConfigs[model]?.name ?? model}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('kiroModelDescription')}</p>
+        </div>
+      )}
 
       <div>
         <div className="flex items-center space-x-3">

--- a/packages/webapp/src/app/preferences/page.tsx
+++ b/packages/webapp/src/app/preferences/page.tsx
@@ -9,7 +9,6 @@ import { getTranslations } from 'next-intl/server';
 export const dynamic = 'force-dynamic';
 
 export default async function PreferencesPage() {
-  // Get the current prompt and preferences directly in server component
   const promptData = await readCommonPrompt();
   const additionalSystemPrompt = promptData?.additionalSystemPrompt || '';
   const globalPreferences = await getPreferences();

--- a/packages/webapp/src/app/sessions/[workerId]/actions.ts
+++ b/packages/webapp/src/app/sessions/[workerId]/actions.ts
@@ -8,6 +8,7 @@ import {
   stopSessionSchema,
   markSessionReadSchema,
   searchSessionContentSchema,
+  updateSessionModelSchema,
 } from './schemas';
 import { authActionClient } from '@/lib/safe-action';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
@@ -22,17 +23,28 @@ import {
   getUnreadSummary,
   updateSessionLastMessage,
   searchSessionContent,
+  updateSession,
 } from '@remote-swe-agents/agent-core/lib';
 import { sendWorkerEvent, updateSessionAgentStatus, sendWebappEvent } from '@remote-swe-agents/agent-core/lib';
-import { MessageItem } from '@remote-swe-agents/agent-core/schema';
+import { MessageItem, ModelType, KiroModelId } from '@remote-swe-agents/agent-core/schema';
 
 export const sendMessageToAgent = authActionClient
   .inputSchema(sendMessageToAgentSchema)
   .action(async ({ parsedInput, ctx }) => {
-    const { workerId, message, imageKeys = [], fileKeys = [], modelOverride } = parsedInput;
+    const { workerId, message, imageKeys = [], fileKeys = [], modelOverride, kiroModelOverride } = parsedInput;
     const session = await getSession(workerId);
     if (!session) {
       throw new Error('Session not found');
+    }
+
+    // Sync session-level model from the form's selector value on every send.
+    // This closes flush-race windows and migrates legacy sessions in one pass.
+    const isKiroSession = session.inferenceMode === 'kiro-cli';
+    if (!isKiroSession && modelOverride && session.bedrockDefaultModel !== modelOverride) {
+      await updateSession(workerId, { bedrockDefaultModel: modelOverride });
+    }
+    if (isKiroSession && kiroModelOverride && session.kiroDefaultModel !== kiroModelOverride) {
+      await updateSession(workerId, { kiroDefaultModel: kiroModelOverride as KiroModelId });
     }
 
     const content = [];
@@ -66,7 +78,9 @@ export const sendMessageToAgent = authActionClient
       role: 'user',
       tokenCount: 0,
       messageType: 'userMessage',
-      modelOverride,
+      // Per-message model overrides are deprecated — model selection is now
+      // session-level only (bedrockDefaultModel / kiroDefaultModel).
+      // Legacy read-side fallbacks remain for pre-migration sessions.
     };
 
     await ddb.send(
@@ -151,4 +165,20 @@ export const searchSessionContentAction = authActionClient
       sessionId: workerId,
     });
     return { results, totalSessions, timedOut };
+  });
+
+export const updateSessionModel = authActionClient
+  .inputSchema(updateSessionModelSchema)
+  .action(async ({ parsedInput }) => {
+    const { workerId, bedrockDefaultModel, kiroDefaultModel } = parsedInput;
+    const session = await getSession(workerId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+    const updates: { bedrockDefaultModel?: ModelType; kiroDefaultModel?: KiroModelId } = {};
+    if (bedrockDefaultModel) updates.bedrockDefaultModel = bedrockDefaultModel;
+    if (kiroDefaultModel) updates.kiroDefaultModel = kiroDefaultModel;
+    if (Object.keys(updates).length === 0) return { success: true };
+    await updateSession(workerId, updates);
+    return { success: true };
   });

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -5,14 +5,23 @@ import { Button } from '@/components/ui/button';
 import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hooks';
 import { Loader2, Send, Paperclip, Share } from 'lucide-react';
 import { toast } from 'sonner';
-import { sendMessageToAgent } from '../actions';
+import { sendMessageToAgent, updateSessionModel } from '../actions';
 import { sendMessageToAgentSchema } from '../schemas';
 import { KeyboardEventHandler, useCallback, useEffect, useRef } from 'react';
 import { MessageView } from './MessageList';
 import { useTranslations } from 'next-intl';
 import ImageUploader from '@/components/ImageUploader';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { ModelType, getAvailableModelTypes, modelConfigs } from '@remote-swe-agents/agent-core/schema';
+import { useAction } from 'next-safe-action/hooks';
+import {
+  ModelType,
+  InferenceMode,
+  getAvailableModelTypes,
+  modelConfigs,
+  kiroModelConfigs,
+  getKiroModelIds,
+  KiroModelId,
+} from '@remote-swe-agents/agent-core/schema';
 
 type MessageFormProps = {
   onSubmit: (message: MessageView) => void;
@@ -21,6 +30,18 @@ type MessageFormProps = {
   workerId: string;
   onShareSession: () => void;
   defaultModelOverride: ModelType;
+  /**
+   * Effective inference mode for this session. When `'kiro-cli'` the Bedrock
+   * model selector is replaced with a Kiro model selector that lets the user
+   * swap the model per message via the `/model` slash command in kiro-cli.
+   */
+  inferenceMode?: InferenceMode;
+  /**
+   * Default Kiro model for this session, resolved server-side as
+   * `session.kiroModel > userPrefs.kiroModel > 'auto'`. Used as the initial
+   * value of the per-message selector on Kiro sessions.
+   */
+  kiroModel?: string;
 };
 
 export default function MessageForm({
@@ -30,9 +51,66 @@ export default function MessageForm({
   workerId,
   onShareSession,
   defaultModelOverride,
+  inferenceMode,
+  kiroModel,
 }: MessageFormProps) {
   const t = useTranslations('sessions');
   const draftStorageKey = `draft-message-${workerId}`;
+
+  const isKiroSession = inferenceMode === 'kiro-cli';
+  const kiroModelIds = getKiroModelIds();
+  const defaultKiroModel = kiroModel && kiroModel in kiroModelConfigs ? kiroModel : 'auto';
+
+  // Session-level model sync: selector changes are debounced and persisted on
+  // the session item so they survive page reloads and apply to future turns.
+  const { execute: executeUpdateModel } = useAction(updateSessionModel, {
+    onError: () => {
+      toast.error(t('modelUpdateFailed'));
+    },
+  });
+  const modelUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingModelChangeRef = useRef<{ field: 'bedrock' | 'kiro'; value: string } | null>(null);
+
+  const flushModelChange = useCallback(() => {
+    if (modelUpdateTimeoutRef.current) {
+      clearTimeout(modelUpdateTimeoutRef.current);
+      modelUpdateTimeoutRef.current = null;
+    }
+    const pending = pendingModelChangeRef.current;
+    if (pending) {
+      pendingModelChangeRef.current = null;
+      if (pending.field === 'bedrock') {
+        executeUpdateModel({ workerId, bedrockDefaultModel: pending.value as ModelType });
+      } else {
+        executeUpdateModel({ workerId, kiroDefaultModel: pending.value as KiroModelId });
+      }
+    }
+  }, [workerId, executeUpdateModel]);
+
+  useEffect(() => {
+    return () => {
+      flushModelChange();
+    };
+  }, [flushModelChange]);
+
+  const handleModelChange = useCallback(
+    (field: 'bedrock' | 'kiro', value: string) => {
+      pendingModelChangeRef.current = { field, value };
+      if (modelUpdateTimeoutRef.current) {
+        clearTimeout(modelUpdateTimeoutRef.current);
+      }
+      modelUpdateTimeoutRef.current = setTimeout(() => {
+        modelUpdateTimeoutRef.current = null;
+        pendingModelChangeRef.current = null;
+        if (field === 'bedrock') {
+          executeUpdateModel({ workerId, bedrockDefaultModel: value as ModelType });
+        } else {
+          executeUpdateModel({ workerId, kiroDefaultModel: value as KiroModelId });
+        }
+      }, 300);
+    },
+    [workerId, executeUpdateModel]
+  );
 
   const pendingRef = useRef<{ id: string; message: string; modelOverride?: ModelType } | null>(null);
 
@@ -49,6 +127,7 @@ export default function MessageForm({
         pendingRef.current = null;
         reset();
         setValue('modelOverride', args.input.modelOverride);
+        setValue('kiroModelOverride', args.input.kiroModelOverride);
         clearImagesRef.current();
         try {
           localStorage.removeItem(draftStorageKey);
@@ -87,6 +166,7 @@ export default function MessageForm({
         imageKeys: [],
         fileKeys: [],
         modelOverride: defaultModelOverride,
+        kiroModelOverride: defaultKiroModel,
       },
     },
   });
@@ -206,6 +286,7 @@ export default function MessageForm({
 
   const handleOptimisticSubmit = useCallback(
     (e?: React.BaseSyntheticEvent) => {
+      flushModelChange();
       const message = getValues('message');
       const modelOverride = getValues('modelOverride');
       if (message?.trim()) {
@@ -296,17 +377,36 @@ export default function MessageForm({
               </div>
 
               <div className="flex gap-2 items-center">
-                <select
-                  {...register('modelOverride')}
-                  disabled={isExecuting}
-                  className="text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white focus:outline-none"
-                >
-                  {getAvailableModelTypes().map((type) => (
-                    <option key={type} value={type}>
-                      {modelConfigs[type].name}
-                    </option>
-                  ))}
-                </select>
+                {isKiroSession ? (
+                  <select
+                    {...register('kiroModelOverride', {
+                      onChange: (e) => handleModelChange('kiro', e.target.value),
+                    })}
+                    disabled={isExecuting}
+                    aria-label={t('kiroModelSelector')}
+                    className="text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white focus:outline-none"
+                  >
+                    {kiroModelIds.map((id) => (
+                      <option key={id} value={id}>
+                        {kiroModelConfigs[id]?.name ?? id}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <select
+                    {...register('modelOverride', {
+                      onChange: (e) => handleModelChange('bedrock', e.target.value),
+                    })}
+                    disabled={isExecuting}
+                    className="text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white focus:outline-none"
+                  >
+                    {getAvailableModelTypes().map((type) => (
+                      <option key={type} value={type}>
+                        {modelConfigs[type].name}
+                      </option>
+                    ))}
+                  </select>
+                )}
                 <TooltipProvider delayDuration={100}>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -24,6 +24,7 @@ import {
   InstanceStatus,
   GlobalPreferences,
   SessionItem,
+  InferenceMode,
 } from '@remote-swe-agents/agent-core/schema';
 import { useTranslations } from 'next-intl';
 import TodoList from './TodoList';
@@ -54,6 +55,18 @@ interface SessionPageClientProps {
   lastReadAt?: number;
   childSessions?: { workerId: string; title?: string }[];
   parentSessionId?: string;
+  /**
+   * Effective inference mode for this session, resolved server-side via the
+   * priority chain (session > customAgent > userPreferences > env > default).
+   * When `'kiro-cli'`, the chat input shows the Kiro model selector instead
+   * of the Bedrock model picker.
+   */
+  inferenceMode?: InferenceMode;
+  /**
+   * Kiro model baked into the session (or inherited from user preferences for
+   * legacy sessions). Only meaningful when `inferenceMode === 'kiro-cli'`.
+   */
+  kiroModel?: string;
 }
 
 export default function SessionPageClient({
@@ -71,6 +84,8 @@ export default function SessionPageClient({
   unreadMap,
   lastReadAt,
   parentSessionId,
+  inferenceMode,
+  kiroModel,
 }: SessionPageClientProps) {
   const t = useTranslations('sessions');
   const router = useRouter();
@@ -560,7 +575,21 @@ export default function SessionPageClient({
             onRollback={onRollbackMessage}
             workerId={workerId}
             onShareSession={() => setShowShareModal(true)}
-            defaultModelOverride={messages.findLast((m) => m.modelOverride)?.modelOverride ?? preferences.modelOverride}
+            // For Kiro sessions, do NOT seed the Bedrock model selector from
+            // message history: Kiro sessions can carry non-Bedrock
+            // `modelOverride` values on their messages that would fail the
+            // strict `ModelType` zod schema on the client and permanently
+            // disable the submit button. The Kiro branch of the form uses its
+            // own `kiroModelOverride` selector instead, so seeding
+            // `defaultModelOverride` from preferences here is purely
+            // defensive and never user-visible on Kiro sessions.
+            defaultModelOverride={
+              inferenceMode === 'kiro-cli'
+                ? preferences.modelOverride
+                : (messages.findLast((m) => m.modelOverride)?.modelOverride ?? preferences.modelOverride)
+            }
+            inferenceMode={inferenceMode}
+            kiroModel={kiroModel}
           />
 
           {/* Scroll buttons - hidden when scrolled to bottom */}

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -10,6 +10,7 @@ import {
   getTodoList,
   getUnreadMap,
   noOpFiltering,
+  resolveModelConfig,
 } from '@remote-swe-agents/agent-core/lib';
 import SessionPageClient from './component/SessionPageClient';
 import { MessageView } from './component/MessageList';
@@ -271,6 +272,36 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
   let agentIconUrl: string | undefined;
   const customAgent = session.customAgentId ? await getCustomAgent(session.customAgentId) : undefined;
   const iconKey = customAgent?.iconKey || preferences.defaultAgentIconKey;
+
+  // Resolve the effective inference mode / models for this session
+  // server-side, via the shared priority chain (session > customAgent > env >
+  // default).
+  //
+  // User preferences are DELIBERATELY not consulted here. They are only
+  // the default used at session creation time; flipping them must not
+  // retroactively reinterpret existing / legacy sessions. Sessions created
+  // before `inferenceMode` was persisted therefore fall through to
+  // Bedrock, matching the single-backend world they originally ran in.
+  const resolvedModel = resolveModelConfig({
+    session: {
+      inferenceMode: session.inferenceMode,
+      bedrockDefaultModel: session.bedrockDefaultModel,
+      kiroDefaultModel: session.kiroDefaultModel,
+      kiroModel: session.kiroModel,
+    },
+    customAgent: customAgent
+      ? {
+          inferenceMode: customAgent.inferenceMode,
+          bedrockDefaultModel: customAgent.bedrockDefaultModel,
+          defaultModel: customAgent.defaultModel,
+          kiroDefaultModel: customAgent.kiroDefaultModel,
+          kiroModel: customAgent.kiroModel,
+        }
+      : undefined,
+    env: { inferenceMode: process.env.INFERENCE_MODE },
+  });
+  const effectiveInferenceMode = resolvedModel.inferenceMode;
+  const effectiveKiroModel = effectiveInferenceMode === 'kiro-cli' ? resolvedModel.kiroModel : undefined;
   if (iconKey) {
     agentIconUrl = `/api/agent-icon?key=${encodeURIComponent(iconKey)}`;
   }
@@ -292,6 +323,8 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
         unreadMap={unreadMap}
         lastReadAt={lastReadAt}
         parentSessionId={session.parentSessionId}
+        inferenceMode={effectiveInferenceMode}
+        kiroModel={effectiveKiroModel}
       />
       <RefreshOnFocus />
     </>

--- a/packages/webapp/src/app/sessions/[workerId]/schemas.ts
+++ b/packages/webapp/src/app/sessions/[workerId]/schemas.ts
@@ -1,4 +1,9 @@
-import { agentStatusSchema, modelTypeSchema, runtimeTypeSchema } from '@remote-swe-agents/agent-core/schema';
+import {
+  agentStatusSchema,
+  kiroModelSchema,
+  modelTypeSchema,
+  runtimeTypeSchema,
+} from '@remote-swe-agents/agent-core/schema';
 import { z } from 'zod';
 
 export const sendMessageToAgentSchema = z.object({
@@ -7,6 +12,22 @@ export const sendMessageToAgentSchema = z.object({
   imageKeys: z.array(z.string()).optional(),
   fileKeys: z.array(z.string()).optional(),
   modelOverride: modelTypeSchema.optional(),
+  /**
+   * Per-message Kiro model override. Only honoured on Kiro sessions.
+   * Ignored on Bedrock sessions.
+   *
+   * The string is interpolated into a `/model <id>` slash command prompt
+   * that kiro-cli parses as a command. Restricting it to model-id-safe
+   * characters is a defence-in-depth guard against a malicious or
+   * DevTools-tampered request injecting additional slash commands via
+   * newline / whitespace / control characters. Authorised catalog model
+   * ids match [a-zA-Z0-9._-]+ (see kiroModelConfigs).
+   */
+  kiroModelOverride: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+$/, 'invalid kiro model id')
+    .max(64)
+    .optional(),
 });
 
 export const fetchTodoListSchema = z.object({
@@ -36,4 +57,10 @@ export const markSessionReadSchema = z.object({
 export const searchSessionContentSchema = z.object({
   workerId: z.string(),
   query: z.string().min(1).max(200),
+});
+
+export const updateSessionModelSchema = z.object({
+  workerId: z.string(),
+  bedrockDefaultModel: modelTypeSchema.optional(),
+  kiroDefaultModel: kiroModelSchema.optional(),
 });

--- a/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
+++ b/packages/webapp/src/app/sessions/new/NewSessionForm.tsx
@@ -5,6 +5,9 @@ import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hoo
 import { Button } from '@/components/ui/button';
 import { Paperclip, FileText } from 'lucide-react';
 import { createNewWorker } from './actions';
+import { getUserPreferencesAction, checkKiroApiKeyAction } from '../../preferences/actions';
+import { useAction } from 'next-safe-action/hooks';
+import Link from 'next/link';
 import { createNewWorkerSchema, PromptTemplate } from './schemas';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
@@ -12,13 +15,17 @@ import ImageUploader from '@/components/ImageUploader';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Form, FormControl, FormField } from '@/components/ui/form';
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import TemplateModal from './TemplateModal';
 import {
   CustomAgent,
   getAvailableModelTypes,
   GlobalPreferences,
   modelConfigs,
+  InferenceMode,
+  KiroModelId,
+  kiroModelConfigs,
+  getKiroModelIds,
 } from '@remote-swe-agents/agent-core/schema';
 
 interface NewSessionFormProps {
@@ -26,17 +33,51 @@ interface NewSessionFormProps {
   customAgents: CustomAgent[];
   preferences: GlobalPreferences;
   agentIconUrls?: Record<string, string>;
+  /**
+   * Default Kiro model resolved server-side from the user's preferences
+   * (`kiroDefaultModel > kiroModel > 'auto'`).
+   */
+  kiroModel: string;
 }
+
+// Map internal inference mode identifiers to i18n translation keys.
+// The mode value `'kiro-cli'` is an implementation detail; the user-facing
+// translation key is `'kiro'`.
+const inferenceModeI18nKey: Record<InferenceMode, string> = {
+  bedrock: 'bedrock',
+  'kiro-cli': 'kiro',
+};
 
 export default function NewSessionForm({
   templates,
   customAgents,
   preferences,
   agentIconUrls = {},
+  kiroModel: ssrKiroModel,
 }: NewSessionFormProps) {
   const t = useTranslations('new_session');
   const sessionsT = useTranslations('sessions');
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false);
+  const [hasApiKey, setHasApiKey] = useState(false);
+  const [userDefaultMode, setUserDefaultMode] = useState<InferenceMode>('bedrock');
+
+  const { execute: execGetUserPrefs } = useAction(getUserPreferencesAction, {
+    onSuccess: ({ data }) => {
+      if (!data) return;
+      if (data.inferenceMode) setUserDefaultMode(data.inferenceMode);
+    },
+  });
+  const { execute: execCheckKey } = useAction(checkKiroApiKeyAction, {
+    onSuccess: ({ data }) => {
+      if (data) setHasApiKey(data.hasKey);
+    },
+  });
+
+  useEffect(() => {
+    execGetUserPrefs({});
+    execCheckKey({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     form,
@@ -56,10 +97,60 @@ export default function NewSessionForm({
         fileKeys: [],
         modelOverride: preferences.modelOverride,
         customAgentId: 'DEFAULT',
+        inferenceMode: 'bedrock',
+        kiroModel: ssrKiroModel as KiroModelId,
       },
     },
   });
   const { register, formState, reset, setValue, watch, control } = form;
+
+  const selectedCustomAgentId = watch('customAgentId');
+  const inferenceMode = watch('inferenceMode') ?? 'bedrock';
+
+  // Resolve the custom agent currently selected, if any.
+  const selectedCustomAgent = useMemo(
+    () => customAgents.find((a) => a.SK === selectedCustomAgentId),
+    [customAgents, selectedCustomAgentId]
+  );
+
+  // A custom agent may pin the inference mode; when it does, the user cannot
+  // override it from this form.
+  const customAgentForcedMode = selectedCustomAgent?.inferenceMode;
+  const isModeLocked = Boolean(customAgentForcedMode);
+
+  // Keep the form's inferenceMode aligned with the effective mode:
+  //   1. If a custom agent forces a mode, adopt it.
+  //   2. Otherwise, once user preferences load, adopt the user's default
+  //      (guarded by API key availability for Kiro).
+  useEffect(() => {
+    if (customAgentForcedMode) {
+      setValue('inferenceMode', customAgentForcedMode);
+      return;
+    }
+    if (userDefaultMode === 'kiro-cli' && !hasApiKey) {
+      setValue('inferenceMode', 'bedrock');
+      return;
+    }
+    setValue('inferenceMode', userDefaultMode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customAgentForcedMode, userDefaultMode, hasApiKey]);
+
+  // Keep Kiro model in sync when entering Kiro mode.
+  useEffect(() => {
+    if (inferenceMode === 'kiro-cli') {
+      setValue('kiroModel', (ssrKiroModel as KiroModelId) || 'auto');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inferenceMode]);
+
+  const handleSelectMode = (mode: InferenceMode) => {
+    if (isModeLocked) return;
+    if (mode === 'kiro-cli' && !hasApiKey) return;
+    setValue('inferenceMode', mode);
+    if (mode === 'kiro-cli') {
+      setValue('kiroModel', form.getValues('kiroModel') || 'auto');
+    }
+  };
 
   const { uploadingImages, uploadingFiles, handleFileSelect, handlePaste, ImagePreviewList, isUploading } =
     ImageUploader({
@@ -97,7 +188,7 @@ export default function NewSessionForm({
                     field.onChange(value);
                     const agent = customAgents.find((a) => a.SK == value);
                     if (agent) {
-                      setValue('modelOverride', agent.defaultModel);
+                      setValue('modelOverride', agent.bedrockDefaultModel ?? agent.defaultModel);
                     }
                   }}
                   disabled={isPending}
@@ -140,32 +231,104 @@ export default function NewSessionForm({
             />
           </div>
 
-          {/* Model Override Selection */}
+          {/* Inference Mode toggle */}
           <div className="mb-4">
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              {t('modelOverride')}
+              {t('inferenceMode')}
             </label>
-            <FormField
-              name="modelOverride"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} disabled={isPending}>
-                  <FormControl>
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {getAvailableModelTypes().map((type) => (
-                      <SelectItem key={type} value={type}>
-                        {modelConfigs[type].name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            />
+            <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-100 dark:bg-gray-800 mb-2">
+              {(['bedrock', 'kiro-cli'] as const).map((mode) => {
+                const isActive = inferenceMode === mode;
+                const isDisabled = isPending || isModeLocked || (mode === 'kiro-cli' && !hasApiKey);
+                return (
+                  <button
+                    key={mode}
+                    type="button"
+                    disabled={isDisabled}
+                    onClick={() => handleSelectMode(mode)}
+                    className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                      isActive
+                        ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm'
+                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                    } ${isDisabled && !isActive ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  >
+                    {t(`inferenceModes.${inferenceModeI18nKey[mode]}`)}
+                  </button>
+                );
+              })}
+            </div>
+            {isModeLocked && customAgentForcedMode && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t('customAgentForcesMode', {
+                  mode: t(`inferenceModes.${inferenceModeI18nKey[customAgentForcedMode]}`),
+                })}
+              </p>
+            )}
+            {inferenceMode === 'kiro-cli' && !hasApiKey && (
+              <p className="text-sm text-amber-600 dark:text-amber-400">
+                {t('kiroApiKeyRequired')}{' '}
+                <Link href="/preferences" className="underline hover:no-underline">
+                  {t('goToPreferences')}
+                </Link>
+              </p>
+            )}
           </div>
+
+          {/* Model selector — separate blocks per mode to avoid React reconciliation issues */}
+          {inferenceMode === 'bedrock' && (
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                {t('modelOverride')}
+              </label>
+              <FormField
+                name="modelOverride"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value as string | undefined} onValueChange={field.onChange} disabled={isPending}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {getAvailableModelTypes().map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {modelConfigs[type].name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          )}
+          {inferenceMode === 'kiro-cli' && (
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                {t('modelOverride')}
+              </label>
+              <FormField
+                name="kiroModel"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value || 'auto'} onValueChange={field.onChange} disabled={isPending}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Auto (recommended)" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {getKiroModelIds().map((model) => (
+                        <SelectItem key={model} value={model}>
+                          {kiroModelConfigs[model]?.name ?? model}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          )}
 
           <div className="flex items-center justify-end mb-2">
             <label

--- a/packages/webapp/src/app/sessions/new/actions.ts
+++ b/packages/webapp/src/app/sessions/new/actions.ts
@@ -8,16 +8,30 @@ import { redirect } from 'next/navigation';
 export const createNewWorker = authActionClient
   .inputSchema(createNewWorkerSchema)
   .action(async ({ parsedInput, ctx }) => {
-    const { message, imageKeys = [], fileKeys = [], modelOverride, customAgentId = '' } = parsedInput;
+    const {
+      message,
+      imageKeys = [],
+      fileKeys = [],
+      modelOverride,
+      customAgentId = '',
+      inferenceMode,
+      kiroModel,
+      bedrockDefaultModel,
+      kiroDefaultModel,
+    } = parsedInput;
     const { userId } = ctx;
 
+    const effectiveBedrockDefault = bedrockDefaultModel ?? modelOverride;
     const workerId = await createSession({
       message,
       initiator: `webapp#${userId}`,
       customAgentId: customAgentId || undefined,
-      modelOverride,
       imageKeys,
       fileKeys,
+      inferenceMode,
+      kiroModel: kiroDefaultModel ?? kiroModel,
+      bedrockDefaultModel: effectiveBedrockDefault,
+      kiroDefaultModel,
     });
 
     redirect(`/sessions/${workerId}`);

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -6,7 +6,8 @@ import NewSessionForm from './NewSessionForm';
 import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { PromptTemplate } from '@/app/sessions/new/schemas';
-import { getCustomAgents, getPreferences } from '@remote-swe-agents/agent-core/lib';
+import { getCustomAgents, getPreferences, getUserPreferences } from '@remote-swe-agents/agent-core/lib';
+import { getSession } from '@/lib/auth';
 
 export default async function NewSessionPage() {
   const t = await getTranslations('new_session');
@@ -26,6 +27,9 @@ export default async function NewSessionPage() {
   );
   const preferences = await getPreferences();
   const customAgents = await getCustomAgents();
+  const session = await getSession();
+  const userPreferences = await getUserPreferences(session.userId);
+  const kiroModel = userPreferences.kiroDefaultModel || userPreferences.kiroModel || 'auto';
 
   templates = (result.Items ?? []) as PromptTemplate[];
 
@@ -77,6 +81,7 @@ export default async function NewSessionPage() {
                   preferences={preferences}
                   customAgents={customAgents}
                   agentIconUrls={agentIconUrls}
+                  kiroModel={kiroModel}
                 />
               </div>
             </div>

--- a/packages/webapp/src/app/sessions/new/schemas.test.ts
+++ b/packages/webapp/src/app/sessions/new/schemas.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { createNewWorkerSchema } from './schemas';
+
+// These tests pin the runtime behaviour of the `optionalEnum` helper after the
+// `.optional()` wrapping added to fix the react-hook-form Control type
+// mismatch (TS2322 on `control={control}`). The wrapping must NOT change
+// parsing behaviour: empty strings still normalise to undefined, omitted
+// fields stay undefined, valid enums pass, invalid enums are rejected.
+describe('createNewWorkerSchema optionalEnum behaviour', () => {
+  test('empty string modelOverride normalises to undefined (not a validation error)', () => {
+    const r = createNewWorkerSchema.safeParse({ message: 'hi', modelOverride: '' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.modelOverride).toBeUndefined();
+  });
+
+  test('omitted modelOverride stays undefined', () => {
+    const r = createNewWorkerSchema.safeParse({ message: 'hi' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.modelOverride).toBeUndefined();
+  });
+
+  test('valid enum value passes through', () => {
+    const r = createNewWorkerSchema.safeParse({ message: 'hi', modelOverride: 'opus5' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.modelOverride).toBe('opus5');
+  });
+
+  test('invalid enum value is rejected', () => {
+    const r = createNewWorkerSchema.safeParse({ message: 'hi', modelOverride: 'not-a-real-model' });
+    expect(r.success).toBe(false);
+  });
+
+  test('empty string inferenceMode / kiroDefaultModel also normalise to undefined', () => {
+    const r = createNewWorkerSchema.safeParse({ message: 'hi', inferenceMode: '', kiroDefaultModel: '' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.inferenceMode).toBeUndefined();
+      expect(r.data.kiroDefaultModel).toBeUndefined();
+    }
+  });
+});

--- a/packages/webapp/src/app/sessions/new/schemas.ts
+++ b/packages/webapp/src/app/sessions/new/schemas.ts
@@ -1,12 +1,31 @@
-import { modelTypeSchema } from '@remote-swe-agents/agent-core/schema';
+import { inferenceModeSchema, kiroModelSchema, modelTypeSchema } from '@remote-swe-agents/agent-core/schema';
 import { z } from 'zod';
+
+// Treat empty strings as "not set" for optional enum fields. Form state can
+// end up with "" (e.g. after a reset), which would otherwise fail enum
+// validation invisibly and leave the submit button disabled with no error.
+//
+// The trailing `.optional()` wraps the ZodEffects in a ZodOptional so the
+// field's INPUT type is optional (`field?: unknown`) rather than a required
+// `field: unknown`. Without it, react-hook-form's 3-generic Control renders
+// the input type (required `unknown`) as incompatible with the resolver's
+// OUTPUT type (optional enum), producing the "Property is optional in ... but
+// required in ..." TS2322 on every `control={control}` FormField. Runtime
+// behaviour is unchanged: `''` → preprocess → undefined; `undefined` short-
+// circuits through the outer ZodOptional.
+const optionalEnum = <T extends z.ZodType>(schema: T) =>
+  z.preprocess((v) => (v === '' ? undefined : v), schema.optional()).optional();
 
 export const createNewWorkerSchema = z.object({
   message: z.string().min(1),
   imageKeys: z.array(z.string()).optional(),
   fileKeys: z.array(z.string()).optional(),
-  modelOverride: modelTypeSchema.optional(),
+  modelOverride: optionalEnum(modelTypeSchema),
   customAgentId: z.string().optional(),
+  inferenceMode: optionalEnum(inferenceModeSchema),
+  kiroModel: z.string().optional(),
+  bedrockDefaultModel: optionalEnum(modelTypeSchema),
+  kiroDefaultModel: optionalEnum(kiroModelSchema),
 });
 
 export const promptTemplateSchema = z.object({

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -149,7 +149,9 @@
     "searchNoResults": "No matching messages found.",
     "searchResults": "Search results",
     "searchResultCount": "{count, plural, one {# result} other {# results}}",
-    "searchTimedOut": "Results may be incomplete (search timed out)."
+    "searchTimedOut": "Results may be incomplete (search timed out).",
+    "kiroModelSelector": "Kiro model",
+    "modelUpdateFailed": "Failed to save model selection"
   },
   "home": {
     "title": "Welcome to Remote SWE Agents",
@@ -255,7 +257,15 @@
       "updateError": "Failed to update template",
       "deleteSuccess": "Template deleted successfully",
       "deleteError": "Failed to delete template"
-    }
+    },
+    "inferenceMode": "Inference Backend",
+    "inferenceModes": {
+      "bedrock": "Bedrock",
+      "kiro": "Kiro"
+    },
+    "kiroApiKeyRequired": "Set your Kiro API key in Preferences to use Kiro mode.",
+    "goToPreferences": "Open Preferences",
+    "customAgentForcesMode": "This custom agent is configured to always use {mode}."
   },
   "preferences": {
     "title": "Preferences",
@@ -292,7 +302,26 @@
       "enabled": "Push notifications are enabled",
       "disabled": "Push notifications are disabled",
       "notSupported": "Push notifications are not supported in this browser"
-    }
+    },
+    "inferenceMode": "Default Inference Mode",
+    "inferenceModeDescription": "Default inference backend for new sessions. You can override per-session when creating one.",
+    "inferenceModes": {
+      "bedrock": "Bedrock",
+      "kiro": "Kiro"
+    },
+    "inferenceModeUpdateSuccess": "Inference mode updated",
+    "inferenceModeUpdateError": "Failed to update inference mode",
+    "kiroApiKey": "Kiro API Key",
+    "kiroApiKeyPlaceholder": "Enter your Kiro API key",
+    "kiroApiKeyConfigured": "API key is configured",
+    "kiroApiKeyRequired": "Set your Kiro API key first to enable Kiro mode",
+    "kiroApiKeySaveSuccess": "Kiro API key saved",
+    "kiroApiKeySaveError": "Failed to save API key",
+    "kiroApiKeyDeleteSuccess": "Kiro API key deleted",
+    "kiroApiKeyDeleteError": "Failed to delete API key",
+    "kiroApiKeyDeleteConfirm": "Are you sure you want to delete your Kiro API key?",
+    "kiroModel": "Kiro Model",
+    "kiroModelDescription": "Choose the AI model for Kiro inference"
   },
   "api_settings": {
     "title": "API Keys",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -149,7 +149,9 @@
     "searchNoResults": "一致するメッセージが見つかりません。",
     "searchResults": "検索結果",
     "searchResultCount": "{count}件の結果",
-    "searchTimedOut": "結果が不完全な可能性があります（検索がタイムアウトしました）。"
+    "searchTimedOut": "結果が不完全な可能性があります（検索がタイムアウトしました）。",
+    "kiroModelSelector": "Kiro モデル",
+    "modelUpdateFailed": "モデル選択の保存に失敗しました"
   },
   "home": {
     "title": "Remote SWE Agents へようこそ",
@@ -254,7 +256,15 @@
       "updateError": "テンプレートの更新に失敗しました",
       "deleteSuccess": "テンプレートが正常に削除されました",
       "deleteError": "テンプレートの削除に失敗しました"
-    }
+    },
+    "inferenceMode": "推論バックエンド",
+    "inferenceModes": {
+      "bedrock": "Bedrock",
+      "kiro": "Kiro"
+    },
+    "kiroApiKeyRequired": "Kiro モードを使うには、Preferences で Kiro API キーを設定してください。",
+    "goToPreferences": "Preferences を開く",
+    "customAgentForcesMode": "このカスタムエージェントは常に {mode} を使う設定です。"
   },
   "preferences": {
     "title": "設定",
@@ -291,7 +301,26 @@
       "enabled": "プッシュ通知は有効です",
       "disabled": "プッシュ通知は無効です",
       "notSupported": "このブラウザではプッシュ通知はサポートされていません"
-    }
+    },
+    "inferenceMode": "デフォルト推論モード",
+    "inferenceModeDescription": "新しいセッションのデフォルトの推論バックエンドです。セッション作成時に個別に上書きできます。",
+    "inferenceModes": {
+      "bedrock": "Bedrock",
+      "kiro": "Kiro"
+    },
+    "inferenceModeUpdateSuccess": "推論モードを更新しました",
+    "inferenceModeUpdateError": "推論モードの更新に失敗しました",
+    "kiroApiKey": "Kiro API キー",
+    "kiroApiKeyPlaceholder": "Kiro API キーを入力してください",
+    "kiroApiKeyConfigured": "API キーが設定されています",
+    "kiroApiKeyRequired": "Kiro モードを有効にするには、先に Kiro API キーを設定してください",
+    "kiroApiKeySaveSuccess": "Kiro API キーを保存しました",
+    "kiroApiKeySaveError": "API キーの保存に失敗しました",
+    "kiroApiKeyDeleteSuccess": "Kiro API キーを削除しました",
+    "kiroApiKeyDeleteError": "API キーの削除に失敗しました",
+    "kiroApiKeyDeleteConfirm": "Kiro API キーを削除してもよろしいですか？",
+    "kiroModel": "Kiro モデル",
+    "kiroModelDescription": "Kiro 推論に使用するAIモデルを選択してください"
   },
   "api_settings": {
     "title": "APIキー",


### PR DESCRIPTION
## Summary
Webapp UI for the Kiro CLI inference mode: preferences (mode segment control, per-user API key management, default model selector), new-session mode/model pass-through, and session-page model selection with session-level sync.

## Motivation
The Kiro backend landed server-side in an earlier PR of this series; this PR makes it usable end-to-end from the webapp.

## Changes
- Preferences page: inference-mode segment control, per-user Kiro API key UI, Kiro default-model selector + per-user preference actions
- New session: mode toggle (gated on an API key being configured; respects a custom agent's pinned mode), per-mode model selectors, mode/model pass-through into `createSession` (new optional params persisted on the session item)
- Session page: server-side effective-mode resolution via `resolveModelConfig`, Kiro model selector in the chat input, debounced session-level model sync (`updateSessionModel`; per-message `modelOverride` deprecated), guarded `kiroModelOverride` on sendMessageToAgent
- `UserParamsCleaner`: cleans up per-user SSM parameters when a user is deleted

## Testing
- webapp: `next build` succeeds, `tsc --noEmit` clean, vitest green, prettier check clean
- CDK synth + snapshot updated (UserParamsCleaner)

## Notes
- Depends on: #6 in this series (`feat: Kiro CLI inference backend …`), already merged.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
